### PR TITLE
Clarify reduction explanation.

### DIFF
--- a/spec/reduction-notes.md
+++ b/spec/reduction-notes.md
@@ -138,9 +138,9 @@ This example reveals the general structure of the canonical Lurk expression eval
   - an identity transformation.
   - a mapping of input to 'more reduced' output.
 - Given that Lurk is Turing complete, this does not guarantee termination.
-- Any Lurk expression whose evaluation *does* terminate will eventually lead to a fixed point of reduction.
 - The reduction step performs a fixed computation, with no recursion. This is necessary so it can be proved in a circuit.
 - The reduction is performed in continuation-passing style, which is what allows a complete evaluation to be sliced into
   as many reductions as needed.
+- Any Lurk expression whose evaluation *does* terminate will eventually lead to a fixed point of reduction (when the continuation is considered as an input/output of reduction).
 - This leads naturally to the tail-call elimination observed above.
 


### PR DESCRIPTION
Clarify that terminating evaluation results being a fixed-point of reduction depends on considering the continuation (and lexical environment) as part of the reduction step's I/O.

That is, it's not the case that repeated *expression evaluation* will result in unchanged subsequent results.

A clarifying example:
```
Lurk REPL welcomes you.
> (+ 1 1)
[3 iterations] => 2
> 2
[1 iterations] => 2
> ;; 2 is self-evaluating.
> '(+ 1 1)
[1 iterations] => (+ 1 1)
> (+ 1 1)
[3 iterations] => 2
> ;; (+ 1 1) is not self-evaluating.
```