### PR TITLE
Processs multiple expressions when loading from REPL.

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -235,14 +235,17 @@ impl<F: LurkField> ReplState<F> {
     pub fn handle_load<P: AsRef<Path>>(&mut self, store: &mut Store<F>, path: P) -> Result<()> {
         println!("Loading from {}.", path.as_ref().to_str().unwrap());
         let input = read_to_string(path)?;
+        let mut chars = input.chars().peekable();
 
-        let expr = store.read(&input).unwrap();
-        let (result, _limit, _next_cont, _) = self.eval_expr(expr, store);
+        while let Some(expr) = store.read_next(&mut chars) {
+            let (result, _limit, _next_cont, _) = self.eval_expr(expr, store);
 
-        self.env = result;
+            self.env = result;
 
+            io::stdout().flush().unwrap();
+        }
         println!("Read: {}", input);
-        io::stdout().flush().unwrap();
+
         Ok(())
     }
 


### PR DESCRIPTION
When loading a Lurk file in the REPL (with `:load`), only the first expression was previously processed. This PR extends this behavior to process expressions sequentially. In this context, 'process' means the expression is evaluated, and the REPL's env is replaced with the result.

Idiomatically, file loading is used to define library code, by returning `current-env` from within a lexical scope which binds some variables (often to functions).

Previously, all such definitions had to be created within a single expression. However, it is convenient when writing library code, to write independent top-level definitions.

The behavior introduced in this PR allows that. For example, consider loading a Lurk file containing the following code:
```
(let ((square (lambda (x) (* x x))))
  (current-env))

(let ((inc (lambda (x) (+ x 1))))
  (current-env))

(let ((avocado 9))
  (current-env))
```

This then allows the following usage:

```
Lurk REPL welcomes you.
> :load "lib.lurk"
Loading from lib.lurk.
Read: (let ((square (lambda (x) (* x x))))
  (current-env))

(let ((inc (lambda (x) (+ x 1))))
  (current-env))

(let ((avocado 9))
  (current-env))

> (current-env)
[1 iterations] => ((AVOCADO . 9) (INC . <FUNCTION (X) (+ X 1))>) (SQUARE . <FUNCTION (X) (* X X))>))
> (inc (square avocado))
[18 iterations] => 82
```

This is equivalent to loading library code which previously would need to have been defined as follows:
```
(let ((square (lambda (x) (* x x)))
      (inc (lambda (x) (+ x 1)))
      (avocado 9))
  (current-env))
```

Although the 'old' way is more compact and sometimes desirable, it sometimes makes incremental development, composition, and structuring of library code cumbersome. The old method will still work, but the new addition adds flexibility.