### PR TITLE
Zero args

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1494,7 +1494,7 @@ fn reduce_cons<F: PrimeField, CS: ConstraintSystem<F>>(
         )?;
 
         let the_call_continuation = AllocatedContPtr::pick(
-            &mut cs.namespace(|| "the_call_tag"),
+            &mut cs.namespace(|| "the_call_continuation"),
             &rest_is_nil,
             &call0_continuation,
             &call_continuation,

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1689,7 +1689,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     );
     results.add_clauses_cont(ContTag::Error, result, env, &g.error_ptr_cont, &g.false_num);
 
-    let (_continuation_hash, continuation_components) = ContPtr::allocate_maybe_dummy_components(
+    let (continuation_hash, continuation_components) = ContPtr::allocate_maybe_dummy_components(
         &mut cs.namespace(|| "allocate_continuation_components"),
         witness
             .as_ref()
@@ -1705,16 +1705,17 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
 
     // Continuation::Call0
     /////////////////////////////////////////////////////////////////////////////
-    let (saved_env, continuation, function) = {
-        (
-            AllocatedPtr::by_index(0, &continuation_components),
-            AllocatedContPtr::by_index(2, &continuation_components),
-            result,
-        )
-    };
-    let call0_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
-        &[&saved_env, function, &continuation, default_num_pair];
-    hash_default_results.add_hash_input_clauses(ContTag::Call0, &g.tail_cont_tag, call0_components);
+    let old_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] = &[
+        &AllocatedPtr::by_index(0, &continuation_components),
+        &AllocatedPtr::by_index(1, &continuation_components),
+        &AllocatedPtr::by_index(2, &continuation_components),
+        &AllocatedPtr::by_index(3, &continuation_components),
+    ];
+    hash_default_results.add_hash_input_clauses(
+        ContTag::Call0,
+        &continuation_hash,
+        &old_continuation_components,
+    );
 
     // Continuation::Call
     /////////////////////////////////////////////////////////////////////////////

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2272,14 +2272,14 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
             &mut cs.namespace(|| "Binop: the expression"),
             &rest_is_nil,
             &allocated_arg2,
-            &result,
+            result,
         )?;
 
         let the_env = AllocatedPtr::pick(
             &mut cs.namespace(|| "Binop: the environment"),
             &rest_is_nil,
             &saved_env,
-            &env,
+            env,
         )?;
 
         (the_expr, the_env, the_cont)
@@ -2313,14 +2313,14 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
             &mut cs.namespace(|| "Relop: the expression"),
             &rest_is_nil,
             &allocated_arg2,
-            &result,
+            result,
         )?;
 
         let the_env = AllocatedPtr::pick(
             &mut cs.namespace(|| "Relop: the environment"),
             &rest_is_nil,
             &saved_env,
-            &env,
+            env,
         )?;
 
         (the_expr, the_env, the_cont)

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2069,41 +2069,41 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::Call0
     /////////////////////////////////////////////////////////////////////////////
     let (body_form, closed_env, the_cont) = {
-        let mut call0_cs = cs.namespace(|| "Call0");
+        let mut cs = cs.namespace(|| "Call0");
         let continuation = AllocatedContPtr::by_index(0, &continuation_components);
         let (_, arg_t, body_t, closed_env) = Ptr::allocate_maybe_fun(
-            &mut call0_cs.namespace(|| "allocate fun"),
+            &mut cs.namespace(|| "allocate fun"),
             store,
             result.ptr(store).as_ref(),
         )?;
 
-        let (body_form, _) = car_cdr(&mut call0_cs.namespace(|| "body_form"), g, &body_t, store)?;
+        let (body_form, _) = car_cdr(&mut cs.namespace(|| "body_form"), g, &body_t, store)?;
 
         let args_is_dummy =
-            arg_t.alloc_equal(&mut call0_cs.namespace(|| "args_is_dummy"), &g.dummy_arg_ptr)?;
+            arg_t.alloc_equal(&mut cs.namespace(|| "args_is_dummy"), &g.dummy_arg_ptr)?;
 
         let next_exp = AllocatedPtr::pick(
-            &mut call0_cs.namespace(|| "pick nexp exp"),
+            &mut cs.namespace(|| "pick nexp exp"),
             &args_is_dummy,
             &body_form,
             result,
         )?;
 
         let result_is_fun = alloc_equal(
-            call0_cs.namespace(|| "result_is_fun"),
+            cs.namespace(|| "result_is_fun"),
             function.tag(),
             &g.fun_tag,
         )?;
 
         let the_cont = AllocatedContPtr::pick(
-            &mut call0_cs.namespace(|| "the_cont"),
+            &mut cs.namespace(|| "the_cont"),
             &result_is_fun,
             &continuation,
             &g.error_ptr_cont,
         )?;
 
         let the_env = AllocatedPtr::pick(
-            &mut call0_cs.namespace(|| "the_env"),
+            &mut cs.namespace(|| "the_env"),
             &result_is_fun,
             &closed_env,
             env,
@@ -2122,23 +2122,23 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::Call, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     let (next_expr, the_cont) = {
-        let mut call_cs = cs.namespace(|| "Call");
+        let mut cs = cs.namespace(|| "Call");
         let next_expr = AllocatedPtr::by_index(1, &continuation_components);
         let result_is_fun = alloc_equal(
-            call_cs.namespace(|| "result_is_fun"),
+            cs.namespace(|| "result_is_fun"),
             function.tag(),
             &g.fun_tag,
         )?;
 
         let next_expr = AllocatedPtr::pick(
-            &mut call_cs.namespace(|| "next_expr"),
+            &mut cs.namespace(|| "next_expr"),
             &result_is_fun,
             &next_expr,
             result,
         )?;
 
         let the_cont = AllocatedContPtr::pick(
-            &mut call_cs.namespace(|| "the_cont"),
+            &mut cs.namespace(|| "the_cont"),
             &result_is_fun,
             &newer_cont,
             &g.error_ptr_cont,
@@ -2150,42 +2150,42 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::Call2, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     let (the_expr, the_env, the_cont) = {
-        let mut call2_cs = cs.namespace(|| "Call2");
+        let mut cs = cs.namespace(|| "Call2");
         let fun = AllocatedPtr::by_index(1, &continuation_components);
         let continuation = AllocatedContPtr::by_index(2, &continuation_components);
 
         {
             let (hash, arg_t, body_t, closed_env) = Ptr::allocate_maybe_fun(
-                &mut call2_cs.namespace(|| "allocate fun"),
+                &mut cs.namespace(|| "allocate fun"),
                 store,
                 fun.ptr(store).as_ref(),
             )?;
 
             let (body_form, _) =
-                car_cdr(&mut call2_cs.namespace(|| "body_form"), g, &body_t, store)?;
+                car_cdr(&mut cs.namespace(|| "body_form"), g, &body_t, store)?;
 
             let fun_is_correct = constraints::alloc_equal(
-                &mut call2_cs.namespace(|| "fun hash is correct"),
+                &mut cs.namespace(|| "fun hash is correct"),
                 fun.hash(),
                 &hash,
             )?;
 
             let cont_is_call2_precomp = constraints::alloc_equal(
-                &mut call2_cs.namespace(|| "branch taken"),
+                &mut cs.namespace(|| "branch taken"),
                 cont.tag(),
                 &g.call2_cont_tag,
             )?;
 
-            let cont_is_call2_and_not_dummy = and!(call2_cs, &cont_is_call2_precomp, not_dummy)?;
+            let cont_is_call2_and_not_dummy = and!(cs, &cont_is_call2_precomp, not_dummy)?;
 
             enforce_implication(
-                &mut call2_cs.namespace(|| "implies non-dummy fun"),
+                &mut cs.namespace(|| "implies non-dummy fun"),
                 &cont_is_call2_and_not_dummy,
                 &fun_is_correct,
             )?;
 
             let newer_env = extend(
-                &mut call2_cs.namespace(|| "extend env"),
+                &mut cs.namespace(|| "extend env"),
                 g,
                 store,
                 &closed_env,
@@ -2194,50 +2194,45 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
             )?;
 
             let continuation_is_tail = alloc_equal(
-                &mut call2_cs.namespace(|| "continuation is tail"),
+                &mut cs.namespace(|| "continuation is tail"),
                 continuation.tag(),
                 &g.tail_cont_tag,
             )?;
 
             let tail_cont = AllocatedContPtr::pick(
-                &mut call2_cs.namespace(|| "the tail continuation"),
+                &mut cs.namespace(|| "the tail continuation"),
                 &continuation_is_tail,
                 &continuation,
                 &newer_cont,
             );
 
             let result_is_fun = alloc_equal(
-                call2_cs.namespace(|| "result_is_fun"),
+                cs.namespace(|| "result_is_fun"),
                 function.tag(),
                 &g.fun_tag,
             )?;
             let args_is_dummy = arg_t.alloc_equal(
-                &mut call2_cs.namespace(|| "args_is_dummy"),
+                &mut cs.namespace(|| "args_is_dummy"),
                 &g.dummy_arg_ptr,
             )?;
-            let cond = or!(call2_cs, &args_is_dummy.not(), &result_is_fun)?;
-
-            let call2_cont = match tail_cont {
-                Ok(c) => c,
-                Err(_) => g.dummy_ptr.clone(),
-            };
+            let cond = or!(cs, &args_is_dummy.not(), &result_is_fun)?;
 
             let the_cont = AllocatedContPtr::pick(
-                &mut call2_cs.namespace(|| "the_cont"),
+                &mut cs.namespace(|| "the_cont"),
                 &cond,
-                &call2_cont,
+                &tail_cont.unwrap(),
                 &g.error_ptr_cont,
             )?;
 
             let the_env = AllocatedPtr::pick(
-                &mut call2_cs.namespace(|| "the_env"),
+                &mut cs.namespace(|| "the_env"),
                 &cond,
                 &newer_env,
                 env,
             )?;
 
             let the_expr = AllocatedPtr::pick(
-                &mut call2_cs.namespace(|| "the_expr"),
+                &mut cs.namespace(|| "the_expr"),
                 &cond,
                 &body_form,
                 result,
@@ -2251,36 +2246,36 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::Binop, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     let (the_expr, the_env, the_cont) = {
-        let mut binop_cs = cs.namespace(|| "Binop");
+        let mut cs = cs.namespace(|| "Binop");
         let saved_env = AllocatedPtr::by_index(1, &continuation_components);
         let unevaled_args = AllocatedPtr::by_index(2, &continuation_components);
 
         let (allocated_arg2, allocated_rest) = car_cdr(
-            &mut binop_cs.namespace(|| "cons using newer continuation"),
+            &mut cs.namespace(|| "cons using newer continuation"),
             g,
             &unevaled_args,
             store,
         )?;
 
         let rest_is_nil =
-            allocated_rest.alloc_equal(&mut binop_cs.namespace(|| "args_is_nil"), &g.nil_ptr)?;
+            allocated_rest.alloc_equal(&mut cs.namespace(|| "args_is_nil"), &g.nil_ptr)?;
 
         let the_cont = AllocatedContPtr::pick(
-            &mut binop_cs.namespace(|| "the_cont"),
+            &mut cs.namespace(|| "the_cont"),
             &rest_is_nil,
             &newer_cont,
             &g.error_ptr_cont,
         )?;
 
         let the_expr = AllocatedPtr::pick(
-            &mut binop_cs.namespace(|| "the_expr"),
+            &mut cs.namespace(|| "the_expr"),
             &rest_is_nil,
             &allocated_arg2,
             result,
         )?;
 
         let the_env = AllocatedPtr::pick(
-            &mut binop_cs.namespace(|| "the_env"),
+            &mut cs.namespace(|| "the_env"),
             &rest_is_nil,
             &saved_env,
             env,
@@ -2293,36 +2288,36 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::Relop, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     let (the_expr, the_env, the_cont) = {
-        let mut relop_cs = cs.namespace(|| "Relop");
+        let mut cs = cs.namespace(|| "Relop");
         let saved_env = AllocatedPtr::by_index(1, &continuation_components);
         let unevaled_args = AllocatedPtr::by_index(2, &continuation_components);
 
         let (allocated_arg2, allocated_rest) = car_cdr(
-            &mut relop_cs.namespace(|| "cons"),
+            &mut cs.namespace(|| "cons"),
             g,
             &unevaled_args,
             store,
         )?;
 
         let rest_is_nil =
-            allocated_rest.alloc_equal(&mut relop_cs.namespace(|| "args_is_nil"), &g.nil_ptr)?;
+            allocated_rest.alloc_equal(&mut cs.namespace(|| "args_is_nil"), &g.nil_ptr)?;
 
         let the_cont = AllocatedContPtr::pick(
-            &mut relop_cs.namespace(|| "the_cont"),
+            &mut cs.namespace(|| "the_cont"),
             &rest_is_nil,
             &newer_cont,
             &g.error_ptr_cont,
         )?;
 
         let the_expr = AllocatedPtr::pick(
-            &mut relop_cs.namespace(|| "the_expr"),
+            &mut cs.namespace(|| "the_expr"),
             &rest_is_nil,
             &allocated_arg2,
             result,
         )?;
 
         let the_env = AllocatedPtr::pick(
-            &mut relop_cs.namespace(|| "the_env"),
+            &mut cs.namespace(|| "the_env"),
             &rest_is_nil,
             &saved_env,
             env,
@@ -2335,38 +2330,38 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::Relop2
     /////////////////////////////////////////////////////////////////////////////
     let (res, continuation) = {
-        let mut relop2_cs = cs.namespace(|| "Relop2");
+        let mut cs = cs.namespace(|| "Relop2");
         let rel2 = AllocatedPtr::by_index(0, &continuation_components);
         let arg1 = AllocatedPtr::by_index(1, &continuation_components);
         let continuation = AllocatedContPtr::by_index(2, &continuation_components);
         let arg2 = result;
 
         let tags_equal = alloc_equal(
-            &mut relop2_cs.namespace(|| "tags equal"),
+            &mut cs.namespace(|| "tags equal"),
             arg1.tag(),
             arg2.tag(),
         )?;
 
         let vals_equal = alloc_equal(
-            &mut relop2_cs.namespace(|| "vals equal"),
+            &mut cs.namespace(|| "vals equal"),
             arg1.hash(),
             arg2.hash(),
         )?;
 
         let tag_is_num = alloc_equal(
-            &mut relop2_cs.namespace(|| "arg1 tag is num"),
+            &mut cs.namespace(|| "arg1 tag is num"),
             arg1.tag(),
             &g.num_tag,
         )?;
 
         let rel2_is_equal = alloc_equal(
-            &mut relop2_cs.namespace(|| "rel2 tag is Equal"),
+            &mut cs.namespace(|| "rel2 tag is Equal"),
             rel2.tag(),
             &g.rel2_equal_tag,
         )?;
 
         let args_equal = Boolean::and(
-            &mut relop2_cs.namespace(|| "args equal"),
+            &mut cs.namespace(|| "args equal"),
             &tags_equal,
             &vals_equal,
         )?;
@@ -2377,19 +2372,19 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
 
         // not_num_tag_without_nums = args_equal && (tag_is_num || rel2_is_equal)
         let not_num_tag_without_nums = constraints::or(
-            &mut relop2_cs.namespace(|| "sub_res"),
+            &mut cs.namespace(|| "sub_res"),
             &tag_is_num,
             &rel2_is_equal,
         )?;
 
         let boolean_res = Boolean::and(
-            &mut relop2_cs.namespace(|| "boolean_res"),
+            &mut cs.namespace(|| "boolean_res"),
             &args_equal,
             &not_num_tag_without_nums,
         )?;
 
         let res = AllocatedPtr::pick(
-            &mut relop2_cs.namespace(|| "res"),
+            &mut cs.namespace(|| "res"),
             &boolean_res,
             &g.t_ptr,
             &g.nil_ptr,
@@ -2405,7 +2400,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::If
     /////////////////////////////////////////////////////////////////////////////
     let (res, continuation) = {
-        let mut if_cs = cs.namespace(|| "If");
+        let mut cs = cs.namespace(|| "If");
         let unevaled_args = AllocatedPtr::by_index(0, &continuation_components);
         let continuation = AllocatedContPtr::by_index(1, &continuation_components);
 
@@ -2419,19 +2414,19 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         // We address this by adding 2 to the tags returned by Op2 and Rel2 fr() methods, so this collision cannot happen.
         // TODO: It might make even more sense to make all disjoint.
         let (arg1, more) = car_cdr(
-            &mut if_cs.namespace(|| "unevaled_args cons"),
+            &mut cs.namespace(|| "unevaled_args cons"),
             g,
             &unevaled_args,
             store,
         )?;
 
         let condition_is_nil =
-            condition.alloc_equal(&mut if_cs.namespace(|| "condition is nil"), &g.nil_ptr)?;
+            condition.alloc_equal(&mut cs.namespace(|| "condition is nil"), &g.nil_ptr)?;
 
-        let (arg2, _end) = car_cdr(&mut if_cs.namespace(|| "more cons"), g, &more, store)?;
+        let (arg2, _end) = car_cdr(&mut cs.namespace(|| "more cons"), g, &more, store)?;
 
         let res = AllocatedPtr::pick(
-            &mut if_cs.namespace(|| "pick arg1 or arg2"),
+            &mut cs.namespace(|| "pick arg1 or arg2"),
             &condition_is_nil,
             &arg2,
             &arg1,
@@ -2469,13 +2464,13 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::Let, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     let (body, extended_env, tail_cont) = {
-        let mut let_cs = cs.namespace(|| "Let");
+        let mut cs = cs.namespace(|| "Let");
         let var = AllocatedPtr::by_index(0, &continuation_components);
         let body = AllocatedPtr::by_index(1, &continuation_components);
         let let_cont = AllocatedContPtr::by_index(3, &continuation_components);
 
         let extended_env = extend(
-            &mut let_cs.namespace(|| "extend env"),
+            &mut cs.namespace(|| "extend env"),
             g,
             store,
             env,
@@ -2484,13 +2479,13 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         )?;
 
         let continuation_is_tail = alloc_equal(
-            &mut let_cs.namespace(|| "continuation is tail"),
+            &mut cs.namespace(|| "continuation is tail"),
             let_cont.tag(),
             &g.tail_cont_tag,
         )?;
 
         let tail_cont = AllocatedContPtr::pick(
-            &mut let_cs.namespace(|| "the tail continuation"),
+            &mut cs.namespace(|| "the tail continuation"),
             &continuation_is_tail,
             &let_cont,
             &newer_cont,
@@ -2507,13 +2502,13 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     // Continuation::LetRec, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     let (body, extended_env, return_cont) = {
-        let mut letrec_cs = cs.namespace(|| "LetRec");
+        let mut cs = cs.namespace(|| "LetRec");
         let var = AllocatedPtr::by_index(0, &continuation_components);
         let body = AllocatedPtr::by_index(1, &continuation_components);
         let letrec_cont = AllocatedContPtr::by_index(3, &continuation_components);
 
         let extended_env = extend_rec(
-            &mut letrec_cs.namespace(|| "extend_rec env"),
+            &mut cs.namespace(|| "extend_rec env"),
             g,
             env,
             &var,
@@ -2522,23 +2517,23 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         )?;
 
         let is_error =
-            extended_env.alloc_equal(&mut letrec_cs.namespace(|| "is_error"), &g.error_ptr)?;
+            extended_env.alloc_equal(&mut cs.namespace(|| "is_error"), &g.error_ptr)?;
 
         let continuation_is_tail = alloc_equal(
-            &mut letrec_cs.namespace(|| "continuation is tail"),
+            &mut cs.namespace(|| "continuation is tail"),
             letrec_cont.tag(),
             &g.tail_cont_tag,
         )?;
 
         let tail_cont = AllocatedContPtr::pick(
-            &mut letrec_cs.namespace(|| "the tail continuation"),
+            &mut cs.namespace(|| "the tail continuation"),
             &continuation_is_tail,
             &letrec_cont,
             &newer_cont,
         )?;
 
         let return_cont = AllocatedContPtr::pick(
-            &mut letrec_cs.namespace(|| "return_cont"),
+            &mut cs.namespace(|| "return_cont"),
             &is_error,
             &g.error_ptr_cont,
             &tail_cont,

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -194,7 +194,7 @@ impl<F: PrimeField> CircuitFrame<'_, F, IO<F>, Witness<F>> {
     ) -> Result<AllocatedIO<F>, SynthesisError> {
         let (input_expr, input_env, input_cont) = inputs;
 
-        let res = reduce_expression(
+        reduce_expression(
             &mut cs.namespace(|| format!("reduce expression {}", i)),
             &input_expr,
             &input_env,
@@ -202,9 +202,7 @@ impl<F: PrimeField> CircuitFrame<'_, F, IO<F>, Witness<F>> {
             &self.witness,
             self.store,
             g,
-        );
-
-        res
+        )
     }
 }
 
@@ -2189,8 +2187,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
 
     // Continuation::Call0 (after getting newer cont)
     /////////////////////////////////////////////////////////////////////////////
-    let (body_form, closed_env, tail_cont) = {
-        //let fun = AllocatedPtr::by_index(1, &continuation_components);
+    let (body_form, closed_env, continuation) = {
         let continuation = AllocatedContPtr::by_index(0, &continuation_components);
         let (_, _, body_t, closed_env) = Ptr::allocate_maybe_fun(
             &mut cs.namespace(|| "allocate Call2 fun using newer continuation in Call0"),
@@ -2207,7 +2204,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
 
         (body_form, closed_env, continuation)
     };
-    results.add_clauses_cont(ContTag::Call0, &body_form, &closed_env, &tail_cont, &g.false_num);
+    results.add_clauses_cont(ContTag::Call0, &body_form, &closed_env, &continuation, &g.false_num);
 
     // Continuation::Call (after getting newer cont)
     /////////////////////////////////////////////////////////////////////////////

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2202,13 +2202,13 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
             store,
         )?;
 
-        let arg_is_nil = arg_t.alloc_equal(&mut cs.namespace(|| "args_is_nil"), &g.nil_ptr)?;
+        let arg_is_nil = arg_t.alloc_equal(&mut cs.namespace(|| "args_is_nil"), &g.dummy_arg_ptr)?;
 
         let next_exp = AllocatedPtr::pick(
             &mut cs.namespace(|| "default env using newer continuation in Call0"),
             &arg_is_nil,
-            result,
             &body_form,
+            result,
         )?;
 
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2126,7 +2126,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         let next_expr = AllocatedPtr::by_index(1, &continuation_components);
         let result_is_fun = alloc_equal(
             cs.namespace(|| "result_is_fun"),
-            function.tag(),
+            result.tag(),
             &g.fun_tag,
         )?;
 
@@ -2208,7 +2208,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
 
             let result_is_fun = alloc_equal(
                 cs.namespace(|| "result_is_fun"),
-                function.tag(),
+                result.tag(),
                 &g.fun_tag,
             )?;
             let args_is_dummy = arg_t.alloc_equal(

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2189,7 +2189,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     /////////////////////////////////////////////////////////////////////////////
     let (body_form, closed_env, continuation) = {
         let continuation = AllocatedContPtr::by_index(0, &continuation_components);
-        let (_, _, body_t, closed_env) = Ptr::allocate_maybe_fun(
+        let (hash, arg_t, body_t, closed_env) = Ptr::allocate_maybe_fun(
             &mut cs.namespace(|| "allocate Call2 fun using newer continuation in Call0"),
             store,
             result.ptr(store).as_ref(),
@@ -2202,7 +2202,17 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
             store,
         )?;
 
-        (body_form, closed_env, continuation)
+        let arg_is_nil = arg_t.alloc_equal(&mut cs.namespace(|| "args_is_nil"), &g.nil_ptr)?;
+
+        let next_exp = AllocatedPtr::pick(
+            &mut cs.namespace(|| "default env using newer continuation in Call0"),
+            &arg_is_nil,
+            result,
+            &body_form,
+        )?;
+
+
+        (next_exp, closed_env, continuation)
     };
     results.add_clauses_cont(ContTag::Call0, &body_form, &closed_env, &continuation, &g.false_num);
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1682,8 +1682,20 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
 
     let default_num_pair = &[&g.default_num, &g.default_num];
 
+    // Continuation::Call0
     /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Call                                                      //
+    let (saved_env, continuation, function) = {
+        (
+            AllocatedPtr::by_index(0, &continuation_components),
+            AllocatedContPtr::by_index(2, &continuation_components),
+            result,
+        )
+    };
+    let call0_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
+        &[&saved_env, function, &continuation, default_num_pair];
+    hash_default_results.add_hash_input_clauses(ContTag::Call0, &g.tail_cont_tag, call0_components);
+
+    // Continuation::Call
     /////////////////////////////////////////////////////////////////////////////
     let (saved_env, continuation, function) = {
         (
@@ -1696,8 +1708,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         &[&saved_env, function, &continuation, default_num_pair];
     hash_default_results.add_hash_input_clauses(ContTag::Call, &g.call2_cont_tag, call_components);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Call2                                                     //
+    // Continuation::Call2
     /////////////////////////////////////////////////////////////////////////////
     let (saved_env, continuation) = {
         (
@@ -1713,8 +1724,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     ];
     hash_default_results.add_hash_input_clauses(ContTag::Call2, &g.tail_cont_tag, call2_components);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Let                                                       //
+    // Continuation::Let
     /////////////////////////////////////////////////////////////////////////////
     let (saved_env, let_cont) = {
         (
@@ -1726,8 +1736,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         &[&saved_env, &let_cont, default_num_pair, default_num_pair];
     hash_default_results.add_hash_input_clauses(ContTag::Let, &g.tail_cont_tag, let_components);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::LetRec                                                    //
+    // Continuation::LetRec
     /////////////////////////////////////////////////////////////////////////////
     let (saved_env, letrec_cont) = {
         (
@@ -1743,8 +1752,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         letrec_components,
     );
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Unop                                                      //
+    // Continuation::Unop
     /////////////////////////////////////////////////////////////////////////////
     let (unop_val, unop_continuation) = {
         let op1 = AllocatedPtr::by_index(0, &continuation_components);
@@ -1818,8 +1826,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         (AllocatedPtr::by_index(0, &res), unop_continuation)
     };
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Emit                                                      //
+    // Continuation::Emit
     /////////////////////////////////////////////////////////////////////////////
     let emit_components: &[&dyn AsAllocatedHashComponents<F>; 4] = &[
         &unop_continuation,
@@ -1829,8 +1836,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     ];
     hash_default_results.add_hash_input_clauses(ContTag::Unop, &g.emit_cont_tag, emit_components);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Binop                                                      //
+    // Continuation::Binop
     /////////////////////////////////////////////////////////////////////////////
     let (op2, continuation) = {
         (
@@ -1850,8 +1856,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         binop_components,
     );
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Binop2                                                    //
+    // Continuation::Binop2
     /////////////////////////////////////////////////////////////////////////////
     let (res, c) = {
         let op2 = AllocatedPtr::by_index(0, &continuation_components);
@@ -1973,8 +1978,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
 
     results.add_clauses_cont(ContTag::Binop2, &res, env, &c, &g.true_num);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Relop                                                      //
+    // Continuation::Relop
     /////////////////////////////////////////////////////////////////////////////
     let (relop2, relop_cont) = {
         (
@@ -1994,8 +1998,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         relop_components,
     );
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Relop2                                                    //
+    // Continuation::Relop2
     /////////////////////////////////////////////////////////////////////////////
     let (res, continuation) = {
         let rel2 = AllocatedPtr::by_index(0, &continuation_components);
@@ -2058,8 +2061,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     };
     results.add_clauses_cont(ContTag::Relop2, &res, env, &continuation, &g.true_num);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::If                                                        //
+    // Continuation::If
     /////////////////////////////////////////////////////////////////////////////
     let (res, continuation) = {
         let unevaled_args = AllocatedPtr::by_index(0, &continuation_components);
@@ -2097,8 +2099,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
 
     results.add_clauses_cont(ContTag::If, &res, env, &continuation, &g.false_num);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Lookup                                                    //
+    // Continuation::Lookup
     /////////////////////////////////////////////////////////////////////////////
     let saved_env = AllocatedPtr::by_index(0, &continuation_components);
     let continuation = AllocatedContPtr::by_index(1, &continuation_components);
@@ -2110,8 +2111,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         &g.true_num,
     );
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Tail                                                      //
+    // Continuation::Tail
     /////////////////////////////////////////////////////////////////////////////
     let saved_env = AllocatedPtr::by_index(0, &continuation_components);
     let continuation = AllocatedContPtr::by_index(1, &continuation_components);
@@ -2167,8 +2167,34 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         ],
     )?;
 
+    // Continuation::Call0 (after hash)
     /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Call (after hash)                                         //
+    let (next, the_cont) = {
+        let next_expr = AllocatedPtr::by_index(1, &continuation_components);
+        let result_is_fun = alloc_equal(
+            cs.namespace(|| "result_is_fun default using newer continuation in zero-arg call"),
+            function.tag(),
+            &g.fun_tag,
+        )?;
+
+        let next = AllocatedPtr::pick(
+            &mut cs.namespace(|| "default env using newer continuation in zero-arg call"),
+            &result_is_fun,
+            &next_expr,
+            result,
+        )?;
+
+        let the_cont = AllocatedContPtr::pick(
+            &mut cs.namespace(|| "default cont using newer continuation in zero-arg call"),
+            &result_is_fun,
+            &newer_cont,
+            &g.error_ptr_cont,
+        )?;
+        (next, the_cont)
+    };
+    results.add_clauses_cont(ContTag::Call0, &next, env, &the_cont, &g.false_num);
+
+    // Continuation::Call (after hash)
     /////////////////////////////////////////////////////////////////////////////
     let (next, the_cont) = {
         let next_expr = AllocatedPtr::by_index(1, &continuation_components);
@@ -2195,8 +2221,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     };
     results.add_clauses_cont(ContTag::Call, &next, env, &the_cont, &g.false_num);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Call2 (after hash)                                        //
+    // Continuation::Call2 (after hash)
     /////////////////////////////////////////////////////////////////////////////
     let (body_form, newer_env, tail_cont) = {
         let fun = AllocatedPtr::by_index(1, &continuation_components);
@@ -2262,8 +2287,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         }
     };
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Binop (after hash)                                        //
+    // Continuation::Binop (after hash)
     /////////////////////////////////////////////////////////////////////////////
     let (allocated_arg2, saved_env) = {
         let saved_env = AllocatedPtr::by_index(1, &continuation_components);
@@ -2287,8 +2311,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         &g.false_num,
     );
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Relop (after hash)                                        //
+    // Continuation::Relop (after hash)
     /////////////////////////////////////////////////////////////////////////////
     let (allocated_arg2, saved_env) = {
         let saved_env = AllocatedPtr::by_index(1, &continuation_components);
@@ -2324,8 +2347,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         &g.false_num,
     );
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Let   (after hash)                                        //
+    // Continuation::Let   (after hash)
     /////////////////////////////////////////////////////////////////////////////
     let (body, extended_env, tail_cont) = {
         let var = AllocatedPtr::by_index(0, &continuation_components);
@@ -2362,8 +2384,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
     };
     results.add_clauses_cont(ContTag::Let, &body, &extended_env, &let_cont, &g.false_num);
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::LetRec (after hash)                                       //
+    // Continuation::LetRec (after hash)
     /////////////////////////////////////////////////////////////////////////////
     let (body, extended_env, return_cont) = {
         let var = AllocatedPtr::by_index(0, &continuation_components);
@@ -2414,8 +2435,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         &g.false_num,
     );
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Continuation::Unop (after hash)                                         //
+    // Continuation::Unop (after hash)
     /////////////////////////////////////////////////////////////////////////////
     let unop_op1 = AllocatedPtr::by_index(0, &continuation_components);
     let other_unop_continuation = AllocatedContPtr::by_index(1, &continuation_components);
@@ -2439,8 +2459,7 @@ fn apply_continuation<F: PrimeField, CS: ConstraintSystem<F>>(
         &g.true_num,
     );
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Main multi_case                                                         //
+    // Main multi_case
     /////////////////////////////////////////////////////////////////////////////
 
     let all_clauses = [
@@ -2704,9 +2723,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(29670, cs.num_constraints());
+            assert_eq!(29696, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(29648, cs.aux().len());
+            assert_eq!(29673, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -33,6 +33,7 @@ pub struct GlobalAllocations<F: PrimeField> {
     pub outermost_cont_tag: AllocatedNum<F>,
     pub lookup_cont_tag: AllocatedNum<F>,
     pub tail_cont_tag: AllocatedNum<F>,
+    pub call0_cont_tag: AllocatedNum<F>,
     pub call_cont_tag: AllocatedNum<F>,
     pub call2_cont_tag: AllocatedNum<F>,
     pub unop_cont_tag: AllocatedNum<F>,
@@ -121,6 +122,8 @@ impl<F: PrimeField> GlobalAllocations<F> {
             ContTag::LetRec.allocate_constant(&mut cs.namespace(|| "letrec_cont_tag"))?;
         let tail_cont_tag =
             ContTag::Tail.allocate_constant(&mut cs.namespace(|| "tail_cont_tag"))?;
+        let call0_cont_tag =
+            ContTag::Call0.allocate_constant(&mut cs.namespace(|| "call0_cont_tag"))?;
         let call_cont_tag =
             ContTag::Call.allocate_constant(&mut cs.namespace(|| "call_cont_tag"))?;
         let call2_cont_tag =
@@ -183,6 +186,7 @@ impl<F: PrimeField> GlobalAllocations<F> {
             let_cont_tag,
             letrec_cont_tag,
             tail_cont_tag,
+            call0_cont_tag,
             call_cont_tag,
             call2_cont_tag,
             unop_cont_tag,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -729,7 +729,6 @@ fn apply_continuation<F: PrimeField>(
                             // Applying zero args to a non-zero arg function leaves it unchanged.
                             // This is arguably consistent with auto-currying.
                             // TODO: maybe it should be an error.
-                            //let cont = make_tail_continuation(saved_env, continuation, store);
                             Control::Return(*result, *env, continuation)
                         }
                     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -737,7 +737,7 @@ fn apply_continuation<F: PrimeField>(
                     }
                     _ => unreachable!(),
                 }, // Bad function
-                _ => todo!("return error continuation"),
+                _ => Control::Return(*result, *env, store.intern_cont_error()),
             },
             _ => unreachable!(),
         },
@@ -2294,6 +2294,23 @@ mod test {
 
             assert_eq!(s.intern_cont_error(), continuation);
             assert_eq!(3, iterations);
+        }
+        {
+            let mut s = Store::<Fr>::default();
+            let limit = 20;
+            let expr = s.read("(123)").unwrap();
+
+            let (
+                IO {
+                    expr: _result_expr,
+                    env: _new_env,
+                    cont: continuation,
+                },
+                iterations,
+            ) = Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
+
+            assert_eq!(s.intern_cont_error(), continuation);
+            assert_eq!(2, iterations);
         }
     }
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1135,7 +1135,7 @@ mod tests {
         outer_prove_aux(
             &"(let ((x 9) (f (lambda () (+ x 1)))) (f))",
             |store| store.num(10),
-            12,
+            10,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,
             true,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1121,7 +1121,7 @@ mod tests {
         outer_prove_aux(
             &"((lambda () 123))",
             |store| store.num(123),
-            4,
+            3,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,
             true,
@@ -1135,7 +1135,7 @@ mod tests {
         outer_prove_aux(
             &"(let ((x 9) (f (lambda () (+ x 1)))) (f))",
             |store| store.num(10),
-            13,
+            12,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,
             true,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1171,7 +1171,9 @@ mod tests {
         // Tests don't currently have a way of checking this, but we need that.
         outer_prove_aux(
             &"((lambda () 123) 1)",
-            |store| store.num(999),
+            |store| {
+                store.intern_num(1)
+            },
             3,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,
@@ -1180,13 +1182,16 @@ mod tests {
             false,
         );
     }
+
     #[test]
     fn outer_prove_evaluate_zero_arg_lambda5() {
         // FIXME: This should be an error.
         // Tests don't currently have a way of checking this, but we need that.
         outer_prove_aux(
             &"(123)",
-            |store| store.num(999),
+            |store| {
+                store.intern_num(123)
+            },
             2,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1171,9 +1171,7 @@ mod tests {
         // Tests don't currently have a way of checking this, but we need that.
         outer_prove_aux(
             &"((lambda () 123) 1)",
-            |store| {
-                store.intern_num(1)
-            },
+            |store| store.intern_num(1),
             3,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,
@@ -1189,9 +1187,7 @@ mod tests {
         // Tests don't currently have a way of checking this, but we need that.
         outer_prove_aux(
             &"(123)",
-            |store| {
-                store.intern_num(123)
-            },
+            |store| store.intern_num(123),
             2,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1164,14 +1164,30 @@ mod tests {
             false,
         );
     }
+
     #[test]
     fn outer_prove_evaluate_zero_arg_lambda4() {
         // FIXME: This should be an error.
         // Tests don't currently have a way of checking this, but we need that.
         outer_prove_aux(
             &"((lambda () 123) 1)",
-            |store| store.num(123),
+            |store| todo!(),
             3,
+            DEFAULT_CHUNK_FRAME_COUNT,
+            DEFAULT_CHECK_NOVA,
+            true,
+            300,
+            false,
+        );
+    }
+    #[test]
+    fn outer_prove_evaluate_zero_arg_lambda5() {
+        // FIXME: This should be an error.
+        // Tests don't currently have a way of checking this, but we need that.
+        outer_prove_aux(
+            &"(123)",
+            |store| todo!(),
+            2,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,
             true,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -644,6 +644,36 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "assertion failed: rest.is_nil()")]
+    fn outer_prove_evaluate_binop_rest_is_nil() {
+        outer_prove_aux(
+            &"(- 9 8 7)",
+            |store| store.nil(),
+            3,
+            DEFAULT_CHUNK_FRAME_COUNT,
+            DEFAULT_CHECK_NOVA,
+            true,
+            300,
+            false,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: rest.is_nil()")]
+    fn outer_prove_evaluate_relop_rest_is_nil() {
+        outer_prove_aux(
+            &"(= 9 8 7)",
+            |store| store.nil(),
+            3,
+            DEFAULT_CHUNK_FRAME_COUNT,
+            DEFAULT_CHECK_NOVA,
+            true,
+            300,
+            false,
+        );
+    }
+
+    #[test]
     fn outer_prove_evaluate_diff() {
         outer_prove_aux(
             &"(- 9 5)",

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1171,7 +1171,7 @@ mod tests {
         // Tests don't currently have a way of checking this, but we need that.
         outer_prove_aux(
             &"((lambda () 123) 1)",
-            |store| todo!(),
+            |store| store.num(999),
             3,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,
@@ -1186,7 +1186,7 @@ mod tests {
         // Tests don't currently have a way of checking this, but we need that.
         outer_prove_aux(
             &"(123)",
-            |store| todo!(),
+            |store| store.num(999),
             2,
             DEFAULT_CHUNK_FRAME_COUNT,
             DEFAULT_CHECK_NOVA,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1175,8 +1175,6 @@ mod tests {
     }
     #[test]
     fn outer_prove_evaluate_zero_arg_lambda3() {
-        // FIXME: This should return the Fun, to match eval.rs
-        // Actual expected value might need tweaking once constraint system is satisfied.
         outer_prove_aux(
             &"((lambda (x) 123))",
             |store| {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -319,7 +319,6 @@ impl ReplState {
             } else {
                 let (result, _limit, _next_cont) = self.eval_expr(ptr, store);
 
-                println!("Read: {}", input);
                 println!("Evaled: {}", result.fmt_to_string(store));
                 io::stdout().flush().unwrap();
             }

--- a/src/store.rs
+++ b/src/store.rs
@@ -73,7 +73,7 @@ pub struct Store<F: PrimeField> {
 
     str_store: StringSet,
     thunk_store: IndexSet<Thunk<F>>,
-    call0_store: IndexSet<(Ptr<F>, ContPtr<F>)>,
+    call0_store: IndexSet<ContPtr<F>>,
     call_store: IndexSet<(Ptr<F>, Ptr<F>, ContPtr<F>)>,
     call2_store: IndexSet<(Ptr<F>, Ptr<F>, ContPtr<F>)>,
     tail_store: IndexSet<(Ptr<F>, ContPtr<F>)>,
@@ -383,7 +383,6 @@ impl<F: PrimeField> Hash for Thunk<F> {
 pub enum Continuation<F: PrimeField> {
     Outermost,
     Call0 {
-        saved_env: Ptr<F>,
         continuation: ContPtr<F>,
     },
     Call {
@@ -871,8 +870,8 @@ impl<F: PrimeField> Store<F> {
         ContPtr(ContTag::Outermost, RawPtr::new(ptr.to_usize()))
     }
 
-    pub fn intern_cont_call0(&mut self, a: Ptr<F>, b: ContPtr<F>) -> ContPtr<F> {
-        let (p, inserted) = self.call0_store.insert_full((a, b));
+    pub fn intern_cont_call0(&mut self, a: ContPtr<F>) -> ContPtr<F> {
+        let (p, inserted) = self.call0_store.insert_full(a);
         let ptr = ContPtr(ContTag::Call0, RawPtr::new(p));
         if inserted {
             self.dehydrated_cont.push(ptr)
@@ -1156,10 +1155,7 @@ impl<F: PrimeField> Store<F> {
             Call0 => self
                 .call0_store
                 .get_index(ptr.1.idx())
-                .map(|(b, c)| Continuation::Call0 {
-                    saved_env: *b,
-                    continuation: *c,
-                }),
+                .map(|c| Continuation::Call0 { continuation: *c }),
             Call => self
                 .call_store
                 .get_index(ptr.1.idx())
@@ -1358,10 +1354,7 @@ impl<F: PrimeField> Store<F> {
 
         let hash = match &cont {
             Outermost | Terminal | Dummy | Error => self.get_hash_components_default(),
-            Call0 {
-                saved_env,
-                continuation,
-            } => self.get_hash_components_call0(saved_env, continuation)?,
+            Call0 { continuation } => self.get_hash_components_call0(continuation)?,
             Call {
                 unevaled_arg,
                 saved_env,
@@ -1557,17 +1550,12 @@ impl<F: PrimeField> Store<F> {
         Some([saved_env, cont, def, def])
     }
 
-    fn get_hash_components_call0(
-        &self,
-        saved_env: &Ptr<F>,
-        cont: &ContPtr<F>,
-    ) -> Option<[[F; 2]; 4]> {
+    fn get_hash_components_call0(&self, cont: &ContPtr<F>) -> Option<[[F; 2]; 4]> {
         let def = [F::zero(), F::zero()];
 
-        let saved_env = self.hash_expr(saved_env)?.into_hash_components();
         let cont = self.hash_cont(cont)?.into_hash_components();
 
-        Some([saved_env, cont, def, def])
+        Some([cont, def, def, def])
     }
 
     fn get_hash_components_call(

--- a/src/store.rs
+++ b/src/store.rs
@@ -1919,21 +1919,22 @@ mod test {
         use super::ContTag::*;
 
         assert_eq!(0b0001_0000_0000_0000, Outermost as u16);
-        assert_eq!(0b0001_0000_0000_0001, Call as u16);
-        assert_eq!(0b0001_0000_0000_0010, Call2 as u16);
-        assert_eq!(0b0001_0000_0000_0011, Tail as u16);
-        assert_eq!(0b0001_0000_0000_0100, Error as u16);
-        assert_eq!(0b0001_0000_0000_0101, Lookup as u16);
-        assert_eq!(0b0001_0000_0000_0110, Unop as u16);
-        assert_eq!(0b0001_0000_0000_0111, Binop as u16);
-        assert_eq!(0b0001_0000_0000_1000, Binop2 as u16);
-        assert_eq!(0b0001_0000_0000_1001, Relop as u16);
-        assert_eq!(0b0001_0000_0000_1010, Relop2 as u16);
-        assert_eq!(0b0001_0000_0000_1011, If as u16);
-        assert_eq!(0b0001_0000_0000_1100, Let as u16);
-        assert_eq!(0b0001_0000_0000_1101, LetRec as u16);
-        assert_eq!(0b0001_0000_0000_1110, Dummy as u16);
-        assert_eq!(0b0001_0000_0000_1111, Terminal as u16);
+        assert_eq!(0b0001_0000_0000_0001, Call0 as u16);
+        assert_eq!(0b0001_0000_0000_0010, Call as u16);
+        assert_eq!(0b0001_0000_0000_0011, Call2 as u16);
+        assert_eq!(0b0001_0000_0000_0100, Tail as u16);
+        assert_eq!(0b0001_0000_0000_0101, Error as u16);
+        assert_eq!(0b0001_0000_0000_0110, Lookup as u16);
+        assert_eq!(0b0001_0000_0000_0111, Unop as u16);
+        assert_eq!(0b0001_0000_0000_1000, Binop as u16);
+        assert_eq!(0b0001_0000_0000_1001, Binop2 as u16);
+        assert_eq!(0b0001_0000_0000_1010, Relop as u16);
+        assert_eq!(0b0001_0000_0000_1011, Relop2 as u16);
+        assert_eq!(0b0001_0000_0000_1100, If as u16);
+        assert_eq!(0b0001_0000_0000_1101, Let as u16);
+        assert_eq!(0b0001_0000_0000_1110, LetRec as u16);
+        assert_eq!(0b0001_0000_0000_1111, Dummy as u16);
+        assert_eq!(0b0001_0000_0001_0000, Terminal as u16);
     }
 
     #[test]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -131,6 +131,16 @@ impl<F: PrimeField> Write<F> for Continuation<F> {
     fn fmt<W: io::Write>(&self, store: &Store<F>, w: &mut W) -> io::Result<()> {
         match self {
             Continuation::Outermost => write!(w, "Outermost"),
+            Continuation::Call0 {
+                saved_env,
+                continuation,
+            } => {
+                write!(w, "Call0{{ saved_env: ")?;
+                saved_env.fmt(store, w)?;
+                write!(w, ", continuation: ")?;
+                continuation.fmt(store, w)?;
+                write!(w, " }}")
+            }
             Continuation::Call {
                 unevaled_arg,
                 saved_env,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -48,12 +48,15 @@ impl<F: PrimeField> Write<F> for Expression<'_, F> {
             Sym(s) => write!(w, "{}", s),
             Str(s) => write!(w, "\"{}\"", s),
             Fun(arg, body, _closed_env) => {
+                let is_zero_arg = *arg == store.get_sym("_", true).expect("dummy_arg (_) missing");
                 let arg = store.fetch(arg).unwrap();
                 let body = store.fetch(body).unwrap();
                 write!(w, "<FUNCTION (")?;
-                arg.fmt(store, w)?;
-                write!(w, ") . ")?;
-                body.fmt(store, w)?;
+                if !is_zero_arg {
+                    arg.fmt(store, w)?;
+                }
+                write!(w, ") ")?;
+                body.print_tail(store, w)?;
                 write!(w, ">")
             }
             Num(n) => write!(w, "{}", n),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -134,13 +134,8 @@ impl<F: PrimeField> Write<F> for Continuation<F> {
     fn fmt<W: io::Write>(&self, store: &Store<F>, w: &mut W) -> io::Result<()> {
         match self {
             Continuation::Outermost => write!(w, "Outermost"),
-            Continuation::Call0 {
-                saved_env,
-                continuation,
-            } => {
-                write!(w, "Call0{{ saved_env: ")?;
-                saved_env.fmt(store, w)?;
-                write!(w, ", continuation: ")?;
+            Continuation::Call0 { continuation } => {
+                write!(w, "Call0{{ continuation: ")?;
                 continuation.fmt(store, w)?;
                 write!(w, " }}")
             }


### PR DESCRIPTION
This PR adds some small changes/fixes to improve and correct the behavior of zero-argument functions and how they are applied.

In particular, these situations were not well considered:
- Calling zero-argument function with more than zero arguments.
- Calling a non-zero-argument function with zero arguments.

To most simply see the differences, compare transcripts obtained from current `master` and from this PR branch. Also included are examples which show the printed function representation, which I also improved here.

`master`:
```
Lurk REPL welcomes you.
> ((lambda () 123) 9)
[4 iterations] => 123
> ((lambda (x) (cons 123 x)))
[7 iterations] => (123)
> (lambda () 123)
[1 iterations] => <FUNCTION (_) . (123)>
> (lambda (x) 123)
[1 iterations] => <FUNCTION (X) . (123)>
```

This work:
```
Lurk REPL welcomes you.
> ((lambda () 123) 9)
[3 iterations] => ERROR!
> ((lambda (x) (cons 123 x)))
[3 iterations] => <FUNCTION (X) (CONS 123 X))>
> (lambda () 123)
[1 iterations] => <FUNCTION () 123)>
> (lambda (x) 123)
[1 iterations] => <FUNCTION (X) 123)>
```

The specific changes I made are:
- It is now an error to call a zero-arg function with a value. Previously, the value was silently discarded. (The new behavior agrees with the `lurk` API.)
- Calling a non-zero-arg function with no value now returns the function unchanged. Previously the missing arg was implicitly assumed to be NIL. (This is an error in the `lurk` API.)

It could be argued that the second case should be made to agree with the `lurk` API. My reasoning here is ergonomic and meant to mesh with the current auto-currying behavior.

In general, applying a function of N args to M args leads to a function of N - M args -- except when N - M = 0, in which case a value is returned.

This comprehensible behavior is preserved if applying a function of N args to 0 args leads to a function of N args (i.e. no change), except when N is 0, in which case N-M = 0, and a value is returned.

This behavior makes sense to me and seems to allow potentially useful behavior.

In order to implement these changes, I added a `Call0` continuation.

---

I did not have time to figure out how to add support for these changes to the circuit. This is partially because the happily refactored `apply_continuation` circuit is now a bit hard to reason about. My hope is that until further refactoring improves *that* situation, @emmorais can add the circuit.

I have included some failing tests in `nova.rs` — along with notes. Notice that one of these (`…_zero_arg_lambda3`) also fails to produce a satisfied constraint system on `master`, so I think it exercises a previously untested circuit path which will need to be debugged.