### PR TITLE
Support alternate fields in REPL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Or use the wrapper script:
 bin/lurkrs
 ```
 
+Set the environment variable `LURK_FIELD` to specify the scalar field of the Lurk language instance:
+- `LURK_FIELD=PALLAS` (default): scalar field of Pallas
+- `LURK_FIELD=VESTA` (default): scalar field of Vesta
+- `LURK_FIELD=BLS12-381` (default): scalar field of BLS12-381
+
 ```
 ➜  lurk-rs ✗ bin/lurkrs
     Finished release [optimized] target(s) in 0.06s

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use lurk::field::LanguageField;
+use lurk::proof::nova::{PallasScalar, VestaScalar};
 use lurk::repl::repl;
 
 fn main() -> Result<()> {
@@ -12,5 +14,21 @@ fn main() -> Result<()> {
         None
     };
 
-    repl(lurk_file.as_deref())
+    let default_field = LanguageField::Pallas;
+    let field = if let Ok(lurk_field) = std::env::var("LURK_FIELD") {
+        match lurk_field.as_str() {
+            "BLS12-381" => LanguageField::BLS12_381,
+            "PALLAS" => LanguageField::Pallas,
+            "VESTA" => LanguageField::Vesta,
+            _ => default_field,
+        }
+    } else {
+        default_field
+    };
+
+    match field {
+        LanguageField::BLS12_381 => repl::<_, blstrs::Scalar>(lurk_file.as_deref()),
+        LanguageField::Pallas => repl::<_, PallasScalar>(lurk_file.as_deref()),
+        LanguageField::Vesta => repl::<_, VestaScalar>(lurk_file.as_deref()),
+    }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -5,6 +5,12 @@ use std::hash::Hash;
 
 use multihash::Multihash;
 
+pub enum LanguageField {
+    Pallas,
+    Vesta,
+    BLS12_381,
+}
+
 pub trait LurkField: ff::PrimeField {
     // These constants are assumed to be based on some global table like
     // multicodec, ideally extended to include arbitrary precision codecs

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -17,7 +17,7 @@ use nova::{
     traits::Group,
     FinalSNARK, StepSNARK,
 };
-use pasta_curves::pallas;
+use pasta_curves::{pallas, vesta};
 
 use crate::circuit::MultiFrame;
 use crate::eval::{Evaluator, Frame, Witness, IO};
@@ -27,6 +27,9 @@ use crate::proof::Prover;
 use crate::store::{Ptr, Store};
 
 type PallasPoint = pallas::Point;
+
+pub type PallasScalar = pallas::Scalar;
+pub type VestaScalar = vesta::Scalar;
 
 pub struct Proof<G: Group> {
     pub step_proofs: Vec<StepSNARK<G>>,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,8 +1,8 @@
 use crate::eval::{empty_sym_env, Evaluator, IO};
+use crate::field::LurkField;
 use crate::store::{ContPtr, ContTag, Expression, Pointer, Ptr, Store, Tag};
 use crate::writer::Write;
 use anyhow::Result;
-use blstrs::Scalar as Fr;
 use rustyline::error::ReadlineError;
 use rustyline::validate::{
     MatchingBracketValidator, ValidationContext, ValidationResult, Validator,
@@ -25,19 +25,19 @@ impl Validator for InputValidator {
 }
 
 #[derive(Clone)]
-pub struct ReplState {
-    env: Ptr<Fr>,
+pub struct ReplState<F: LurkField> {
+    env: Ptr<F>,
     limit: usize,
 }
 
-pub struct Repl {
-    state: ReplState,
+pub struct Repl<F: LurkField> {
+    state: ReplState<F>,
     rl: Editor<InputValidator>,
     history_path: PathBuf,
 }
 
-impl Repl {
-    pub fn new(s: &mut Store<Fr>, limit: usize) -> Result<Self> {
+impl<F: LurkField> Repl<F> {
+    pub fn new(s: &mut Store<F>, limit: usize) -> Result<Self> {
         let history_path = dirs::home_dir()
             .expect("missing home directory")
             .join(".lurk-history");
@@ -69,10 +69,10 @@ impl Repl {
 }
 
 // For the moment, input must be on a single line.
-pub fn repl<P: AsRef<Path>>(lurk_file: Option<P>) -> Result<()> {
+pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
     println!("Lurk REPL welcomes you.");
 
-    let mut s = Store::default();
+    let mut s = Store::<F>::default();
     let limit = 100_000_000;
     let mut repl = Repl::new(&mut s, limit)?;
 
@@ -145,8 +145,8 @@ pub fn repl<P: AsRef<Path>>(lurk_file: Option<P>) -> Result<()> {
     Ok(())
 }
 
-impl ReplState {
-    pub fn new(s: &mut Store<Fr>, limit: usize) -> Self {
+impl<F: LurkField> ReplState<F> {
+    pub fn new(s: &mut Store<F>, limit: usize) -> Self {
         Self {
             env: empty_sym_env(s),
             limit,
@@ -154,9 +154,9 @@ impl ReplState {
     }
     pub fn eval_expr(
         &mut self,
-        expr: Ptr<Fr>,
-        store: &mut Store<Fr>,
-    ) -> (Ptr<Fr>, usize, ContPtr<Fr>, Vec<Ptr<Fr>>) {
+        expr: Ptr<F>,
+        store: &mut Store<F>,
+    ) -> (Ptr<F>, usize, ContPtr<F>, Vec<Ptr<F>>) {
         let (
             IO {
                 expr: result,
@@ -175,7 +175,7 @@ impl ReplState {
     /// Second bool is true if processing should continue.
     pub fn maybe_handle_command(
         &mut self,
-        store: &mut Store<Fr>,
+        store: &mut Store<F>,
         line: &str,
     ) -> Result<(bool, bool)> {
         let mut chars = line.chars().peekable();
@@ -232,7 +232,7 @@ impl ReplState {
         Ok(result)
     }
 
-    pub fn handle_load<P: AsRef<Path>>(&mut self, store: &mut Store<Fr>, path: P) -> Result<()> {
+    pub fn handle_load<P: AsRef<Path>>(&mut self, store: &mut Store<F>, path: P) -> Result<()> {
         println!("Loading from {}.", path.as_ref().to_str().unwrap());
         let input = read_to_string(path)?;
 
@@ -248,7 +248,7 @@ impl ReplState {
 
     pub fn handle_run<P: AsRef<Path> + Copy>(
         &mut self,
-        store: &mut Store<Fr>,
+        store: &mut Store<F>,
         path: P,
     ) -> Result<()> {
         println!("Running from {}.", path.as_ref().to_str().unwrap());

--- a/tests/lurk-tests.rs
+++ b/tests/lurk-tests.rs
@@ -1,4 +1,4 @@
-use lurk::repl::repl;
+use lurk::{proof, repl::repl};
 use std::path::Path;
 
 #[test]
@@ -16,6 +16,7 @@ fn lurk_tests() {
     dbg!(&example_dir);
     for f in test_files {
         let joined = example_dir.join(f);
-        repl(Some(joined)).unwrap();
+
+        repl::<_, proof::nova::PallasScalar>(Some(joined)).unwrap();
     }
 }


### PR DESCRIPTION
Support multiple fields in REPL, defaulting to the scalar field of Pallas. For now, selection is by env var, but we should probably add a command-line option also.

```
➜  lurk-rs git:(repl-backend) ✗ bin/lurkrs
   Compiling lurk v0.1.1 (/Users/clwk/fil/lurk-rs)
    Finished release [optimized] target(s) in 4.50s
     Running `target/release/examples/repl`
Lurk REPL welcomes you.
> (- 0 1)
[3 iterations] => 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000000
> 
Exiting...
➜  lurk-rs git:(repl-backend) ✗ LURK_FIELD=PALLAS bin/lurkrs
    Finished release [optimized] target(s) in 0.12s
     Running `target/release/examples/repl`
Lurk REPL welcomes you.
> (- 0 1)
[3 iterations] => 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000000
> 
Exiting...
➜  lurk-rs git:(repl-backend) ✗ LURK_FIELD=VESTA bin/lurkrs
    Finished release [optimized] target(s) in 0.12s
     Running `target/release/examples/repl`
Lurk REPL welcomes you.
> (- 0 1)
[3 iterations] => 0x40000000000000000000000000000000224698fc094cf91b992d30ed00000000
> 
Exiting...
➜  lurk-rs git:(repl-backend) ✗ LURK_FIELD=BLS12-381 bin/lurkrs               
    Finished release [optimized] target(s) in 0.12s
     Running `target/release/examples/repl`
Lurk REPL welcomes you.
> (- 0 1)
[3 iterations] => 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000
>
```