### PR TITLE
Add BEGIN

### DIFF
--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -473,7 +473,7 @@ impl Evaluation {
 
         let input = evaluator.initial();
 
-        let (output, iterations) = evaluator.eval();
+        let (output, iterations, _) = evaluator.eval();
 
         Self::new(store, input, output, Some(iterations))
     }
@@ -1006,7 +1006,7 @@ pub fn evaluate<F: LurkField>(store: &mut Store<F>, expr: Ptr<F>, limit: usize) 
     let env = empty_sym_env(store);
     let mut evaluator = Evaluator::new(expr, env, store, limit);
 
-    let (io, iterations) = evaluator.eval();
+    let (io, iterations, _) = evaluator.eval();
 
     assert!(io.is_terminal());
     (io, iterations)

--- a/lurk_macro/tests/macro_test.rs
+++ b/lurk_macro/tests/macro_test.rs
@@ -69,6 +69,7 @@ mod test {
                 cont: _continuation,
             },
             iterations,
+            _emitted,
         ) = Evaluator::new(expr, empty_sym_env(&s_), &mut s_, limit).eval();
 
         assert_eq!(91, iterations);
@@ -90,6 +91,7 @@ mod test {
                 cont: _continuation,
             },
             iterations,
+            _emitted,
         ) = Evaluator::new(expr, empty_sym_env(&s_), &mut s_, limit).eval();
 
         assert_eq!(4, iterations);

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1144,7 +1144,6 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let letrec_hash = letrec.value();
     let cons_hash = hash_sym("cons");
     let begin_hash = hash_sym("begin");
-    let begin1_hash = hash_sym("begin1");
     let car_hash = hash_sym("car");
     let cdr_hash = hash_sym("cdr");
     let atom_hash = hash_sym("atom");
@@ -1415,15 +1414,6 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&[&g.op2_begin_tag, &g.default_num], env, &more, cont],
     )?;
     results.add_clauses_cons(*begin_hash.value(), &arg1, env, &continuation, &g.false_num);
-
-    // head == BEGIN1
-    let continuation = AllocatedContPtr::construct(
-        &mut cs.namespace(|| "binop begin1"),
-        store,
-        &g.binop_cont_tag,
-        &[&[&g.op2_begin1_tag, &g.default_num], env, &more, cont],
-    )?;
-    results.add_clauses_cons(*begin1_hash.value(), &arg1, env, &continuation, &g.false_num);
 
     // head == CAR
 
@@ -2304,9 +2294,6 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &g.op2_begin_tag,
         )?;
 
-        //let operator_is_begin1 =
-        //    operator.alloc_equal(&mut cs.namespace(|| "operator_is_begin1"), &g.op2_begin1_tag)?;
-
         let rest_is_nil =
             allocated_rest.alloc_equal(&mut cs.namespace(|| "rest_is_nil"), &g.nil_ptr)?;
 
@@ -2330,9 +2317,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &begin_again,
         )?;
 
-        let otherwise = Boolean::not(
-            &op_is_begin,
-        );
+        let otherwise = Boolean::not(&op_is_begin);
 
         let otherwise_if_rest_is_nil = Boolean::and(
             &mut cs.namespace(|| "otherwise_if_rest_is_nil"),
@@ -3103,9 +3088,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(32629, cs.num_constraints());
+            assert_eq!(32114, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(32590, cs.aux().len());
+            assert_eq!(32075, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2322,7 +2322,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &mut cs.namespace(|| "the_exp_if_begin"),
             &op_is_begin,
             &begin_again,
-            &result,
+            result,
         )?;
 
         let otherwise = Boolean::not(&op_is_begin);

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2513,7 +2513,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                 },
                 CaseClause {
                     key: Op2::Begin1.as_field(),
-                    value: &arg1.hash(),
+                    value: arg1.hash(),
                 },
             ],
             &g.default_num,

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -50,7 +50,6 @@ pub struct GlobalAllocations<F: LurkField> {
     pub op1_emit_tag: AllocatedNum<F>,
     pub op2_cons_tag: AllocatedNum<F>,
     pub op2_begin_tag: AllocatedNum<F>,
-    pub op2_begin1_tag: AllocatedNum<F>,
     pub op2_sum_tag: AllocatedNum<F>,
     pub op2_diff_tag: AllocatedNum<F>,
     pub op2_product_tag: AllocatedNum<F>,
@@ -150,8 +149,6 @@ impl<F: LurkField> GlobalAllocations<F> {
         let op1_emit_tag = Op1::Emit.allocate_constant(&mut cs.namespace(|| "op1_emit_tag"))?;
         let op2_cons_tag = Op2::Cons.allocate_constant(&mut cs.namespace(|| "op2_cons_tag"))?;
         let op2_begin_tag = Op2::Begin.allocate_constant(&mut cs.namespace(|| "op2_begin_tag"))?;
-        let op2_begin1_tag =
-            Op2::Begin1.allocate_constant(&mut cs.namespace(|| "op2_begin1_tag"))?;
         let op2_sum_tag = Op2::Sum.allocate_constant(&mut cs.namespace(|| "op2_sum_tag"))?;
         let op2_diff_tag = Op2::Diff.allocate_constant(&mut cs.namespace(|| "op2_diff_tag"))?;
 
@@ -207,7 +204,6 @@ impl<F: LurkField> GlobalAllocations<F> {
             op1_emit_tag,
             op2_cons_tag,
             op2_begin_tag,
-            op2_begin1_tag,
             op2_sum_tag,
             op2_diff_tag,
             op2_product_tag,

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -49,6 +49,8 @@ pub struct GlobalAllocations<F: LurkField> {
     pub op1_atom_tag: AllocatedNum<F>,
     pub op1_emit_tag: AllocatedNum<F>,
     pub op2_cons_tag: AllocatedNum<F>,
+    pub op2_begin_tag: AllocatedNum<F>,
+    pub op2_begin1_tag: AllocatedNum<F>,
     pub op2_sum_tag: AllocatedNum<F>,
     pub op2_diff_tag: AllocatedNum<F>,
     pub op2_product_tag: AllocatedNum<F>,
@@ -147,6 +149,9 @@ impl<F: LurkField> GlobalAllocations<F> {
         let op1_atom_tag = Op1::Atom.allocate_constant(&mut cs.namespace(|| "op1_atom_tag"))?;
         let op1_emit_tag = Op1::Emit.allocate_constant(&mut cs.namespace(|| "op1_emit_tag"))?;
         let op2_cons_tag = Op2::Cons.allocate_constant(&mut cs.namespace(|| "op2_cons_tag"))?;
+        let op2_begin_tag = Op2::Begin.allocate_constant(&mut cs.namespace(|| "op2_begin_tag"))?;
+        let op2_begin1_tag =
+            Op2::Begin1.allocate_constant(&mut cs.namespace(|| "op2_begin1_tag"))?;
         let op2_sum_tag = Op2::Sum.allocate_constant(&mut cs.namespace(|| "op2_sum_tag"))?;
         let op2_diff_tag = Op2::Diff.allocate_constant(&mut cs.namespace(|| "op2_diff_tag"))?;
 
@@ -201,6 +206,8 @@ impl<F: LurkField> GlobalAllocations<F> {
             op1_atom_tag,
             op1_emit_tag,
             op2_cons_tag,
+            op2_begin_tag,
+            op2_begin1_tag,
             op2_sum_tag,
             op2_diff_tag,
             op2_product_tag,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -243,7 +243,14 @@ impl<'a, 'b, F: LurkField> FrameIt<'a, Witness<F>, F> {
 
     /// Like `.iter().take(n).last()`, but skips intermediary stages, to optimize
     /// for evaluation.
-    fn next_n(mut self, n: usize) -> Option<(Frame<IO<F>, Witness<F>>, Frame<IO<F>, Witness<F>>, Vec<Ptr<F>>)> {
+    fn next_n(
+        mut self,
+        n: usize,
+    ) -> Option<(
+        Frame<IO<F>, Witness<F>>,
+        Frame<IO<F>, Witness<F>>,
+        Vec<Ptr<F>>,
+    )> {
         let mut previous_frame = self.frame.clone();
         let mut emitted: Vec<Ptr<F>> = Vec::new();
         for _ in 0..n {
@@ -1170,7 +1177,9 @@ where
         let frame_iterator = FrameIt::new(initial_input, self.store);
 
         // Initial input performs one reduction, so we need limit - 1 more.
-        if let Some((ultimate_frame, _penultimate_frame, emitted)) = frame_iterator.next_n(self.limit - 1) {
+        if let Some((ultimate_frame, _penultimate_frame, emitted)) =
+            frame_iterator.next_n(self.limit - 1)
+        {
             let output = ultimate_frame.output;
 
             let was_terminal = ultimate_frame.is_complete();
@@ -1467,7 +1476,8 @@ mod test {
         let val = s.num(123);
         let expr = s.read("(emit 123)").unwrap();
 
-        let (output, iterations, emitted) = Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
+        let (output, iterations, emitted) =
+            Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
 
         assert_eq!(2, iterations);
         assert_eq!(Some(val), output.maybe_emitted_expression(&s));

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -608,17 +608,6 @@ fn reduce_with_witness<F: LurkField>(
                             store.intern_cont_binop(Op2::Begin, env, more, cont),
                         )
                     }
-                } else if head == store.sym("begin1") {
-                    let (arg1, more) = store.car_cdr(&rest);
-                    if more.is_nil() {
-                        Control::Return(arg1, env, cont)
-                    } else {
-                        Control::Return(
-                            arg1,
-                            env,
-                            store.intern_cont_binop(Op2::Begin1, env, more, cont),
-                        )
-                    }
                 } else if head == store.sym("car") {
                     let (arg1, end) = store.car_cdr(&rest);
                     if !end.is_nil() {
@@ -2761,52 +2750,6 @@ mod test {
             let expected = s.list(&[binding]);
             assert_eq!(expected, result_expr);
             assert_eq!(5, iterations);
-        }
-    }
-    #[test]
-    fn begin1_current_env() {
-        {
-            let mut s = Store::<Fr>::default();
-            let limit = 1000;
-            let expr = s.read("(begin1 (current-env))").unwrap();
-            let (
-                IO {
-                    expr: result_expr,
-                    env: _new_env,
-                    cont: _continuation,
-                },
-                iterations,
-            ) = Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
-            let expected = s.nil();
-            assert_eq!(expected, result_expr);
-            assert_eq!(2, iterations);
-        }
-    }
-    #[test]
-    fn begin1_current_env1() {
-        {
-            let mut s = Store::<Fr>::default();
-            let limit = 1000;
-            let expr = s
-                .read(
-                    "(let ((a 1))
-                       (begin1 (current-env)))",
-                )
-                .unwrap();
-            let (
-                IO {
-                    expr: result_expr,
-                    env: _new_env,
-                    cont: _continuation,
-                },
-                iterations,
-            ) = Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
-            let a = s.sym("a");
-            let one = s.num(1);
-            let binding = s.cons(a, one);
-            let expected = s.list(&[binding]);
-            assert_eq!(expected, result_expr);
-            assert_eq!(4, iterations);
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -902,22 +902,6 @@ fn apply_continuation<F: LurkField>(
                         let begin_again = store.cons(begin, unevaled_args);
                         Control::Return(begin_again, saved_env, continuation)
                     }
-                } else if operator == Op2::Begin1 {
-                    if rest.is_nil() {
-                        let begin = store.sym("begin");
-                        let quote = store.sym("quote");
-                        let quoted = store.list(&[quote, *result]);
-                        let arg2_then_evaled_arg1 = store.list(&[begin, arg2, quoted]);
-                        Control::Return(arg2_then_evaled_arg1, saved_env, continuation)
-                    } else {
-                        let begin = store.sym("begin");
-                        let begin_rest = store.cons(begin, unevaled_args);
-                        Control::Return(
-                            begin_rest,
-                            saved_env,
-                            store.intern_cont_binop2(operator, *result, continuation),
-                        )
-                    }
                 } else if !rest.is_nil() {
                     Control::Return(*result, *env, store.intern_cont_error())
                 } else {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -604,6 +604,13 @@ fn reduce_with_witness<F: LurkField>(
                         env,
                         store.intern_cont_binop(Op2::Begin, env, more, cont),
                     )
+                } else if head == store.sym("begin1") {
+                    let (arg1, more) = store.car_cdr(&rest);
+                    Control::Return(
+                        arg1,
+                        env,
+                        store.intern_cont_binop(Op2::Begin1, env, more, cont),
+                    )
                 } else if head == store.sym("car") {
                     let (arg1, end) = store.car_cdr(&rest);
                     if !end.is_nil() {
@@ -887,6 +894,20 @@ fn apply_continuation<F: LurkField>(
                         let begin_again = store.cons(begin, unevaled_args);
                         Control::Return(begin_again, saved_env, continuation)
                     }
+                } else if operator == Op2::Begin1 {
+                    if rest.is_nil() {
+                        let begin = store.sym("begin");
+                        let arg2_then_evaled_arg1 = store.list(&[begin, arg2, *result]);
+                        Control::Return(arg2_then_evaled_arg1, saved_env, continuation)
+                    } else {
+                        let begin = store.sym("begin");
+                        let begin_rest = store.cons(begin, unevaled_args);
+                        Control::Return(
+                            begin_rest,
+                            saved_env,
+                            store.intern_cont_binop2(operator, *result, continuation),
+                        )
+                    }
                 } else if !rest.is_nil() {
                     Control::Return(*result, *env, store.intern_cont_error())
                 } else {
@@ -936,6 +957,7 @@ fn apply_continuation<F: LurkField>(
                             store.intern_num(tmp)
                         }
                         Op2::Cons => store.cons(evaled_arg, *arg2),
+                        Op2::Begin1 => evaled_arg,
                         Op2::Begin => unreachable!(),
                     },
                     _ => match operator {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -952,7 +952,6 @@ fn apply_continuation<F: LurkField>(
                             store.intern_num(tmp)
                         }
                         Op2::Cons => store.cons(evaled_arg, *arg2),
-                        Op2::Begin1 => evaled_arg,
                         Op2::Begin => unreachable!(),
                     },
                     _ => match operator {

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -690,7 +690,8 @@ mod tests {
         let fun_from_comm = s.list(&[cdr, quoted_commitment]);
         let input = s.list(&[fun_from_comm, five]);
 
-        let (output, _iterations, _emitted) = Evaluator::new(input, empty_sym_env(&s), &mut s, limit).eval();
+        let (output, _iterations, _emitted) =
+            Evaluator::new(input, empty_sym_env(&s), &mut s, limit).eval();
 
         let result_expr = output.expr;
 

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -676,7 +676,7 @@ mod tests {
             .unwrap();
         let limit = 300;
 
-        let (evaled, _) = Evaluator::new(fun_src, empty_sym_env(&s), &mut s, limit).eval();
+        let (evaled, _, _) = Evaluator::new(fun_src, empty_sym_env(&s), &mut s, limit).eval();
 
         let fun = evaled.expr;
 
@@ -690,7 +690,7 @@ mod tests {
         let fun_from_comm = s.list(&[cdr, quoted_commitment]);
         let input = s.list(&[fun_from_comm, five]);
 
-        let (output, _iterations) = Evaluator::new(input, empty_sym_env(&s), &mut s, limit).eval();
+        let (output, _iterations, _emitted) = Evaluator::new(input, empty_sym_env(&s), &mut s, limit).eval();
 
         let result_expr = output.expr;
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -262,6 +262,7 @@ mod tests {
         check_constraint_systems: bool,
         limit: usize,
         debug: bool,
+        emitted: Option<Vec<(usize, Ptr<Fr>)>>,
     ) {
         let mut s = Store::default();
         let expected_result = expected_result(&mut s);
@@ -297,6 +298,22 @@ mod tests {
 
             let adjusted_iterations = nova_prover.expected_total_iterations(expected_iterations);
             let output = cs[cs.len() - 1].0.output.unwrap();
+
+            if emitted.is_some() {
+                for i in 0..frames.len() {
+                    let frame_output = frames[i].output;
+                    dbg!("output: {:?}", frame_output.fmt_to_string(&s));
+                }
+                for elem in emitted.unwrap() {
+                    let frame_emitted = frames[elem.0].output;
+                    if let Some(expr) = frame_emitted.maybe_emitted_expression(&s) {
+                        let a = s.fetch(&expr);
+                        let b = s.fetch(&elem.1);
+                        assert_eq!(a, b);
+                        //assert_eq!(expr, elem.1);
+                    }
+                }
+            }
 
             if !debug {
                 dbg!(
@@ -362,6 +379,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
     }
 
@@ -378,6 +396,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
     }
 
@@ -394,6 +413,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
     }
 
@@ -410,7 +430,9 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
+
         outer_prove_aux(
             "(= 5 6)",
             |store| store.nil(),
@@ -421,6 +443,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
     }
 
@@ -436,7 +459,9 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
+
         outer_prove_aux(
             "(= nil 5)",
             |store| store.num(5),
@@ -447,6 +472,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
     }
 
@@ -462,6 +488,7 @@ mod tests {
             true,
             10,
             false,
+            None,
         );
     }
 
@@ -477,6 +504,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
 
         outer_prove_aux(
@@ -489,6 +517,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         )
     }
 
@@ -504,6 +533,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         )
     }
 
@@ -520,6 +550,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
     }
 
@@ -541,6 +572,7 @@ mod tests {
             true,
             200,
             false,
+            None,
         );
     }
 
@@ -563,6 +595,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -577,7 +610,9 @@ mod tests {
             true,
             10,
             false,
+            None,
         );
+
         outer_prove_aux(
             "(car '(1 . 2))",
             |store| store.num(1),
@@ -588,6 +623,7 @@ mod tests {
             true,
             10,
             false,
+            None,
         );
 
         outer_prove_aux(
@@ -600,6 +636,7 @@ mod tests {
             true,
             10,
             false,
+            None,
         );
 
         outer_prove_aux(
@@ -612,6 +649,7 @@ mod tests {
             true,
             10,
             false,
+            None,
         )
     }
 
@@ -638,6 +676,7 @@ mod tests {
             true,
             10,
             false,
+            None,
         );
     }
 
@@ -654,6 +693,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -672,6 +712,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -693,6 +734,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -715,6 +757,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -734,6 +777,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -750,6 +794,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -765,6 +810,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -780,6 +826,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -795,6 +842,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -811,6 +859,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -827,6 +876,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -842,6 +892,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -857,6 +908,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -877,6 +929,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -892,6 +945,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -907,6 +961,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -924,6 +979,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -939,6 +995,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -954,6 +1011,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -969,6 +1027,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -984,6 +1043,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -999,6 +1059,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1014,6 +1075,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1029,6 +1091,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1044,6 +1107,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1059,6 +1123,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1075,6 +1140,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
     #[test]
@@ -1090,6 +1156,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1109,6 +1176,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1132,6 +1200,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1151,6 +1220,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1171,6 +1241,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1198,6 +1269,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1225,6 +1297,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1249,6 +1322,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1265,6 +1339,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1281,6 +1356,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1302,6 +1378,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1322,6 +1399,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1345,6 +1423,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1367,6 +1446,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1391,6 +1471,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1415,6 +1496,7 @@ mod tests {
             true,
             50,
             false,
+            None,
         );
     }
 
@@ -1439,6 +1521,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1455,6 +1538,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1470,6 +1554,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1485,6 +1570,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1500,6 +1586,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1515,6 +1602,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1531,6 +1619,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1547,6 +1636,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1563,6 +1653,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
     #[test]
@@ -1583,6 +1674,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1598,6 +1690,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1613,6 +1706,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1634,6 +1728,7 @@ mod tests {
             true,
             100,
             false,
+            None,
         );
     }
 
@@ -1654,6 +1749,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1674,6 +1770,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1690,6 +1787,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1712,6 +1810,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1734,6 +1833,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1752,6 +1852,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1770,6 +1871,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1799,6 +1901,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1819,6 +1922,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1843,6 +1947,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1875,6 +1980,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1912,6 +2018,7 @@ mod tests {
             true,
             300,
             false,
+            None,
         );
     }
 
@@ -1924,15 +2031,8 @@ mod tests {
         let expr = s.read(src).unwrap();
         let limit = 300;
 
-        let (
-            IO {
-                expr: _result_expr,
-                env: _new_env,
-                cont: _continuation,
-            },
-            _iterations,
-            emitted,
-        ) = Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
+        let (_io, _iterations, emitted) =
+            Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
 
         outer_prove_aux(
             &src,
@@ -1944,9 +2044,25 @@ mod tests {
             true,
             300,
             false,
+            Some(vec![(11, s.num(1)), (2, s.num(2)), (7, s.num(3))]),
         );
-        assert_eq!(s.num(1), emitted[0]);
-        assert_eq!(s.num(2), emitted[1]);
-        assert_eq!(s.num(3), emitted[2]);
+        let expected = vec![s.num(1), s.num(2), s.num(3)];
+        assert_eq!(emitted, expected);
+    }
+
+    #[test]
+    fn outer_prove_begin_empty() {
+        outer_prove_aux(
+            "(begin)",
+            |store| store.nil(),
+            Status::Terminal,
+            2,
+            DEFAULT_CHUNK_FRAME_COUNT,
+            DEFAULT_CHECK_NOVA,
+            true,
+            300,
+            false,
+            None,
+        );
     }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -325,7 +325,6 @@ mod tests {
     fn check_emitted_frames<Fo: Fn(&'_ mut Store<Fr>) -> Vec<Ptr<Fr>>>(
         source: &str,
         chunk_frame_count: usize,
-        check_nova: bool,
         limit: usize,
         emitted: Fo,
     ) {
@@ -336,22 +335,16 @@ mod tests {
         let e = empty_sym_env(&s);
 
         let nova_prover = NovaProver::<Fr>::new(chunk_frame_count);
-        let proof_results = if check_nova {
-            Some(
-                nova_prover
-                    .evaluate_and_prove(expr, empty_sym_env(&s), &mut s, limit)
-                    .unwrap(),
-            )
-        } else {
-            None
-        };
+        let proof_results = Some(
+            nova_prover
+                .evaluate_and_prove(expr, empty_sym_env(&s), &mut s, limit)
+                .unwrap(),
+        );
 
         let shape_and_gens = nova_prover.make_shape_and_gens();
 
-        if check_nova {
-            if let Some((proof, instance)) = proof_results {
-                proof.verify(&shape_and_gens, &instance);
-            }
+        if let Some((proof, instance)) = proof_results {
+            proof.verify(&shape_and_gens, &instance);
         }
 
         let frames = nova_prover.get_evaluation_frames(expr, e, &mut s, limit);
@@ -1994,7 +1987,6 @@ mod tests {
         check_emitted_frames(
             &src,
             DEFAULT_CHUNK_FRAME_COUNT,
-            DEFAULT_CHECK_NOVA,
             300,
             |store| vec![store.num(1), store.num(2), store.num(3)],
         );

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1984,12 +1984,9 @@ mod tests {
             false,
         );
 
-        check_emitted_frames(
-            &src,
-            DEFAULT_CHUNK_FRAME_COUNT,
-            300,
-            |store| vec![store.num(1), store.num(2), store.num(3)],
-        );
+        check_emitted_frames(&src, DEFAULT_CHUNK_FRAME_COUNT, 300, |store| {
+            vec![store.num(1), store.num(2), store.num(3)]
+        });
     }
 
     #[test]

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -335,30 +335,15 @@ mod tests {
         let e = empty_sym_env(&s);
 
         let nova_prover = NovaProver::<Fr>::new(chunk_frame_count);
-        let proof_results = Some(
-            nova_prover
-                .evaluate_and_prove(expr, empty_sym_env(&s), &mut s, limit)
-                .unwrap(),
-        );
-
-        let shape_and_gens = nova_prover.make_shape_and_gens();
-
-        if let Some((proof, instance)) = proof_results {
-            proof.verify(&shape_and_gens, &instance);
-        }
 
         let frames = nova_prover.get_evaluation_frames(expr, e, &mut s, limit);
 
         let emitted_result = emitted(&mut s);
 
-        let mut emitted_vec = Vec::new();
-
-        for i in 0..frames.len() {
-            let frame_output = frames[i].output;
-            if let Some(expr) = frame_output.maybe_emitted_expression(&s) {
-                emitted_vec.push(expr)
-            }
-        }
+        let emitted_vec: Vec<_> = frames
+            .iter()
+            .flat_map(|frame| frame.output.maybe_emitted_expression(&s))
+            .collect();
         assert_eq!(emitted_vec, emitted_result);
     }
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1862,6 +1862,7 @@ mod tests {
                 cont: _continuation,
             },
             _iterations,
+            _emitted,
         ) = Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
 
         outer_prove_aux(
@@ -1898,6 +1899,7 @@ mod tests {
                 cont: _continuation,
             },
             _iterations,
+            _emitted,
         ) = Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
 
         outer_prove_aux(
@@ -1915,8 +1917,25 @@ mod tests {
 
     #[test]
     fn outer_prove_begin() {
+        let mut s = Store::<Fr>::default();
+
+        let src = "(begin (emit 1) (emit 2) (emit 3))";
+
+        let expr = s.read(src).unwrap();
+        let limit = 300;
+
+        let (
+            IO {
+                expr: result_expr,
+                env: _new_env,
+                cont: _continuation,
+            },
+            _iterations,
+            emitted,
+        ) = Evaluator::new(expr, empty_sym_env(&s), &mut s, limit).eval();
+
         outer_prove_aux(
-            "(begin (emit 1) (emit 2) (emit 3))",
+            &src,
             |store| store.num(3),
             Status::Terminal,
             13,
@@ -1926,5 +1945,8 @@ mod tests {
             300,
             false,
         );
+        assert_eq!(s.num(1), emitted[0]);
+        assert_eq!(s.num(2), emitted[1]);
+        assert_eq!(s.num(3), emitted[2]);
     }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1912,4 +1912,34 @@ mod tests {
             false,
         );
     }
+
+    #[test]
+    fn outer_prove_begin() {
+        outer_prove_aux(
+            "(begin (emit 1) (emit 2) (emit 3))",
+            |store| store.num(3),
+            Status::Terminal,
+            13,
+            DEFAULT_CHUNK_FRAME_COUNT,
+            DEFAULT_CHECK_NOVA,
+            true,
+            300,
+            false,
+        );
+    }
+
+    #[test]
+    fn outer_prove_begin1() {
+        outer_prove_aux(
+            "(begin1 (emit 1) (emit 2) (emit 3))",
+            |store| store.num(1),
+            Status::Terminal,
+            14,
+            DEFAULT_CHUNK_FRAME_COUNT,
+            DEFAULT_CHECK_NOVA,
+            true,
+            300,
+            false,
+        );
+    }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1926,7 +1926,7 @@ mod tests {
 
         let (
             IO {
-                expr: result_expr,
+                expr: _result_expr,
                 env: _new_env,
                 cont: _continuation,
             },

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1927,19 +1927,4 @@ mod tests {
             false,
         );
     }
-
-    #[test]
-    fn outer_prove_begin1() {
-        outer_prove_aux(
-            "(begin1 (emit 1) (emit 2) (emit 3))",
-            |store| store.num(1),
-            Status::Terminal,
-            14,
-            DEFAULT_CHUNK_FRAME_COUNT,
-            DEFAULT_CHECK_NOVA,
-            true,
-            300,
-            false,
-        );
-    }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -315,10 +315,6 @@ impl ReplState {
                                 let (second, rest) = store.car_cdr(&rest);
 
                                 assert!(rest.is_nil());
-                                //let (_, _, _, emitted) = self.clone().eval_expr(first, store);
-                                //let (second_evaled, _, _, _) = self.eval_expr(second, store);
-                                //let (mut first_emitted, mut rest_emitted) =
-                                //    store.car_cdr(&second_evaled);
                                 let (first_evaled, _, _, _) = self.clone().eval_expr(first, store);
                                 let (_, _, _, emitted) = self.eval_expr(second, store);
                                 let (mut first_emitted, mut rest_emitted) =

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -319,8 +319,15 @@ impl ReplState {
                                 let (second_evaled, _, _, _) = self.eval_expr(second, store);
                                 let (mut first_emitted, mut rest_emitted) =
                                     store.car_cdr(&second_evaled);
-                                for elem in emitted {
-                                    assert_eq!(elem, first_emitted);
+                                for i in 0..emitted.len() {
+                                    if emitted[i] != first_emitted {
+                                        panic!(
+                                            ":ASSERT-EMITTED failed at position {}. Expected {}, but found {}.",
+                                            i,
+                                            first_emitted.fmt_to_string(store),
+                                            emitted[i].fmt_to_string(store),
+                                        );
+                                    }
                                     (first_emitted, rest_emitted) = store.car_cdr(&rest_emitted);
                                 }
                             } else {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -319,8 +319,8 @@ impl ReplState {
                                 let (second_evaled, _, _, _) = self.eval_expr(second, store);
                                 let (mut first_emitted, mut rest_emitted) =
                                     store.car_cdr(&second_evaled);
-                                for i in 0..emitted.len() {
-                                    assert_eq!(emitted[i], first_emitted);
+                                for elem in emitted {
+                                    assert_eq!(elem, first_emitted);
                                     (first_emitted, rest_emitted) = store.car_cdr(&rest_emitted);
                                 }
                             } else {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -113,6 +113,7 @@ pub fn repl<P: AsRef<Path>>(lurk_file: Option<P>) -> Result<()> {
                             cont: next_cont,
                         },
                         iterations,
+                        emitted,
                     ) = Evaluator::new(expr, repl.state.env, &mut s, limit).eval();
 
                     print!("[{} iterations] => ", iterations);
@@ -163,6 +164,7 @@ impl ReplState {
                 cont: next_cont,
             },
             limit,
+            emitted,
         ) = Evaluator::new(expr, self.env, store, self.limit).eval();
 
         (result, limit, next_cont)

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -319,13 +319,13 @@ impl ReplState {
                                 let (_, _, _, emitted) = self.eval_expr(second, store);
                                 let (mut first_emitted, mut rest_emitted) =
                                     store.car_cdr(&first_evaled);
-                                for i in 0..emitted.len() {
-                                    if emitted[i] != first_emitted {
+                                for (i, elem) in emitted.iter().enumerate() {
+                                    if elem != &first_emitted {
                                         panic!(
                                             ":ASSERT-EMITTED failed at position {}. Expected {}, but found {}.",
                                             i,
                                             first_emitted.fmt_to_string(store),
-                                            emitted[i].fmt_to_string(store),
+                                            elem.fmt_to_string(store),
                                         );
                                     }
                                     (first_emitted, rest_emitted) = store.car_cdr(&rest_emitted);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -315,10 +315,14 @@ impl ReplState {
                                 let (second, rest) = store.car_cdr(&rest);
 
                                 assert!(rest.is_nil());
-                                let (_, _, _, emitted) = self.clone().eval_expr(first, store);
-                                let (second_evaled, _, _, _) = self.eval_expr(second, store);
+                                //let (_, _, _, emitted) = self.clone().eval_expr(first, store);
+                                //let (second_evaled, _, _, _) = self.eval_expr(second, store);
+                                //let (mut first_emitted, mut rest_emitted) =
+                                //    store.car_cdr(&second_evaled);
+                                let (first_evaled, _, _, _) = self.clone().eval_expr(first, store);
+                                let (_, _, _, emitted) = self.eval_expr(second, store);
                                 let (mut first_emitted, mut rest_emitted) =
-                                    store.car_cdr(&second_evaled);
+                                    store.car_cdr(&first_evaled);
                                 for i in 0..emitted.len() {
                                     if emitted[i] != first_emitted {
                                         panic!(

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -113,7 +113,7 @@ pub fn repl<P: AsRef<Path>>(lurk_file: Option<P>) -> Result<()> {
                             cont: next_cont,
                         },
                         iterations,
-                        emitted,
+                        _emitted,
                     ) = Evaluator::new(expr, repl.state.env, &mut s, limit).eval();
 
                     print!("[{} iterations] => ", iterations);
@@ -164,7 +164,7 @@ impl ReplState {
                 cont: next_cont,
             },
             limit,
-            emitted,
+            _emitted,
         ) = Evaluator::new(expr, self.env, store, self.limit).eval();
 
         (result, limit, next_cont)

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -583,6 +583,7 @@ mod test {
                     cont: _,
                 },
                 _lim,
+                _emitted,
             ) = eval.eval();
 
             let (scalar_store, _) = ScalarStore::new_with_expr(&s, &expr);

--- a/src/store.rs
+++ b/src/store.rs
@@ -591,6 +591,7 @@ pub enum Op2 {
     Product,
     Quotient,
     Cons,
+    Begin,
 }
 
 impl Op2 {
@@ -617,6 +618,7 @@ impl fmt::Display for Op2 {
             Op2::Product => write!(f, "Product"),
             Op2::Quotient => write!(f, "Quotient"),
             Op2::Cons => write!(f, "Cons"),
+            Op2::Begin => write!(f, "Begin"),
         }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -592,6 +592,7 @@ pub enum Op2 {
     Quotient,
     Cons,
     Begin,
+    Begin1,
 }
 
 impl Op2 {
@@ -619,6 +620,7 @@ impl fmt::Display for Op2 {
             Op2::Quotient => write!(f, "Quotient"),
             Op2::Cons => write!(f, "Cons"),
             Op2::Begin => write!(f, "Begin"),
+            Op2::Begin1 => write!(f, "Begin1"),
         }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -592,7 +592,6 @@ pub enum Op2 {
     Quotient,
     Cons,
     Begin,
-    Begin1,
 }
 
 impl Op2 {
@@ -620,7 +619,6 @@ impl fmt::Display for Op2 {
             Op2::Quotient => write!(f, "Quotient"),
             Op2::Cons => write!(f, "Cons"),
             Op2::Begin => write!(f, "Begin"),
-            Op2::Begin1 => write!(f, "Begin1"),
         }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -789,7 +789,6 @@ impl<F: LurkField> Default for Store<F> {
             "let",
             "letrec",
             "begin",
-            "begin1",
             "cons",
             "car",
             "cdr",

--- a/src/store.rs
+++ b/src/store.rs
@@ -2601,18 +2601,21 @@ pub mod test {
         {
             let comparison_expr = store.list(&[eq, fun, opaque_fun]);
             println!("comparison_expr: {}", comparison_expr.fmt_to_string(&store));
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, fun2, opaque_fun]);
             println!("comparison_expr: {}", comparison_expr.fmt_to_string(&store));
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(nil, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, fun2, opaque_fun2]);
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
@@ -2625,7 +2628,8 @@ pub mod test {
             let cons_expr2 = store.list(&[cons, opaque_fun, n]);
 
             let comparison_expr = store.list(&[eq, cons_expr1, cons_expr2]);
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
     }
@@ -2693,17 +2697,20 @@ pub mod test {
 
         {
             let comparison_expr = store.list(&[eq, qsym, qsym_opaque]);
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, qsym2, qsym_opaque]);
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(nil, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, qsym2, qsym_opaque2]);
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
@@ -2716,7 +2723,8 @@ pub mod test {
             let cons_expr2 = store.list(&[cons, qsym_opaque, n]);
 
             let comparison_expr = store.list(&[eq, cons_expr1, cons_expr2]);
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
     }
@@ -2750,17 +2758,20 @@ pub mod test {
         {
             let comparison_expr = store.list(&[eq, qcons, qcons_opaque]);
             // FIXME: need to implement Write for opaque data.
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, qcons2, qcons_opaque]);
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(nil, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, qcons2, qcons_opaque2]);
-            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) =
+                Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {

--- a/src/store.rs
+++ b/src/store.rs
@@ -788,6 +788,8 @@ impl<F: LurkField> Default for Store<F> {
             "_",
             "let",
             "letrec",
+            "begin",
+            "begin1",
             "cons",
             "car",
             "cdr",
@@ -870,6 +872,14 @@ impl<F: LurkField> Store<F> {
 
     pub fn get_nil(&self) -> Ptr<F> {
         self.get_sym("nil", true).expect("missing NIL")
+    }
+
+    pub fn get_begin(&self) -> Ptr<F> {
+        self.get_sym("begin", true).expect("missing BEGIN")
+    }
+
+    pub fn get_quote(&self) -> Ptr<F> {
+        self.get_sym("quote", true).expect("missing QUOTE")
     }
 
     pub fn get_t(&self) -> Ptr<F> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -2601,18 +2601,18 @@ pub mod test {
         {
             let comparison_expr = store.list(&[eq, fun, opaque_fun]);
             println!("comparison_expr: {}", comparison_expr.fmt_to_string(&store));
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, fun2, opaque_fun]);
             println!("comparison_expr: {}", comparison_expr.fmt_to_string(&store));
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(nil, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, fun2, opaque_fun2]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
@@ -2625,7 +2625,7 @@ pub mod test {
             let cons_expr2 = store.list(&[cons, opaque_fun, n]);
 
             let comparison_expr = store.list(&[eq, cons_expr1, cons_expr2]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
     }
@@ -2693,17 +2693,17 @@ pub mod test {
 
         {
             let comparison_expr = store.list(&[eq, qsym, qsym_opaque]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, qsym2, qsym_opaque]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(nil, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, qsym2, qsym_opaque2]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
@@ -2716,7 +2716,7 @@ pub mod test {
             let cons_expr2 = store.list(&[cons, qsym_opaque, n]);
 
             let comparison_expr = store.list(&[eq, cons_expr1, cons_expr2]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
     }
@@ -2750,17 +2750,17 @@ pub mod test {
         {
             let comparison_expr = store.list(&[eq, qcons, qcons_opaque]);
             // FIXME: need to implement Write for opaque data.
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, qcons2, qcons_opaque]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(nil, result.expr);
         }
         {
             let comparison_expr = store.list(&[eq, qcons2, qcons_opaque2]);
-            let (result, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
+            let (result, _, _) = Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
             assert_eq!(t, result.expr);
         }
         {
@@ -2777,12 +2777,12 @@ pub mod test {
             let comparison_expr = store.list(&[eq, cons_expr1, cons_expr2]);
             let comparison_expr2 = store.list(&[eq, cons_expr1, cons_expr3]);
             {
-                let (result, _) =
+                let (result, _, _) =
                     Evaluator::new(comparison_expr, empty_env, &mut store, limit).eval();
                 assert_eq!(t, result.expr);
             }
             {
-                let (result, _) =
+                let (result, _, _) =
                     Evaluator::new(comparison_expr2, empty_env, &mut store, limit).eval();
                 assert_eq!(nil, result.expr);
             }


### PR DESCRIPTION
Closes #90.

I implemented BEGIN as a binary operator with special handling for the variadic case. This seems clean and minimal.

This contains no tests and no circuit implementation. As discussed with @emmorais, he will add those.

Based on discussion below, I decided to go ahead and add BEGIN1 also, since it's relatively easy and fresh. Even if we can solve in other ways, those will probably be more expensive, and I think this *is* a fundamental sequencing operator.

Hopefully the examples below clarify the semantics of BEGIN and BEGIN1.
```
> (begin (emit 1) (emit 2) (emit 3))
1
2
3
[13 iterations] => 3
> (begin1 (emit 1) (emit 2) (emit 3))
1
2
3
[14 iterations] => 1
```