### PR TITLE
Car cdr invalid tag error

### DIFF
--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -28,15 +28,16 @@ use fcomm::{
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Cli {
     /// Evaluate inputs before passing to function (outside the proof) when opening. Otherwise inputs are unevaluated.
-    #[clap(long)]
+    #[clap(long, value_parser)]
     eval_input: bool,
 
     /// Iteration limit
-    #[clap(short, long, default_value = "1000")]
+    #[allow(deprecated)]
+    #[clap(short, long, default_value = "1000", value_parser)]
     limit: usize,
 
     /// Exit with error on failed verification
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     error: bool,
 
     /// Be verbose
@@ -68,91 +69,91 @@ enum Command {
 #[derive(Args, Debug)]
 struct Commit {
     /// Path to function
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     function: PathBuf,
 
     /// Path to functional commitment
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     commitment: Option<PathBuf>,
 
     // Function is lurk source.
-    #[clap(long)]
+    #[clap(long, value_parser)]
     lurk: bool,
 }
 
 #[derive(Args, Debug)]
 struct Open {
     /// Path to function input
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     input: Option<PathBuf>,
 
     /// Path to proof output if prove requested
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     proof: Option<PathBuf>,
 
     /// Optional commitment value (hex string). Function will be looked-up by commitment if supplied.
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     commitment: Option<String>,
 
     /// Optional path to function used if commitment is not supplied.
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     function: Option<PathBuf>,
 
     /// Optional path to OpeningRequest -- which subsumes commitment, function, and input if supplied.
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     request: Option<PathBuf>,
 
     // Function is lurk source.
-    #[clap(long)]
+    #[clap(long, value_parser)]
     lurk: bool,
 
     /// Chain commitment openings. Opening includes commitment to new function along with output.
-    #[clap(long)]
+    #[clap(long, value_parser)]
     chain: bool,
 
     /// Quote input before passing to function when opening. Otherwise input will be passed unevaluated and unquoted. --quote-input and --eval-input would cancel each other out if used in conjunction, so is probably not what is desired.
-    #[clap(long)]
+    #[clap(long, value_parser)]
     quote_input: bool,
 }
 
 #[derive(Args, Debug)]
 struct Eval {
     /// Path to expression source
-    #[clap(short = 'x', long, parse(from_os_str))]
+    #[clap(short = 'x', long, value_parser)]
     expression: PathBuf,
 
     /// Wrap evaluation result in a claim
-    #[clap(long)]
+    #[clap(long, value_parser)]
     claim: Option<PathBuf>,
 
     // Expression is lurk source.
-    #[clap(long)]
+    #[clap(long, value_parser)]
     lurk: bool,
 }
 
 #[derive(Args, Debug)]
 struct Prove {
     /// Path to expression source
-    #[clap(short = 'x', long, parse(from_os_str))]
+    #[clap(short = 'x', long, value_parser)]
     expression: Option<PathBuf>,
 
     /// Path to proof input
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     proof: PathBuf,
 
     /// Path to claim to prove
-    #[clap(long)]
+    #[clap(long, value_parser)]
     claim: Option<PathBuf>,
 
     // Expression is lurk source.
-    #[clap(long)]
+    #[clap(long, value_parser)]
     lurk: bool,
 }
 
 #[derive(Args, Debug)]
 struct Verify {
     /// Path to proof input
-    #[clap(short, long, parse(from_os_str))]
+    #[clap(short, long, value_parser)]
     proof: PathBuf,
 }
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3212,9 +3212,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(24995, cs.num_constraints());
+            assert_eq!(25028, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(24916, cs.aux().len());
+            assert_eq!(24943, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2864,13 +2864,13 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             result.alloc_equal(&mut cs.namespace(|| "result_is_nil"), &g.nil_ptr)?;
 
         let car_cdr_has_valid_tag_ = constraints::or(
-            &mut cs.namespace(|| "car_cdr_has_valid_tag"),
+            &mut cs.namespace(|| "car_cdr_has_valid_tag_"),
             &result_has_cons_tag,
             &result_has_str_tag,
         )?;
 
         let car_cdr_has_valid_tag = constraints::or(
-            &mut cs.namespace(|| "car_cdr_has_valid_tag2"),
+            &mut cs.namespace(|| "car_cdr_has_valid_tag"),
             &car_cdr_has_valid_tag_,
             &result_is_nil,
         )?;

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1974,7 +1974,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     /////////////////////////////////////////////////////////////////////////////
     let (unop_val, unop_continuation) = {
         let op1 = AllocatedPtr::by_index(0, &continuation_components);
-        let unop_continuation = AllocatedPtr::by_index(1, &continuation_components);
+        let unop_continuation = AllocatedContPtr::by_index(1, &continuation_components);
 
         let (allocated_car, allocated_cdr) =
             car_cdr(&mut cs.namespace(|| "Unop cons"), g, result, store)?;
@@ -2833,25 +2833,93 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
     // Continuation::Unop newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    let unop_op1 = AllocatedPtr::by_index(0, &continuation_components);
-    let other_unop_continuation = AllocatedContPtr::by_index(1, &continuation_components);
-    let op1_is_emit = alloc_equal(
-        &mut cs.namespace(|| "op1_is_emit"),
-        unop_op1.tag(),
-        &g.op1_emit_tag,
-    )?;
-    let unop_continuation = AllocatedContPtr::pick(
-        &mut cs.namespace(|| "continuation"),
-        &op1_is_emit,
-        &newer_cont,
-        &other_unop_continuation,
-    )?;
+    let (the_expr, the_cont) = {
+        let unop_op1 = AllocatedPtr::by_index(0, &continuation_components);
+        let other_unop_continuation = AllocatedContPtr::by_index(1, &continuation_components);
+        let op1_is_emit = alloc_equal(
+            &mut cs.namespace(|| "op1_is_emit"),
+            unop_op1.tag(),
+            &g.op1_emit_tag,
+        )?;
+        let unop_continuation = AllocatedContPtr::pick(
+            &mut cs.namespace(|| "continuation"),
+            &op1_is_emit,
+            &newer_cont,
+            &other_unop_continuation,
+        )?;
+
+        let result_has_cons_tag = alloc_equal(
+            &mut cs.namespace(|| "result_has_cons_tag"),
+            result.tag(),
+            &g.cons_tag,
+        )?;
+
+        let result_has_str_tag = alloc_equal(
+            &mut cs.namespace(|| "result_has_str_tag"),
+            result.tag(),
+            &g.str_tag,
+        )?;
+
+        let result_is_nil = result.alloc_equal(&mut cs.namespace(|| "result_is_nil"), &g.nil_ptr)?;
+
+        let car_cdr_has_valid_tag_ = constraints::or(
+            &mut cs.namespace(|| "car_cdr_has_valid_tag"),
+            &result_has_cons_tag,
+            &result_has_str_tag,
+        )?;
+
+        let car_cdr_has_valid_tag = constraints::or(
+            &mut cs.namespace(|| "car_cdr_has_valid_tag2"),
+            &car_cdr_has_valid_tag_,
+            &result_is_nil,
+        )?;
+
+        let op1_is_car = alloc_equal(
+            &mut cs.namespace(|| "op1_is_car"),
+            unop_op1.tag(),
+            &g.op1_car_tag,
+        )?;
+
+        let op1_is_cdr = alloc_equal(
+            &mut cs.namespace(|| "op1_is_cdr"),
+            unop_op1.tag(),
+            &g.op1_cdr_tag,
+        )?;
+
+        let op1_is_car_or_cdr = constraints::or(
+            &mut cs.namespace(|| "op1_is_car_or_cdr"),
+            &op1_is_car,
+            &op1_is_cdr,
+        )?;
+
+        let car_cdr_has_invalid_tag = Boolean::and(
+            &mut cs.namespace(|| "car_cdr_has_invalid_tag"),
+            &op1_is_car_or_cdr,
+            &Boolean::not(&car_cdr_has_valid_tag),
+        )?;
+
+        let the_expr = AllocatedPtr::pick(
+            &mut cs.namespace(|| "the_expr"),
+            &car_cdr_has_invalid_tag,
+            &result,
+            &unop_val,
+        )?;
+
+        let the_cont = AllocatedContPtr::pick(
+            &mut cs.namespace(|| "the_cont"),
+            &car_cdr_has_invalid_tag,
+            &g.error_ptr_cont,
+            &unop_continuation,
+        )?;
+
+        (the_expr, the_cont)
+    };
 
     results.add_clauses_cont(
         ContTag::Unop,
-        &unop_val,
+        &the_expr,
         env,
-        &unop_continuation,
+        &the_cont,
         &g.true_num,
     );
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2860,7 +2860,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &g.str_tag,
         )?;
 
-        let result_is_nil = result.alloc_equal(&mut cs.namespace(|| "result_is_nil"), &g.nil_ptr)?;
+        let result_is_nil =
+            result.alloc_equal(&mut cs.namespace(|| "result_is_nil"), &g.nil_ptr)?;
 
         let car_cdr_has_valid_tag_ = constraints::or(
             &mut cs.namespace(|| "car_cdr_has_valid_tag"),
@@ -2901,7 +2902,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let the_expr = AllocatedPtr::pick(
             &mut cs.namespace(|| "the_expr"),
             &car_cdr_has_invalid_tag,
-            &result,
+            result,
             &unop_val,
         )?;
 
@@ -2915,13 +2916,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         (the_expr, the_cont)
     };
 
-    results.add_clauses_cont(
-        ContTag::Unop,
-        &the_expr,
-        env,
-        &the_cont,
-        &g.true_num,
-    );
+    results.add_clauses_cont(ContTag::Unop, &the_expr, env, &the_cont, &g.true_num);
 
     // Main multi_case
     /////////////////////////////////////////////////////////////////////////////

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -628,7 +628,7 @@ fn reduce_with_witness<F: LurkField>(
                 } else if head == store.sym("car") {
                     let (arg1, end) = match store.car_cdr_mut(&rest) {
                         Ok((car, cdr)) => (car, cdr),
-                        Err(_) => unreachable!("Invalid tag"),//TODO: double check
+                        Err(_) => unreachable!("Invalid tag"), //TODO: double check
                     };
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
@@ -881,15 +881,11 @@ fn apply_continuation<F: LurkField>(
                 let val = match operator {
                     Op1::Car => match store.car_cdr_mut(result) {
                         Ok((car, _)) => car,
-                        Err(_) => {
-                            return Control::Return(*result, *env, store.intern_cont_error())
-                        },
+                        Err(_) => return Control::Return(*result, *env, store.intern_cont_error()),
                     },
-                    Op1::Cdr => match store.car_cdr_mut(result){
+                    Op1::Cdr => match store.car_cdr_mut(result) {
                         Ok((_, cdr)) => cdr,
-                        Err(_) => {
-                            return Control::Return(*result, *env, store.intern_cont_error())
-                        },
+                        Err(_) => return Control::Return(*result, *env, store.intern_cont_error()),
                     },
                     Op1::Atom => match result.tag() {
                         Tag::Cons => store.nil(),
@@ -1498,7 +1494,15 @@ mod test {
         let expected = s.num(123);
         let emitted = vec![expected];
         let terminal = s.get_cont_terminal();
-        test_aux(s, expr, Some(expected), None, Some(terminal), Some(emitted), 3);
+        test_aux(
+            s,
+            expr,
+            Some(expected),
+            None,
+            Some(terminal),
+            Some(emitted),
+            3,
+        );
     }
 
     #[test]
@@ -1751,7 +1755,15 @@ mod test {
         let expected = s.num(3);
         let new_env = s.nil();
         let terminal = s.get_cont_terminal();
-        test_aux(s, expr, Some(expected), Some(new_env), Some(terminal), None, 18);
+        test_aux(
+            s,
+            expr,
+            Some(expected),
+            Some(new_env),
+            Some(terminal),
+            None,
+            18,
+        );
     }
 
     #[test]
@@ -2199,11 +2211,35 @@ mod test {
         let nil = s.nil();
         let terminal = s.get_cont_terminal();
 
-        test_aux(s, r#"(car "apple")"#, Some(a), None, Some(terminal), None, 2);
-        test_aux(s, r#"(cdr "apple")"#, Some(pple), None, Some(terminal), None, 2);
+        test_aux(
+            s,
+            r#"(car "apple")"#,
+            Some(a),
+            None,
+            Some(terminal),
+            None,
+            2,
+        );
+        test_aux(
+            s,
+            r#"(cdr "apple")"#,
+            Some(pple),
+            None,
+            Some(terminal),
+            None,
+            2,
+        );
         test_aux(s, r#"(car "")"#, Some(nil), None, Some(terminal), None, 2);
         test_aux(s, r#"(cdr "")"#, Some(empty), None, Some(terminal), None, 2);
-        test_aux(s, r#"(cons #\a "pple")"#, Some(apple), None, Some(terminal), None, 3);
+        test_aux(
+            s,
+            r#"(cons #\a "pple")"#,
+            Some(apple),
+            None,
+            Some(terminal),
+            None,
+            3,
+        );
     }
 
     #[test]
@@ -2218,7 +2254,15 @@ mod test {
         let s = &mut Store::<Fr>::default();
         let expected = s.nil();
         let terminal = s.get_cont_terminal();
-        test_aux(s, r#"(car NIL)"#, Some(expected), None, Some(terminal), None, 2);
+        test_aux(
+            s,
+            r#"(car NIL)"#,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            2,
+        );
     }
 
     #[test]
@@ -2226,7 +2270,15 @@ mod test {
         let s = &mut Store::<Fr>::default();
         let expected = s.nil();
         let terminal = s.get_cont_terminal();
-        test_aux(s, r#"(cdr NIL)"#, Some(expected), None, Some(terminal), None, 2);
+        test_aux(
+            s,
+            r#"(cdr NIL)"#,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            2,
+        );
     }
 
     #[test]
@@ -2257,8 +2309,24 @@ mod test {
     fn test_car_cdr_invalid_tag_error_lambda() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        test_aux(s, r#"(car (lambda (x) x))"#, None, None, Some(error), None, 2);
-        test_aux(s, r#"(cdr (lambda (x) x))"#, None, None, Some(error), None, 2);
+        test_aux(
+            s,
+            r#"(car (lambda (x) x))"#,
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+        );
+        test_aux(
+            s,
+            r#"(cdr (lambda (x) x))"#,
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+        );
     }
 
     #[test]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -628,7 +628,7 @@ fn reduce_with_witness<F: LurkField>(
                 } else if head == store.sym("car") {
                     let (arg1, end) = match store.car_cdr_mut(&rest) {
                         Ok((car, cdr)) => (car, cdr),
-                        Err(_) => unreachable!("Invalid tag"), //TODO: double check
+                        Err(_) => panic!("Invalid tag"),
                     };
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
@@ -638,7 +638,7 @@ fn reduce_with_witness<F: LurkField>(
                 } else if head == store.sym("cdr") {
                     let (arg1, end) = match store.car_cdr_mut(&rest) {
                         Ok((car, cdr)) => (car, cdr),
-                        Err(_) => unreachable!("Invalid tag"), //TODO: double check
+                        Err(_) => panic!("Invalid tag"),
                     };
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1884,7 +1884,15 @@ mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.nil();
         let terminal = s.get_cont_terminal();
-        nova_test_aux(s, r#"(car NIL)"#, Some(expected), None, Some(terminal), None, 2);
+        nova_test_aux(
+            s,
+            r#"(car NIL)"#,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            2,
+        );
     }
 
     #[test]
@@ -1892,7 +1900,15 @@ mod tests {
         let s = &mut Store::<Fr>::default();
         let expected = s.nil();
         let terminal = s.get_cont_terminal();
-        nova_test_aux(s, r#"(cdr NIL)"#, Some(expected), None, Some(terminal), None, 2);
+        nova_test_aux(
+            s,
+            r#"(cdr NIL)"#,
+            Some(expected),
+            None,
+            Some(terminal),
+            None,
+            2,
+        );
     }
 
     #[test]
@@ -1923,7 +1939,23 @@ mod tests {
     fn outer_prove_car_cdr_invalid_tag_error_lambda() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
-        nova_test_aux(s, r#"(car (lambda (x) x))"#, None, None, Some(error), None, 2);
-        nova_test_aux(s, r#"(cdr (lambda (x) x))"#, None, None, Some(error), None, 2);
+        nova_test_aux(
+            s,
+            r#"(car (lambda (x) x))"#,
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+        );
+        nova_test_aux(
+            s,
+            r#"(cdr (lambda (x) x))"#,
+            None,
+            None,
+            Some(error),
+            None,
+            2,
+        );
     }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1878,4 +1878,52 @@ mod tests {
         let error = s.get_cont_error();
         nova_test_aux(s, r#"(cons "")"#, None, None, Some(error), None, 1);
     }
+
+    #[test]
+    fn outer_prove_car_nil() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.nil();
+        let terminal = s.get_cont_terminal();
+        nova_test_aux(s, r#"(car NIL)"#, Some(expected), None, Some(terminal), None, 2);
+    }
+
+    #[test]
+    fn outer_prove_cdr_nil() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.nil();
+        let terminal = s.get_cont_terminal();
+        nova_test_aux(s, r#"(cdr NIL)"#, Some(expected), None, Some(terminal), None, 2);
+    }
+
+    #[test]
+    fn outer_prove_car_cdr_invalid_tag_error_sym() {
+        let s = &mut Store::<Fr>::default();
+        let error = s.get_cont_error();
+        nova_test_aux(s, r#"(car car)"#, None, None, Some(error), None, 2);
+        nova_test_aux(s, r#"(cdr car)"#, None, None, Some(error), None, 2);
+    }
+
+    #[test]
+    fn outer_prove_car_cdr_invalid_tag_error_char() {
+        let s = &mut Store::<Fr>::default();
+        let error = s.get_cont_error();
+        nova_test_aux(s, r#"(car #\a)"#, None, None, Some(error), None, 2);
+        nova_test_aux(s, r#"(cdr #\a)"#, None, None, Some(error), None, 2);
+    }
+
+    #[test]
+    fn outer_prove_car_cdr_invalid_tag_error_num() {
+        let s = &mut Store::<Fr>::default();
+        let error = s.get_cont_error();
+        nova_test_aux(s, r#"(car 42)"#, None, None, Some(error), None, 2);
+        nova_test_aux(s, r#"(cdr 42)"#, None, None, Some(error), None, 2);
+    }
+
+    #[test]
+    fn outer_prove_car_cdr_invalid_tag_error_lambda() {
+        let s = &mut Store::<Fr>::default();
+        let error = s.get_cont_error();
+        nova_test_aux(s, r#"(car (lambda (x) x))"#, None, None, Some(error), None, 2);
+        nova_test_aux(s, r#"(cdr (lambda (x) x))"#, None, None, Some(error), None, 2);
+    }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1683,7 +1683,7 @@ impl<F: LurkField> Store<F> {
     }
 
     /// Mutable version of car_cdr to handle Str. `(cdr str)` may return a new str (the tail), which must be allocated.
-    pub fn car_cdr_mut(&mut self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>),&str> {
+    pub fn car_cdr_mut(&mut self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), &str> {
         match ptr.0 {
             Tag::Nil => Ok((self.get_nil(), self.get_nil())),
             Tag::Cons => match self.fetch(ptr) {
@@ -1705,9 +1705,7 @@ impl<F: LurkField> Store<F> {
                     panic!();
                 }
             }
-            _ => {
-                Err("Invalid tag")
-            }
+            _ => Err("Invalid tag"),
         }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1713,6 +1713,38 @@ impl<F: LurkField> Store<F> {
         }
     }
 
+    /// Mutable version of car_cdr to handle Str. `(cdr str)` may return a new str (the tail), which must be allocated.
+    pub fn car_cdr_mut_err(&mut self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>),&str> {
+        match ptr.0 {
+            Tag::Nil => Ok((self.get_nil(), self.get_nil())),
+            Tag::Cons => match self.fetch(ptr) {
+                Some(Expression::Cons(car, cdr)) => Ok((car, cdr)),
+                Some(Expression::Opaque(_)) => panic!("cannot destructure opaque Cons"),
+                _ => unreachable!(),
+            },
+            Tag::Str => {
+                if let Some(Expression::Str(s)) = self.fetch(ptr) {
+                    let mut str = s.chars();
+                    if let Some(c) = str.next() {
+                        let cdr_str: String = str.collect();
+                        let str = self.intern_str(&cdr_str);
+                        Ok((self.get_char(c), str))
+                    } else {
+                        Ok((self.nil(), self.intern_str(&"")))
+                    }
+                } else {
+                    panic!();
+                }
+            }
+            _ => {
+                // FIXME: Don't panic. This can happen at runtime in a valid Lurk program,
+                // so it should result in an explicit error.
+                //panic!("Can only extract car_cdr from Cons")
+                Err("Invalid tag")
+            }
+        }
+    }
+
     pub fn car_cdr(&self, ptr: &Ptr<F>) -> (Ptr<F>, Ptr<F>) {
         // FIXME: Maybe make error.
         match ptr.0 {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1683,38 +1683,7 @@ impl<F: LurkField> Store<F> {
     }
 
     /// Mutable version of car_cdr to handle Str. `(cdr str)` may return a new str (the tail), which must be allocated.
-    pub fn car_cdr_mut(&mut self, ptr: &Ptr<F>) -> (Ptr<F>, Ptr<F>) {
-        match ptr.0 {
-            Tag::Nil => (self.get_nil(), self.get_nil()),
-            Tag::Cons => match self.fetch(ptr) {
-                Some(Expression::Cons(car, cdr)) => (car, cdr),
-                Some(Expression::Opaque(_)) => panic!("cannot destructure opaque Cons"),
-                _ => unreachable!(),
-            },
-            Tag::Str => {
-                if let Some(Expression::Str(s)) = self.fetch(ptr) {
-                    let mut str = s.chars();
-                    if let Some(c) = str.next() {
-                        let cdr_str: String = str.collect();
-                        let str = self.intern_str(&cdr_str);
-                        (self.get_char(c), str)
-                    } else {
-                        (self.nil(), self.intern_str(&""))
-                    }
-                } else {
-                    panic!();
-                }
-            }
-            _ => {
-                // FIXME: Don't panic. This can happen at runtime in a valid Lurk program,
-                // so it should result in an explicit error.
-                panic!("Can only extract car_cdr from Cons")
-            }
-        }
-    }
-
-    /// Mutable version of car_cdr to handle Str. `(cdr str)` may return a new str (the tail), which must be allocated.
-    pub fn car_cdr_mut_err(&mut self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>),&str> {
+    pub fn car_cdr_mut(&mut self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>),&str> {
         match ptr.0 {
             Tag::Nil => Ok((self.get_nil(), self.get_nil())),
             Tag::Cons => match self.fetch(ptr) {
@@ -1737,9 +1706,6 @@ impl<F: LurkField> Store<F> {
                 }
             }
             _ => {
-                // FIXME: Don't panic. This can happen at runtime in a valid Lurk program,
-                // so it should result in an explicit error.
-                //panic!("Can only extract car_cdr from Cons")
                 Err("Invalid tag")
             }
         }


### PR DESCRIPTION
The next tasks were accomplished: 
*  Return error in the following situations (similarly for `cdr`): 
    - `(car car)`, since tag is symbol.
    - `(car #\a)`, since tag is char. 
    - `(car 42)`, since tag is num.
    - `(car (lambda (x) x))`, since tag is fun.
* Also, add check for `(car NIL)` is NIL.
* Refactored eval.rs to check programs end with terminal continuation.