### PR TITLE
Support quoted symbols.

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3020,8 +3020,8 @@ mod test {
     fn test_quoted_symbols() {
         let s = &mut Store::<Fr>::default();
         let expr = "(let ((|foo bar| 9)
-                          (|Foo Bar| (lambda (|X|) (* x x))))
-                      (|Foo Bar| |foo bar|))";
+                          (|Foo \\| Bar| (lambda (|X|) (* x x))))
+                      (|Foo \\| Bar| |foo bar|))";
         let res = s.num(81);
         let terminal = s.get_cont_terminal();
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2993,6 +2993,11 @@ mod test {
         relational_aux(s, gt, one, most_negative, true);
         relational_aux(s, lte, one, most_negative, false);
         relational_aux(s, gte, one, most_negative, true);
+
+        relational_aux(s, lt, most_negative, one, true);
+        relational_aux(s, gt, most_negative, one, false);
+        relational_aux(s, lte, most_negative, one, true);
+        relational_aux(s, gte, most_negative, one, false);
     }
 
     #[test]
@@ -3009,5 +3014,17 @@ mod test {
         let terminal = s.get_cont_terminal();
 
         test_aux(s, expr, Some(t), None, Some(terminal), None, 19);
+    }
+
+    #[test]
+    fn test_quoted_symbols() {
+        let s = &mut Store::<Fr>::default();
+        let expr = "(let ((|foo bar| 9)
+                          (|Foo Bar| (lambda (|X|) (* x x))))
+                      (|Foo Bar| |foo bar|))";
+        let res = s.num(81);
+        let terminal = s.get_cont_terminal();
+
+        test_aux(s, expr, Some(res), None, Some(terminal), None, 13);
     }
 }


### PR DESCRIPTION
Closes #125, closes #136.

Symbols containing any character ~(except '|')~ can now be used by quoting with '|'. ~The lack of internal quoting is a bug equivalent to the same current lack for strings (see #136).~

In the future, we can consider making the reader directly aware of more symbol characters, allowing them in symbol names, without quoting. For now, explicit quoting should work.

Tests include greek and symbol examples. The following example works in the REPL, though I avoided emoji in the source since it wreaked havoc with my editor.

```
> (let ((|🐊| 9)
        (|🐉| (lambda (|🍓|) (* |🍓| |🍓|))))
    (|🐉| |🐊|))
[13 iterations] => 81
```