### PR TITLE
Correctly handle < when both args are negative.

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -161,10 +161,8 @@ impl<F: LurkField> Num<F> {
 
     pub fn is_less_than(&self, other: Num<F>) -> bool {
         match (self.is_negative(), other.is_negative()) {
-            // Both positive
-            (false, false) => self.is_less_than_aux(other),
-            // Both negative, reverse sign of simple test.
-            (true, true) => !self.is_equal(other) && !self.is_less_than_aux(other),
+            // Both positive or both negative
+            (true, true) | (false, false) => self.is_less_than_aux(other),
             (true, false) => true,
             (false, true) => false,
         }


### PR DESCRIPTION
#133 incorrectly handled the case where both args to a relational operator are negative. This PR tests and fixes that.