### PR TITLE
Use store.ptr_eq in !(:assert-eq ...).

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -289,7 +289,7 @@ impl<F: LurkField> ReplState<F> {
                                 assert!(rest.is_nil());
                                 let (first_evaled, _, _, _) = self.eval_expr(first, store);
                                 let (second_evaled, _, _, _) = self.eval_expr(second, store);
-                                assert_eq!(first_evaled, second_evaled);
+                                assert!(store.ptr_eq(&first_evaled, &second_evaled));
                             } else if s == &":ASSERT" {
                                 let (first, rest) = store.car_cdr(&rest);
                                 assert!(rest.is_nil());


### PR DESCRIPTION
This PR fixes the `!(:assert-eq …)` REPL command to perform a proper `Ptr` equality check and not just check for Rust data-structure equality.

Before:
```
!(:assert-eq (comm 0x185e06ceae235e35b0b54a0032c97c22cde058f810583b4fb8aedf2f1c7aa7f2) (commit 123))

thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `Ptr(Comm, RawPtr(-1, PhantomData))`,
 right: `Ptr(Comm, RawPtr(0, PhantomData))`', /Users/clwk/fil/lurk-rs/src/repl.rs:292:33
```
After:
```
!(:assert-eq (comm 0x185e06ceae235e35b0b54a0032c97c22cde058f810583b4fb8aedf2f1c7aa7f2) (commit 123))
```