### PR TITLE
Remove Relop and Relop2.

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3877,9 +3877,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(19135, cs.num_constraints());
+            assert_eq!(19144, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(19064, cs.aux().len());
+            assert_eq!(19072, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1653,20 +1653,20 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     /////////////////////////////////////////////////////////////////////////////
 
     let numequal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
-        &[&[&g.rel2_numequal_tag, &g.default_num], env, &more, cont];
+        &[&[&g.op2_numequal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
         *numequal_hash.value(),
-        &g.relop_cont_tag,
+        &g.binop_cont_tag,
         numequal_continuation_components,
     );
 
     // head == EQ preimage
     /////////////////////////////////////////////////////////////////////////////
     let equal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
-        &[&[&g.rel2_equal_tag, &g.default_num], env, &more, cont];
+        &[&[&g.op2_equal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
         *equal_hash.value(),
-        &g.relop_cont_tag,
+        &g.binop_cont_tag,
         equal_continuation_components,
     );
 
@@ -2502,26 +2502,6 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         binop_components,
     );
 
-    // Continuation::Relop preimage
-    /////////////////////////////////////////////////////////////////////////////
-    let (relop2, relop_cont) = {
-        (
-            &continuation_components[0],
-            AllocatedContPtr::by_index(3, &continuation_components),
-        )
-    };
-    let relop_components: &[&dyn AsAllocatedHashComponents<F>; 4] = &[
-        &[relop2, &g.default_num],
-        result,
-        &relop_cont,
-        default_num_pair,
-    ];
-    hash_default_results.add_hash_input_clauses(
-        ContTag::Relop.as_field(),
-        &g.relop2_cont_tag,
-        relop_components,
-    );
-
     let defaults = [
         &g.default_num,
         &g.default_num,
@@ -2825,6 +2805,18 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let (a, b) = (arg1.hash(), arg2.hash()); // For Nums, the 'hash' is an immediate value.
 
+        let tags_equal = alloc_equal(&mut cs.namespace(|| "tags equal"), arg1.tag(), arg2.tag())?;
+        let vals_equal = alloc_equal(&mut cs.namespace(|| "vals equal"), arg1.hash(), arg2.hash())?;
+        let args_equal =
+            Boolean::and(&mut cs.namespace(|| "args equal"), &tags_equal, &vals_equal)?;
+
+        let args_equal_ptr = AllocatedPtr::pick(
+            &mut cs.namespace(|| "args_equal_ptr"),
+            &args_equal,
+            &g.t_ptr,
+            &g.nil_ptr,
+        )?;
+
         let not_dummy = alloc_equal(
             &mut cs.namespace(|| "Binop2 not dummy"),
             cont.tag(),
@@ -2881,6 +2873,10 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                     value: &quotient,
                 },
                 CaseClause {
+                    key: Op2::Equal.as_field(),
+                    value: args_equal_ptr.hash(),
+                },
+                CaseClause {
                     key: Op2::Cons.as_field(),
                     value: cons.hash(),
                 },
@@ -2894,6 +2890,12 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                 },
             ],
             &g.default_num,
+        )?;
+
+        let is_equal = alloc_equal(
+            &mut cs.namespace(|| "Op2 is Equal"),
+            op2.tag(),
+            &g.op2_equal_tag,
         )?;
 
         let is_cons = alloc_equal(
@@ -2976,18 +2978,31 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &is_strcons,
         )?;
 
-        let res_tag = pick(
-            &mut cs.namespace(|| "Op2 result tag"),
+        let is_cons_or_strcons_or_hide_or_equal = constraints::or(
+            &mut cs.namespace(|| "is cons or srtcons or hide or equal"),
+            &is_cons_or_strcons_or_hide,
+            &is_equal,
+        )?;
+
+        let res_tag0 = pick(
+            &mut cs.namespace(|| "Op2 result tag (part 1)"),
             &is_cons_or_strcons,
             &cons_tag,
             &comm_or_num_tag,
+        )?;
+
+        let res_tag = pick(
+            &mut cs.namespace(|| "Op2 result tag"),
+            &is_equal,
+            args_equal_ptr.tag(),
+            &res_tag0,
         )?;
 
         let res = AllocatedPtr::from_parts(&res_tag, &val);
 
         let valid_types = constraints::or(
             &mut cs.namespace(|| "Op2 called with valid types"),
-            &is_cons_or_strcons_or_hide,
+            &is_cons_or_strcons_or_hide_or_equal,
             &both_args_are_nums,
         )?;
 
@@ -3009,10 +3024,10 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &Boolean::not(&real_div_and_b_is_zero),
         )?;
 
-        let op2_not_both_num_and_not_cons_or_strcons_or_hide = Boolean::and(
+        let op2_not_both_num_and_not_cons_or_strcons_or_hide_or_equal = Boolean::and(
             &mut cs.namespace(|| "not both num and not cons or strcons or hide"),
             &Boolean::not(&both_args_are_nums),
-            &Boolean::not(&is_cons_or_strcons_or_hide),
+            &Boolean::not(&is_cons_or_strcons_or_hide_or_equal),
         )?;
 
         let args_not_char_str = &Boolean::not(&args_are_char_str);
@@ -3025,7 +3040,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let any_error1 = constraints::or(
             &mut cs.namespace(|| "first two errors"),
             &Boolean::not(&valid_types_and_not_div_by_zero),
-            &op2_not_both_num_and_not_cons_or_strcons_or_hide,
+            &op2_not_both_num_and_not_cons_or_strcons_or_hide_or_equal,
         )?;
 
         let any_error = constraints::or(
@@ -3052,127 +3067,6 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     };
 
     results.add_clauses_cont(ContTag::Binop2, &the_expr, env, &the_cont, &g.true_num);
-
-    // Continuation::Relop, newer_cont is allocated
-    /////////////////////////////////////////////////////////////////////////////
-    let (the_expr, the_env, the_cont) = {
-        let mut cs = cs.namespace(|| "Relop");
-        let saved_env = AllocatedPtr::by_index(1, &continuation_components);
-        let unevaled_args = AllocatedPtr::by_index(2, &continuation_components);
-
-        let (allocated_arg2, allocated_rest) =
-            car_cdr(&mut cs.namespace(|| "cons"), g, &unevaled_args, store)?;
-
-        let rest_is_nil =
-            allocated_rest.alloc_equal(&mut cs.namespace(|| "args_is_nil"), &g.nil_ptr)?;
-
-        let the_cont = AllocatedContPtr::pick(
-            &mut cs.namespace(|| "the_cont"),
-            &rest_is_nil,
-            &newer_cont,
-            &g.error_ptr_cont,
-        )?;
-
-        let the_expr = AllocatedPtr::pick(
-            &mut cs.namespace(|| "the_expr"),
-            &rest_is_nil,
-            &allocated_arg2,
-            result,
-        )?;
-
-        let the_env = AllocatedPtr::pick(
-            &mut cs.namespace(|| "the_env"),
-            &rest_is_nil,
-            &saved_env,
-            env,
-        )?;
-
-        (the_expr, the_env, the_cont)
-    };
-    results.add_clauses_cont(ContTag::Relop, &the_expr, &the_env, &the_cont, &g.false_num);
-
-    // Continuation::Relop2
-    /////////////////////////////////////////////////////////////////////////////
-    let (the_expr, the_cont) = {
-        let mut cs = cs.namespace(|| "Relop2");
-        let rel2 = AllocatedPtr::by_index(0, &continuation_components);
-        let arg1 = AllocatedPtr::by_index(1, &continuation_components);
-        let continuation = AllocatedContPtr::by_index(2, &continuation_components);
-        let arg2 = result;
-
-        let tags_equal = alloc_equal(&mut cs.namespace(|| "tags equal"), arg1.tag(), arg2.tag())?;
-
-        let vals_equal = alloc_equal(&mut cs.namespace(|| "vals equal"), arg1.hash(), arg2.hash())?;
-
-        let arg1_tag_is_num = alloc_equal(
-            &mut cs.namespace(|| "arg1 tag is num"),
-            arg1.tag(),
-            &g.num_tag,
-        )?;
-
-        let arg2_tag_is_num = alloc_equal(
-            &mut cs.namespace(|| "arg2 tag is num"),
-            arg2.tag(),
-            &g.num_tag,
-        )?;
-
-        let args_are_num = Boolean::and(
-            &mut cs.namespace(|| "args are num"),
-            &arg1_tag_is_num,
-            &arg2_tag_is_num,
-        )?;
-
-        let rel2_is_equal = alloc_equal(
-            &mut cs.namespace(|| "rel2 tag is Equal"),
-            rel2.tag(),
-            &g.rel2_equal_tag,
-        )?;
-
-        let args_equal =
-            Boolean::and(&mut cs.namespace(|| "args equal"), &tags_equal, &vals_equal)?;
-
-        let args_are_num_or_rel2_is_equal = constraints::or(
-            &mut cs.namespace(|| "args_are_num_or_rel2_is_equal"),
-            &args_are_num,
-            &rel2_is_equal,
-        )?;
-
-        let not_num_tag_without_nums = constraints::or(
-            &mut cs.namespace(|| "sub_res"),
-            &args_are_num,
-            &rel2_is_equal,
-        )?;
-
-        let boolean_res = Boolean::and(
-            &mut cs.namespace(|| "boolean_res"),
-            &args_equal,
-            &not_num_tag_without_nums,
-        )?;
-
-        let res = AllocatedPtr::pick(
-            &mut cs.namespace(|| "res"),
-            &boolean_res,
-            &g.t_ptr,
-            &g.nil_ptr,
-        )?;
-
-        let the_expr = AllocatedPtr::pick(
-            &mut cs.namespace(|| "the_expr"),
-            &args_are_num_or_rel2_is_equal,
-            &res,
-            result,
-        )?;
-
-        let the_cont = AllocatedContPtr::pick(
-            &mut cs.namespace(|| "the_cont"),
-            &args_are_num_or_rel2_is_equal,
-            &continuation,
-            &g.error_ptr_cont,
-        )?;
-
-        (the_expr, the_cont)
-    };
-    results.add_clauses_cont(ContTag::Relop2, &the_expr, env, &the_cont, &g.true_num);
 
     // Continuation::If
     /////////////////////////////////////////////////////////////////////////////
@@ -3954,9 +3848,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(19498, cs.num_constraints());
+            assert_eq!(19135, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(19422, cs.aux().len());
+            assert_eq!(19064, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -9,7 +9,7 @@ use neptune::{
 
 use super::pointer::AsAllocatedHashComponents;
 use crate::field::LurkField;
-use crate::store::{ContPtr, ContTag, Expression, Op1, Op2, Pointer, Ptr, Rel2, Store, Tag, Thunk};
+use crate::store::{ContPtr, ContTag, Expression, Op1, Op2, Pointer, Ptr, Store, Tag, Thunk};
 use crate::store::{IntoHashComponents, ScalarPtr};
 use crate::store::{ScalarContPtr, ScalarPointer};
 
@@ -46,9 +46,7 @@ pub struct GlobalAllocations<F: LurkField> {
     pub unop_cont_tag: AllocatedNum<F>,
     pub emit_cont_tag: AllocatedNum<F>,
     pub binop_cont_tag: AllocatedNum<F>,
-    pub relop_cont_tag: AllocatedNum<F>,
     pub binop2_cont_tag: AllocatedNum<F>,
-    pub relop2_cont_tag: AllocatedNum<F>,
     pub if_cont_tag: AllocatedNum<F>,
 
     pub op1_car_tag: AllocatedNum<F>,
@@ -69,8 +67,8 @@ pub struct GlobalAllocations<F: LurkField> {
     pub op2_diff_tag: AllocatedNum<F>,
     pub op2_product_tag: AllocatedNum<F>,
     pub op2_quotient_tag: AllocatedNum<F>,
-    pub rel2_equal_tag: AllocatedNum<F>,
-    pub rel2_numequal_tag: AllocatedNum<F>,
+    pub op2_equal_tag: AllocatedNum<F>,
+    pub op2_numequal_tag: AllocatedNum<F>,
 
     pub true_num: AllocatedNum<F>,
     pub false_num: AllocatedNum<F>,
@@ -152,12 +150,8 @@ impl<F: LurkField> GlobalAllocations<F> {
             ContTag::Emit.allocate_constant(&mut cs.namespace(|| "emit_cont_tag"))?;
         let binop_cont_tag =
             ContTag::Binop.allocate_constant(&mut cs.namespace(|| "binop_cont_tag"))?;
-        let relop_cont_tag =
-            ContTag::Relop.allocate_constant(&mut cs.namespace(|| "relop_cont_tag"))?;
         let binop2_cont_tag =
             ContTag::Binop2.allocate_constant(&mut cs.namespace(|| "binop2_cont_tag"))?;
-        let relop2_cont_tag =
-            ContTag::Relop2.allocate_constant(&mut cs.namespace(|| "relop2_cont_tag"))?;
         let if_cont_tag = ContTag::If.allocate_constant(&mut cs.namespace(|| "if_cont_tag"))?;
 
         let op1_car_tag = Op1::Car.allocate_constant(&mut cs.namespace(|| "op1_car_tag"))?;
@@ -184,12 +178,12 @@ impl<F: LurkField> GlobalAllocations<F> {
             Op2::Product.allocate_constant(&mut cs.namespace(|| "op2_product_tag"))?;
         let op2_quotient_tag =
             Op2::Quotient.allocate_constant(&mut cs.namespace(|| "op2_quotient_tag"))?;
-        let rel2_numequal_tag =
-            AllocatedNum::alloc(&mut cs.namespace(|| "relop2_numequal_tag"), || {
-                Ok(Rel2::NumEqual.as_field())
+        let op2_numequal_tag =
+            AllocatedNum::alloc(&mut cs.namespace(|| "op2_numequal_tag"), || {
+                Ok(Op2::NumEqual.as_field())
             })?;
-        let rel2_equal_tag = AllocatedNum::alloc(&mut cs.namespace(|| "relop2_equal_tag"), || {
-            Ok(Rel2::Equal.as_field())
+        let op2_equal_tag = AllocatedNum::alloc(&mut cs.namespace(|| "op2_equal_tag"), || {
+            Ok(Op2::Equal.as_field())
         })?;
 
         let true_num = allocate_constant(&mut cs.namespace(|| "true"), F::one())?;
@@ -225,9 +219,7 @@ impl<F: LurkField> GlobalAllocations<F> {
             unop_cont_tag,
             emit_cont_tag,
             binop_cont_tag,
-            relop_cont_tag,
             binop2_cont_tag,
-            relop2_cont_tag,
             if_cont_tag,
             op1_car_tag,
             op1_cdr_tag,
@@ -247,8 +239,8 @@ impl<F: LurkField> GlobalAllocations<F> {
             op2_diff_tag,
             op2_product_tag,
             op2_quotient_tag,
-            rel2_equal_tag,
-            rel2_numequal_tag,
+            op2_equal_tag,
+            op2_numequal_tag,
             true_num,
             false_num,
             default_num,
@@ -479,18 +471,6 @@ impl Op1 {
 }
 
 impl Op2 {
-    pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
-        &self,
-        cs: &mut CS,
-    ) -> Result<AllocatedNum<F>, SynthesisError> {
-        allocate_constant(
-            &mut cs.namespace(|| format!("{:?} tag", self)),
-            self.as_field(),
-        )
-    }
-}
-
-impl Rel2 {
     pub fn allocate_constant<F: LurkField, CS: ConstraintSystem<F>>(
         &self,
         cs: &mut CS,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,8 +1,8 @@
 use crate::field::LurkField;
 use crate::num::Num;
 use crate::store::{
-    ContPtr, ContTag, Continuation, Expression, Op1, Op2, Pointer, Ptr, Rel2, ScalarPointer, Store,
-    Tag, Thunk,
+    ContPtr, ContTag, Continuation, Expression, Op1, Op2, Pointer, Ptr, ScalarPointer, Store, Tag,
+    Thunk,
 };
 use crate::writer::Write;
 use log::info;
@@ -797,14 +797,14 @@ fn reduce_with_witness<F: LurkField>(
                     Control::Return(
                         arg1,
                         env,
-                        store.intern_cont_relop(Rel2::NumEqual, env, more, cont),
+                        store.intern_cont_binop(Op2::NumEqual, env, more, cont),
                     )
                 } else if head == store.sym("eq") {
                     let (arg1, more) = store.car_cdr(&rest);
                     Control::Return(
                         arg1,
                         env,
-                        store.intern_cont_relop(Rel2::Equal, env, more, cont),
+                        store.intern_cont_binop(Op2::Equal, env, more, cont),
                     )
                 } else if head == store.sym("<") {
                     let (arg1, more) = store.car_cdr(&rest);
@@ -1135,6 +1135,9 @@ fn apply_continuation<F: LurkField>(
                             tmp /= b;
                             store.intern_num(tmp)
                         }
+                        Op2::Equal | Op2::NumEqual => {
+                            store.as_lurk_boolean(store.ptr_eq(&evaled_arg, arg2))
+                        }
                         Op2::Less => store.less_than(a, b),
                         Op2::Greater => store.less_than(b, a),
                         Op2::LessEqual => store.less_equal(a, b),
@@ -1147,6 +1150,7 @@ fn apply_continuation<F: LurkField>(
                         Op2::Begin => unreachable!(),
                     },
                     (Expression::Num(a), _) => match operator {
+                        Op2::Equal => store.nil(),
                         Op2::Cons => store.cons(evaled_arg, *arg2),
                         Op2::Hide => store.hide(a.into_scalar(), *arg2),
                         _ => {
@@ -1161,63 +1165,10 @@ fn apply_continuation<F: LurkField>(
                         }
                     },
                     _ => match operator {
+                        Op2::Equal => store.as_lurk_boolean(store.ptr_eq(&evaled_arg, arg2)),
                         Op2::Cons => store.cons(evaled_arg, *arg2),
                         _ => {
                             return Control::Return(*result, *env, store.intern_cont_error());
-                        }
-                    },
-                };
-                Control::MakeThunk(result, *env, continuation)
-            }
-            _ => unreachable!(),
-        },
-        ContTag::Relop => match store.fetch_cont(cont).unwrap() {
-            Continuation::Relop {
-                operator,
-                saved_env,
-                unevaled_args,
-                continuation,
-            } => {
-                let (arg2, rest) = store.car_cdr(&unevaled_args);
-                if !rest.is_nil() {
-                    Control::Return(*result, *env, store.intern_cont_error())
-                } else {
-                    Control::Return(
-                        arg2,
-                        saved_env,
-                        store.intern_cont_relop2(operator, *result, continuation),
-                    )
-                }
-            }
-            _ => unreachable!(),
-        },
-        ContTag::Relop2 => match store.fetch_cont(cont).unwrap() {
-            Continuation::Relop2 {
-                operator,
-                evaled_arg,
-                continuation,
-            } => {
-                let arg2 = result;
-                let result = match (evaled_arg.tag(), arg2.tag()) {
-                    (Tag::Num, Tag::Num) => match operator {
-                        Rel2::NumEqual | Rel2::Equal => {
-                            if store.ptr_eq(&evaled_arg, arg2) {
-                                store.t() // TODO: maybe explicit boolean.
-                            } else {
-                                store.nil()
-                            }
-                        }
-                    },
-                    (_, _) => match operator {
-                        Rel2::NumEqual => {
-                            return Control::Return(*result, *env, store.intern_cont_error());
-                        }
-                        Rel2::Equal => {
-                            if store.ptr_eq(&evaled_arg, arg2) {
-                                store.t()
-                            } else {
-                                store.nil()
-                            }
                         }
                     },
                 };
@@ -2237,7 +2188,24 @@ mod test {
         }
         {
             let s = &mut Store::<Fr>::default();
+            let expr = "(eq 1 1)";
+
+            let expected = s.t();
+            let terminal = s.get_cont_terminal();
+            test_aux(s, expr, Some(expected), None, Some(terminal), None, 3);
+        }
+        {
+            let s = &mut Store::<Fr>::default();
             let expr = "(eq 'a 1)";
+
+            let expected = s.nil();
+            let terminal = s.get_cont_terminal();
+            test_aux(s, expr, Some(expected), None, Some(terminal), None, 3);
+        }
+
+        {
+            let s = &mut Store::<Fr>::default();
+            let expr = "(eq 1 'a)";
 
             let expected = s.nil();
             let terminal = s.get_cont_terminal();
@@ -2384,7 +2352,7 @@ mod test {
     }
 
     #[test]
-    fn evaluate_map_tree_relop_bug() {
+    fn evaluate_map_tree_numequal_bug() {
         {
             // Reuse map-tree failure case to test Relop behavior.
             // This failed initially and tests regression.

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -25,18 +25,18 @@ pub fn verify_sequential_css<F: LurkField + Copy>(
     for (i, (multiframe, cs)) in css.iter().enumerate() {
         if let Some(prev) = previous_frame {
             if !prev.precedes(multiframe) {
-                dbg!("not preceeding frame");
+                dbg!(i, "not preceeding frame");
                 return Ok(false);
             }
         }
         if !cs.is_satisfied() {
-            dbg!("cs {} not satisfied", i);
+            dbg!(i, "cs not satisfied");
             return Ok(false);
         }
 
         let public_inputs = multiframe.public_inputs();
         if !cs.verify(&public_inputs) {
-            dbg!("cs not verified");
+            dbg!(i, "cs not verified");
             return Ok(false);
         }
         previous_frame = Some(multiframe);

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -491,6 +491,19 @@ mod tests {
     }
 
     #[test]
+    fn outer_prove_equal() {
+        let s = &mut Store::<Fr>::default();
+        let nil = s.nil();
+        let t = s.t();
+        let terminal = s.get_cont_terminal();
+
+        nova_test_aux(s, "(eq 5 nil)", Some(nil), None, Some(terminal), None, 3);
+        nova_test_aux(s, "(eq nil 5)", Some(nil), None, Some(terminal), None, 3);
+        nova_test_aux(s, "(eq nil nil)", Some(t), None, Some(terminal), None, 3);
+        nova_test_aux(s, "(eq 5 5)", Some(t), None, Some(terminal), None, 3);
+    }
+
+    #[test]
     fn outer_prove_quote_end_is_nil_error() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
@@ -810,13 +823,6 @@ mod tests {
         let expected = s.num(9);
         let error = s.get_cont_error();
         nova_test_aux(s, "(- 9 8 7)", Some(expected), None, Some(error), None, 2);
-    }
-
-    #[test]
-    fn outer_prove_evaluate_relop_rest_is_nil() {
-        let s = &mut Store::<Fr>::default();
-        let expected = s.num(9);
-        let error = s.get_cont_error();
         nova_test_aux(s, "(= 9 8 7)", Some(expected), None, Some(error), None, 2);
     }
 

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use crate::field::LurkField;
 
-use crate::store::{Op1, Op2, Pointer, Ptr, Rel2, ScalarContPtr, ScalarPtr, Store, Tag};
+use crate::store::{Op1, Op2, Pointer, Ptr, ScalarContPtr, ScalarPtr, Store, Tag};
 use crate::Num;
 use serde::Deserialize;
 use serde::Serialize;
@@ -265,17 +265,6 @@ pub enum ScalarContinuation<F: LurkField> {
         evaled_arg: ScalarPtr<F>,
         continuation: ScalarContPtr<F>,
     },
-    Relop {
-        operator: Rel2,
-        saved_env: ScalarPtr<F>,
-        unevaled_args: ScalarPtr<F>,
-        continuation: ScalarContPtr<F>,
-    },
-    Relop2 {
-        operator: Rel2,
-        evaled_arg: ScalarPtr<F>,
-        continuation: ScalarContPtr<F>,
-    },
     If {
         unevaled_args: ScalarPtr<F>,
         continuation: ScalarContPtr<F>,
@@ -422,23 +411,6 @@ mod test {
                     100,
                     Box::new(|g| Self::Binop2 {
                         operator: Op2::arbitrary(g),
-                        evaled_arg: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::Relop {
-                        operator: Rel2::arbitrary(g),
-                        saved_env: ScalarPtr::arbitrary(g),
-                        unevaled_args: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::Relop2 {
-                        operator: Rel2::arbitrary(g),
                         evaled_arg: ScalarPtr::arbitrary(g),
                         continuation: ScalarContPtr::arbitrary(g),
                     }),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -246,31 +246,6 @@ impl<F: LurkField> Write<F> for Continuation<F> {
                 continuation.fmt(store, w)?;
                 write!(w, " }}")
             }
-            Continuation::Relop {
-                operator,
-                saved_env,
-                unevaled_args,
-                continuation,
-            } => {
-                write!(w, "Relop{{ operator: {}, saved_env: ", operator)?;
-                saved_env.fmt(store, w)?;
-                write!(w, ", unevaled_args: ")?;
-                unevaled_args.fmt(store, w)?;
-                write!(w, ", continuation: ")?;
-                continuation.fmt(store, w)?;
-                write!(w, ")")
-            }
-            Continuation::Relop2 {
-                operator,
-                evaled_arg,
-                continuation,
-            } => {
-                write!(w, "Relop2{{ operator: {}, evaled_ag: ", operator)?;
-                evaled_arg.fmt(store, w)?;
-                write!(w, ", continuation: ")?;
-                continuation.fmt(store, w)?;
-                write!(w, " }}")
-            }
             Continuation::If {
                 unevaled_args,
                 continuation,


### PR DESCRIPTION
This PR removes the `Relop` and `Relop2` continuation times. It no longer makes sense to separate these from `Binop` and `Binop2`. Removing them and moving `eq` and `=` to `Binop` and `Binop2` allows us to remove a lot of nearly-duplicated code and also removes some constraints.