### PR TITLE
WIP: ipld embedding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +82,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "bellperson"
@@ -149,6 +166,19 @@ checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "cc",
+ "cfg-if 1.0.0",
  "constant_time_eq",
 ]
 
@@ -249,6 +279,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cached"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4dfac631a8e77b2f327f7852bb6172771f5279c4512efe79fad6067b37be3d"
+dependencies = [
+ "hashbrown",
+ "once_cell",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +314,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cid"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5d90881dc52bb7867dd4341dfe6836077370f879df51cee353daa74e035a13"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash",
+ "unsigned-varint",
+]
 
 [[package]]
 name = "cl-sys"
@@ -330,6 +382,15 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -451,6 +512,32 @@ dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
  "parking_lot",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+dependencies = [
+ "data-encoding",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -668,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +968,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
+name = "libipld"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfb2f6a99d838dcb1cc18361c79e827b76e91987227406e705d07cbef51ab7be"
+dependencies = [
+ "async-trait",
+ "cached",
+ "fnv",
+ "libipld-cbor",
+ "libipld-core",
+ "libipld-macro",
+ "log",
+ "multihash",
+ "parking_lot",
+ "thiserror",
+]
+
+[[package]]
+name = "libipld-cbor"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b3bbc4f35b8f25eb140d183f33d4610a1eb6531b312f01161fa06693f8c28a"
+dependencies = [
+ "byteorder",
+ "libipld-core",
+ "thiserror",
+]
+
+[[package]]
+name = "libipld-core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdd758764f9680a818af33c31db733eb7c45224715d8816b9dcf0548c75f7c5"
+dependencies = [
+ "anyhow",
+ "cid",
+ "core2",
+ "multibase",
+ "multihash",
+ "thiserror",
+]
+
+[[package]]
+name = "libipld-macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c4cb1056262ef4056ad9e5fb41f252c45f55009888e21b7837ac051f38814a"
+dependencies = [
+ "libipld-core",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +1051,7 @@ dependencies = [
  "anyhow",
  "bellperson",
  "blstrs",
+ "cid",
  "criterion",
  "dashmap",
  "dirs 4.0.0",
@@ -913,10 +1059,13 @@ dependencies = [
  "generic-array 0.14.5",
  "indexmap",
  "itertools 0.9.0",
+ "libipld",
  "log",
  "merlin",
+ "multihash",
  "neptune",
  "nova-snark",
+ "num-bigint",
  "once_cell",
  "pairing",
  "pasta_curves",
@@ -982,6 +1131,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7392bffd88bc0c4f8297e36a777ab9f80b7127409c4a1acb8fee99c9f27addcd"
+dependencies = [
+ "blake3",
+ "core2",
+ "multihash-derive",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
+ "synstructure",
+]
+
+[[package]]
 name = "neptune"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1228,27 @@ dependencies = [
  "rayon",
  "sha3",
  "subtle",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -1186,6 +1393,16 @@ checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
  "env_logger",
  "log",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -1820,6 +2037,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +2074,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ ahash = "0.7.6"
 pasta_curves = "0.3.0"
 string-interner = "0.14.0"
 dashmap = "5.0.0"
+libipld = { version = "0.13.1", default-features = false, features = ["dag-cbor"] }
+cid = { version = "0.8.3", default-features = false, features = ["alloc"]}
+multihash = { version = "0.16.1", default-features = false, features = ["alloc", "blake3"] }
+num-bigint = { version = "0.4.3", default-features = false} 
+
 
 [features]
 default = ["gpu"]

--- a/flake.nix
+++ b/flake.nix
@@ -37,8 +37,10 @@
     let
       lib = utils.lib.${system};
       pkgs = nixpkgs.legacyPackages.${system};
-      inherit (lib) buildRustProject testRustProject rustDefault filterRustProject;
-      rust = rustDefault;
+      inherit (lib) buildRustProject testRustProject getRust filterRustProject;
+      # Load a nightly rust. The hash takes precedence over the date so remember to set it to
+      # something like `lib.fakeSha256` when changing the date.
+      rustNightly = getRust { date = "2022-02-20"; sha256 = "sha256-ZptNrC/0Eyr0c3IiXVWTJbuprFHq6E1KfBgqjGQBIRs="; };
       crateName = "lurk";
       src = ./.;
       buildInputs = with pkgs;
@@ -48,6 +50,7 @@
           darwin.apple_sdk.frameworks.OpenCL
         ];
       project = buildRustProject {
+        rust = rustNightly;
         root = ./.;
         inherit src buildInputs;
         copyLibs = true;
@@ -81,7 +84,7 @@
       # `nix develop`
       devShell = pkgs.mkShell {
         inputsFrom = builtins.attrValues self.packages.${system};
-        nativeBuildInputs = [ rust ];
+        nativeBuildInputs = [ rustNightly ];
         buildInputs = with pkgs; buildInputs ++ [
           rust-analyzer
           clippy

--- a/src/ipld.rs
+++ b/src/ipld.rs
@@ -1,0 +1,251 @@
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use core::num::TryFromIntError;
+
+use num_bigint::BigUint;
+
+use multihash::Code;
+use multihash::MultihashDigest;
+use multihash::MultihashGeneric;
+
+use libipld::cbor::DagCborCodec;
+use libipld::codec::Codec;
+use libipld::Cid;
+use libipld::Ipld;
+
+use ff::PrimeField;
+
+pub const DAGCBOR: u64 = 0x71;
+
+// In future, we want to make a cid version that can have multicodec fields
+// larger than u64, so we can reserve a whole tree for future Lurk use
+pub const LURK_CODEC_PREFIX: u16 = 0xc0de;
+
+pub const NUM: u16 = 0x01;
+pub const EXPR: u16 = 0x02;
+
+// temporary hack standing in for a future extension of the `ff` trait so that
+// every field `F` is entered on the `multicodec` table
+pub fn dummy_ff_codec<F: PrimeField>() -> u16 {
+    0xbe_ff
+}
+
+// We are assuming that our tags fit in the 32 least significant bits of the `F`
+pub fn f_tag_to_u32<F: ff::PrimeField>(f: F, le: bool) -> u32 {
+    let bytes: Vec<u8> = f.to_repr().as_ref().to_vec();
+    if le {
+        let size = bytes.len();
+        let bytes: [u8; 4] = [
+            bytes[size],
+            bytes[size - 1],
+            bytes[size - 2],
+            bytes[size - 3],
+        ];
+        u32::from_le_bytes(bytes)
+    } else {
+        let bytes: [u8; 4] = [bytes[0], bytes[1], bytes[2], bytes[3]];
+        u32::from_be_bytes(bytes)
+    }
+}
+
+// this assumes we only use poseidon-bls12_381-a2-fc1, or multicodec 0xb401
+// also assumes that F fits within a 512 bit digest
+pub fn f_digest<F: ff::PrimeField>(f: F) -> MultihashGeneric<64> {
+    MultihashGeneric::wrap(0xb401, f.to_repr().as_ref()).unwrap()
+}
+
+// this should be a trait method on ff, or PrimeField::Repr should be readable
+// from &[u8]
+pub fn ff_from_bytes_vartime<F: ff::PrimeField>(bs: &[u8]) -> Option<F> {
+    if bs.is_empty() {
+        return None;
+    }
+    let mut res = F::zero();
+
+    let _256 = F::from(256);
+
+    for b in bs {
+        res.mul_assign(&_256);
+        res.add_assign(&F::from(u64::from(*b)));
+    }
+    Some(res)
+}
+
+pub fn make_codec<F: PrimeField>(tag: u32) -> u64 {
+    u64::from(LURK_CODEC_PREFIX) << 48 & u64::from(dummy_ff_codec::<F>()) << 32 & u64::from(tag)
+}
+
+pub trait IpldEmbed: Sized {
+    fn to_ipld(&self) -> Ipld;
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError>;
+}
+
+// assume that `F` fits within
+pub fn cid(code: u64, ipld: &Ipld) -> Cid {
+    Cid::new_v1(
+        code,
+        Code::Blake3_256.digest(DagCborCodec.encode(ipld).unwrap().as_ref()),
+    )
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum IpldError {
+    Utf8(Vec<u8>, alloc::string::FromUtf8Error),
+    ByteCount(Vec<u8>, u64),
+    UnicodeChar(u32),
+    U64(TryFromIntError),
+    U32(TryFromIntError),
+    Expected(String, Ipld),
+}
+
+impl IpldError {
+    pub fn expected(s: &str, ipld: &Ipld) -> IpldError {
+        IpldError::Expected(String::from(s), ipld.clone())
+    }
+}
+
+impl IpldEmbed for Cid {
+    fn to_ipld(&self) -> Ipld {
+        Ipld::Link(*self)
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        match ipld {
+            Ipld::Link(x) => Ok(*x),
+            xs => Err(IpldError::Expected(String::from("cid"), xs.clone())),
+        }
+    }
+}
+
+impl IpldEmbed for bool {
+    fn to_ipld(&self) -> Ipld {
+        Ipld::Bool(*self)
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        match ipld {
+            Ipld::Bool(x) => Ok(*x),
+            xs => Err(IpldError::Expected(String::from("bool"), xs.clone())),
+        }
+    }
+}
+
+impl IpldEmbed for String {
+    fn to_ipld(&self) -> Ipld {
+        Ipld::String(self.clone())
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        match ipld {
+            Ipld::String(s) => Ok(s.clone()),
+            xs => Err(IpldError::Expected(String::from("String"), xs.clone())),
+        }
+    }
+}
+
+impl IpldEmbed for u32 {
+    fn to_ipld(&self) -> Ipld {
+        Ipld::Integer(*self as i128)
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        match ipld {
+            Ipld::Integer(x) => {
+                let x = (*x).try_into().map_err(IpldError::U32)?;
+                Ok(x)
+            }
+            xs => Err(IpldError::expected("u32", xs)),
+        }
+    }
+}
+
+impl IpldEmbed for u64 {
+    fn to_ipld(&self) -> Ipld {
+        Ipld::Integer(*self as i128)
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        match ipld {
+            Ipld::Integer(x) => {
+                let x = (*x).try_into().map_err(IpldError::U64)?;
+                Ok(x)
+            }
+            xs => Err(IpldError::expected("u64", xs)),
+        }
+    }
+}
+
+impl IpldEmbed for BigUint {
+    fn to_ipld(&self) -> Ipld {
+        Ipld::Bytes(self.to_bytes_be())
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        match ipld {
+            Ipld::Bytes(bs) => Ok(BigUint::from_bytes_be(bs)),
+            xs => Err(IpldError::Expected(String::from("BigUint"), xs.clone())),
+        }
+    }
+}
+
+// needed to avoid trait overlap with Cid
+pub struct FWrap<F: PrimeField>(pub F);
+
+impl<F: PrimeField> IpldEmbed for FWrap<F> {
+    fn to_ipld(&self) -> Ipld {
+        let bytes: Vec<u8> = self.0.to_repr().as_ref().to_owned();
+        Ipld::Bytes(bytes)
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        match ipld {
+            Ipld::Bytes(bs) => {
+                let f = ff_from_bytes_vartime(&bs).ok_or(IpldError::expected(
+                    "non-empty bytes",
+                    &Ipld::Bytes(bs.clone()),
+                ))?;
+                Ok(FWrap(f))
+            }
+            xs => Err(IpldError::expected("PrimeField", xs)),
+        }
+    }
+}
+
+impl<T: IpldEmbed> IpldEmbed for Vec<T> {
+    fn to_ipld(&self) -> Ipld {
+        Ipld::List(self.iter().map(|x| x.to_ipld()).collect())
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        let mut ys = Vec::new();
+        match ipld {
+            Ipld::List(xs) => {
+                for x in xs {
+                    let y = T::from_ipld(x)?;
+                    ys.push(y);
+                }
+                Ok(ys)
+            }
+            xs => Err(IpldError::expected("List", xs)),
+        }
+    }
+}
+
+impl<T: IpldEmbed> IpldEmbed for Option<T> {
+    fn to_ipld(&self) -> Ipld {
+        match self {
+            Some(x) => x.to_ipld(),
+            None => Ipld::Null,
+        }
+    }
+
+    fn from_ipld(ipld: &Ipld) -> Result<Self, IpldError> {
+        match ipld {
+            Ipld::Null => Ok(None),
+            x => {
+                let x = T::from_ipld(x)?;
+                Ok(Some(x))
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::single_match, clippy::type_complexity)]
 
+extern crate alloc;
+
 pub mod circuit;
 pub mod eval;
+pub mod ipld;
 pub mod parser;
 pub mod proof;
 pub mod repl;


### PR DESCRIPTION
Embedding of ScalarPtr, ScalarContPtr as CIDs is done. Have also written an embedding for a new ScalarExpression enum:
```
#[derive(Debug, Clone, PartialEq, Eq)]
pub enum ScalarExpression<F: PrimeField> {
    Nil,
    Cons(ScalarPtr<F>, ScalarPtr<F>),
    Sym(String),
    Fun(ScalarPtr<F>, ScalarPtr<F>, ScalarPtr<F>),
    Num(Num<F>),
    Str(String),
    Thunk(ScalarPtr<F>, ScalarContPtr<F>),
}
```

which I think should be fairly straightforward to convert `Expression` to once I better understand how `store.rs` generates the Scalar hashes.

One suggestion is to create a separate ScalarStore structure, which only has ScalarPtr, and use that as the "universal" environment.