### PR TITLE
Update for Str behavior change.

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1149,6 +1149,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let letrec_t = AllocatedPtr::alloc_constant(&mut cs.namespace(|| "letrec"), letrec)?;
     let letrec_hash = letrec.value();
     let cons_hash = hash_sym("cons");
+    let strcons_hash = hash_sym("strcons");
     let begin_hash = hash_sym("begin");
     let car_hash = hash_sym("car");
     let cdr_hash = hash_sym("cdr");
@@ -1411,6 +1412,16 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         *cons_hash.value(),
         &g.binop_cont_tag,
         cons_continuation_components,
+    );
+
+    // head == STRCONS preimage
+    /////////////////////////////////////////////////////////////////////////////
+    let strcons_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
+        &[&[&g.op2_strcons_tag, &g.default_num], env, &more, cont];
+    hash_default_results.add_hash_input_clauses(
+        *strcons_hash.value(),
+        &g.binop_cont_tag,
+        strcons_continuation_components,
     );
 
     // head == HIDE preimage
@@ -1795,14 +1806,30 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
     // head == CONS, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    // Checking one-arg cons error
-    let the_cont_cons = AllocatedContPtr::pick(
-        &mut cs.namespace(|| "the_cont_cons"),
+    // Checking one-arg cons or strcons error
+    let the_cont_cons_or_strcons = AllocatedContPtr::pick(
+        &mut cs.namespace(|| "the_cont_cons_or_strcons"),
         &end_is_nil,
         &g.error_ptr_cont,
         &newer_cont,
     )?;
-    results.add_clauses_cons(*cons_hash.value(), &arg1, env, &the_cont_cons, &g.false_num);
+    results.add_clauses_cons(
+        *cons_hash.value(),
+        &arg1,
+        env,
+        &the_cont_cons_or_strcons,
+        &g.false_num,
+    );
+
+    // head == STRCONS, newer_cont is allocated
+    /////////////////////////////////////////////////////////////////////////////
+    results.add_clauses_cons(
+        *strcons_hash.value(),
+        &arg1,
+        env,
+        &the_cont_cons_or_strcons,
+        &g.false_num,
+    );
 
     // head == BEGIN, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
@@ -2772,6 +2799,12 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &arg2_is_num,
         )?;
 
+        let some_args_are_nums = constraints::or(
+            &mut cs.namespace(|| "some_args_are_nums"),
+            &arg1_is_num,
+            &arg2_is_num,
+        )?;
+
         let (a, b) = (arg1.hash(), arg2.hash()); // For Nums, the 'hash' is an immediate value.
 
         let not_dummy = alloc_equal(
@@ -2834,6 +2867,10 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                     value: cons.hash(),
                 },
                 CaseClause {
+                    key: Op2::StrCons.as_field(),
+                    value: cons.hash(),
+                },
+                CaseClause {
                     key: Op2::Hide.as_field(),
                     value: hide.hash(),
                 },
@@ -2845,6 +2882,12 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &mut cs.namespace(|| "Op2 is Cons"),
             op2.tag(),
             &g.op2_cons_tag,
+        )?;
+
+        let is_strcons = alloc_equal(
+            &mut cs.namespace(|| "Op2 is StrCons"),
+            op2.tag(),
+            &g.op2_strcons_tag,
         )?;
 
         let is_hide = alloc_equal(
@@ -2900,24 +2943,33 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &g.num_tag,
         )?;
 
+        let is_cons_or_hide =
+            constraints::or(&mut cs.namespace(|| "is cons or hide"), &is_cons, &is_hide)?;
+
+        let is_cons_or_strcons = constraints::or(
+            &mut cs.namespace(|| "is cons or strcons"),
+            &is_cons,
+            &is_strcons,
+        )?;
+
+        let is_cons_or_strcons_or_hide = constraints::or(
+            &mut cs.namespace(|| "is cons or srtcons or hide"),
+            &is_cons_or_hide,
+            &is_strcons,
+        )?;
+
         let res_tag = pick(
             &mut cs.namespace(|| "Op2 result tag"),
-            &is_cons,
+            &is_cons_or_strcons,
             &cons_tag,
             &comm_or_num_tag,
         )?;
 
         let res = AllocatedPtr::from_parts(res_tag, val);
 
-        let is_cons_or_is_hide = constraints::or(
-            &mut cs.namespace(|| "is cons or is hide"),
-            &is_cons,
-            &is_hide,
-        )?;
-
         let valid_types = constraints::or(
             &mut cs.namespace(|| "Op2 called with valid types"),
-            &is_cons_or_is_hide,
+            &is_cons_or_strcons_or_hide,
             &both_args_are_nums,
         )?;
 
@@ -2939,16 +2991,28 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &Boolean::not(&real_div_and_b_is_zero),
         )?;
 
-        let op2_not_both_num_and_not_cons_or_hide = Boolean::and(
-            &mut cs.namespace(|| "not both num and not cons or hide"),
+        let op2_not_both_num_and_not_cons_or_strcons_or_hide = Boolean::and(
+            &mut cs.namespace(|| "not both num and not cons or strcons or hide"),
             &Boolean::not(&both_args_are_nums),
-            &Boolean::not(&is_cons_or_is_hide),
+            &Boolean::not(&is_cons_or_strcons_or_hide),
+        )?;
+
+        let some_num_and_strcons = Boolean::and(
+            &mut cs.namespace(|| "both_num_and_strcons"),
+            &some_args_are_nums,
+            &is_strcons,
+        )?;
+
+        let any_error1 = constraints::or(
+            &mut cs.namespace(|| "first two errors"),
+            &Boolean::not(&valid_types_and_not_div_by_zero),
+            &op2_not_both_num_and_not_cons_or_strcons_or_hide,
         )?;
 
         let any_error = constraints::or(
             &mut cs.namespace(|| "some error happened"),
-            &Boolean::not(&valid_types_and_not_div_by_zero),
-            &op2_not_both_num_and_not_cons_or_hide,
+            &any_error1,
+            &some_num_and_strcons,
         )?;
 
         let the_cont = AllocatedContPtr::pick(
@@ -3871,9 +3935,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(19295, cs.num_constraints());
+            assert_eq!(19328, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(19220, cs.aux().len());
+            assert_eq!(19252, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -58,6 +58,7 @@ pub struct GlobalAllocations<F: LurkField> {
     pub op1_atom_tag: AllocatedNum<F>,
     pub op1_emit_tag: AllocatedNum<F>,
     pub op2_cons_tag: AllocatedNum<F>,
+    pub op2_strcons_tag: AllocatedNum<F>,
     pub op2_hide_tag: AllocatedNum<F>,
     pub op2_begin_tag: AllocatedNum<F>,
     pub op2_sum_tag: AllocatedNum<F>,
@@ -169,6 +170,8 @@ impl<F: LurkField> GlobalAllocations<F> {
         let op1_atom_tag = Op1::Atom.allocate_constant(&mut cs.namespace(|| "op1_atom_tag"))?;
         let op1_emit_tag = Op1::Emit.allocate_constant(&mut cs.namespace(|| "op1_emit_tag"))?;
         let op2_cons_tag = Op2::Cons.allocate_constant(&mut cs.namespace(|| "op2_cons_tag"))?;
+        let op2_strcons_tag =
+            Op2::StrCons.allocate_constant(&mut cs.namespace(|| "op2_strcons_tag"))?;
         let op2_hide_tag = Op2::Hide.allocate_constant(&mut cs.namespace(|| "op2_hide_tag"))?;
         let op2_begin_tag = Op2::Begin.allocate_constant(&mut cs.namespace(|| "op2_begin_tag"))?;
         let op2_sum_tag = Op2::Sum.allocate_constant(&mut cs.namespace(|| "op2_sum_tag"))?;
@@ -234,6 +237,7 @@ impl<F: LurkField> GlobalAllocations<F> {
             op1_atom_tag,
             op1_emit_tag,
             op2_cons_tag,
+            op2_strcons_tag,
             op2_hide_tag,
             op2_begin_tag,
             op2_sum_tag,

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -226,6 +226,33 @@ impl<F: LurkField> AllocatedPtr<F> {
         })
     }
 
+    pub fn construct_strcons<CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        g: &GlobalAllocations<F>,
+        store: &Store<F>,
+        car: &AllocatedPtr<F>,
+        cdr: &AllocatedPtr<F>,
+    ) -> Result<AllocatedPtr<F>, SynthesisError> {
+        // This is actually binary_hash, considering creating that helper for use elsewhere.
+        let preimage = vec![
+            car.tag().clone(),
+            car.hash().clone(),
+            cdr.tag().clone(),
+            cdr.hash().clone(),
+        ];
+
+        let hash = poseidon_hash(
+            cs.namespace(|| "StrCons hash"),
+            preimage,
+            store.poseidon_constants().c4(),
+        )?;
+
+        Ok(AllocatedPtr {
+            tag: g.str_tag.clone(),
+            hash,
+        })
+    }
+
     pub fn construct_fun<CS: ConstraintSystem<F>>(
         mut cs: CS,
         g: &GlobalAllocations<F>,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2267,7 +2267,6 @@ mod tests {
         nova_test_aux(s, r#"(car "")"#, Some(nil), None, Some(terminal), None, 2);
         nova_test_aux(s, r#"(cdr "")"#, Some(empty), None, Some(terminal), None, 2);
 
-        // FIXME: This case fails.
         nova_test_aux(
             s,
             r#"(cons #\a "pple")"#,
@@ -2288,10 +2287,8 @@ mod tests {
             3,
         );
 
-        // FIXME: This case fails.
         nova_test_aux(s, r#"(strcons #\a #\b)"#, None, None, Some(error), None, 3);
 
-        // FIXME: This case fails.
         nova_test_aux(s, r#"(strcons "a" "b")"#, None, None, Some(error), None, 3);
 
         nova_test_aux(s, r#"(strcons 1 2)"#, None, None, Some(error), None, 3);

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2233,4 +2233,67 @@ mod tests {
         let expr = "(secret (comm 123))";
         nova_test_aux(s, expr, None, None, None, None, 2);
     }
+
+    #[test]
+    fn test_str_car_cdr_cons() {
+        let s = &mut Store::<Fr>::default();
+        let a = s.read(r#"#\a"#).unwrap();
+        let apple = s.read(r#" "apple" "#).unwrap();
+        let a_pple = s.read(r#" (#\a . "pple") "#).unwrap();
+        let pple = s.read(r#" "pple" "#).unwrap();
+        let empty = s.intern_str(&"");
+        let nil = s.nil();
+        let terminal = s.get_cont_terminal();
+        let error = s.get_cont_error();
+
+        nova_test_aux(
+            s,
+            r#"(car "apple")"#,
+            Some(a),
+            None,
+            Some(terminal),
+            None,
+            2,
+        );
+        nova_test_aux(
+            s,
+            r#"(cdr "apple")"#,
+            Some(pple),
+            None,
+            Some(terminal),
+            None,
+            2,
+        );
+        nova_test_aux(s, r#"(car "")"#, Some(nil), None, Some(terminal), None, 2);
+        nova_test_aux(s, r#"(cdr "")"#, Some(empty), None, Some(terminal), None, 2);
+
+        // FIXME: This case fails.
+        nova_test_aux(
+            s,
+            r#"(cons #\a "pple")"#,
+            Some(a_pple),
+            None,
+            Some(terminal),
+            None,
+            3,
+        );
+
+        nova_test_aux(
+            s,
+            r#"(strcons #\a "pple")"#,
+            Some(apple),
+            None,
+            Some(terminal),
+            None,
+            3,
+        );
+
+        // FIXME: This case fails.
+        nova_test_aux(s, r#"(strcons #\a #\b)"#, None, None, Some(error), None, 3);
+
+        // FIXME: This case fails.
+        nova_test_aux(s, r#"(strcons "a" "b")"#, None, None, Some(error), None, 3);
+
+        nova_test_aux(s, r#"(strcons 1 2)"#, None, None, Some(error), None, 3);
+    }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1886,19 +1886,26 @@ mod tests {
     }
 
     #[test]
-    fn outer_prove_str_cons() {
+    fn outer_prove_strcons() {
         let s = &mut Store::<Fr>::default();
         let expected_apple = s.read(r#" "apple" "#).unwrap();
         let terminal = s.get_cont_terminal();
         nova_test_aux(
             s,
-            r#"(cons #\a "pple")"#,
+            r#"(strcons #\a "pple")"#,
             Some(expected_apple),
             None,
             Some(terminal),
             None,
             3,
         );
+    }
+
+    #[test]
+    fn outer_prove_str_cons_error() {
+        let s = &mut Store::<Fr>::default();
+        let error = s.get_cont_error();
+        nova_test_aux(s, r#"(strcons #\a 123)"#, None, None, Some(error), None, 3);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -828,6 +828,7 @@ impl<F: LurkField> Default for Store<F> {
             "begin",
             "hide",
             "cons",
+            "strcons",
             "car",
             "cdr",
             "commit",

--- a/src/store.rs
+++ b/src/store.rs
@@ -618,6 +618,7 @@ pub enum Op2 {
     Product,
     Quotient,
     Cons,
+    StrCons,
     Begin,
     Hide,
 }
@@ -648,6 +649,7 @@ impl fmt::Display for Op2 {
             Op2::Product => write!(f, "Product"),
             Op2::Quotient => write!(f, "Quotient"),
             Op2::Cons => write!(f, "Cons"),
+            Op2::StrCons => write!(f, "StrCons"),
             Op2::Begin => write!(f, "Begin"),
             Op2::Hide => write!(f, "Hide"),
         }
@@ -872,6 +874,9 @@ impl<F: LurkField> Store<F> {
     pub fn cons(&mut self, car: Ptr<F>, cdr: Ptr<F>) -> Ptr<F> {
         self.intern_cons(car, cdr)
     }
+    pub fn strcons(&mut self, car: Ptr<F>, cdr: Ptr<F>) -> Ptr<F> {
+        self.intern_strcons(car, cdr)
+    }
 
     pub fn hidden(&self, secret: F, payload: Ptr<F>) -> Option<Ptr<F>> {
         self.comm_store
@@ -1009,14 +1014,6 @@ impl<F: LurkField> Store<F> {
             self.hash_expr(&car);
             self.hash_expr(&cdr);
         }
-        if (car.tag(), cdr.tag()) == (Tag::Char, Tag::Str) {
-            let (c, s) = (
-                self.fetch_char(&car).unwrap(),
-                self.fetch_str(&cdr).unwrap(),
-            );
-            let new_str = format!("{}{}", c, s);
-            return self.intern_str(&new_str);
-        };
 
         let (p, inserted) = self.cons_store.insert_full((car, cdr));
         let ptr = Ptr(Tag::Cons, RawPtr::new(p));
@@ -1024,6 +1021,21 @@ impl<F: LurkField> Store<F> {
             self.dehydrated.push(ptr);
         }
         ptr
+    }
+
+    pub fn intern_strcons(&mut self, car: Ptr<F>, cdr: Ptr<F>) -> Ptr<F> {
+        if car.is_opaque() || cdr.is_opaque() {
+            self.hash_expr(&car);
+            self.hash_expr(&cdr);
+        }
+        assert_eq!((car.tag(), cdr.tag()), (Tag::Char, Tag::Str));
+        let (c, s) = (
+            self.fetch_char(&car).unwrap(),
+            self.fetch_str(&cdr).unwrap(),
+        );
+        let new_str = format!("{}{}", c, s);
+
+        self.intern_str(&new_str)
     }
 
     pub fn intern_comm(&mut self, secret: F, payload: Ptr<F>) -> Ptr<F> {


### PR DESCRIPTION
This PR incorporates https://github.com/lurk-lang/lurk-lib/pull/26 and makes the `lurk_tests` pass after doing so. It also adds equivalent unit tests for eval and circuit.

- [ ] circuit (tests exist now but will fail until circuit is updated). (@emmorais can you push fixes to this branch?)