### PR TITLE
Test nested let regression.

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2586,19 +2586,19 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         );
 
         let next_expr = AllocatedPtr::pick(
-            &mut cs.namespace(|| "pick nexp expr"),
+            &mut cs.namespace(|| "pick next expr"),
             &args_is_dummy,
             &body_form,
             result,
         )?;
         let next_env = AllocatedPtr::pick(
-            &mut cs.namespace(|| "pick nexp env"),
+            &mut cs.namespace(|| "pick next env"),
             &args_is_dummy,
             &closed_env,
             env,
         )?;
         let next_cont = AllocatedContPtr::pick(
-            &mut cs.namespace(|| "pick nexp cont"),
+            &mut cs.namespace(|| "pick next cont"),
             &args_is_dummy,
             &tail_cont.unwrap(),
             &continuation,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1503,6 +1503,7 @@ mod tests {
             10,
         );
     }
+
     #[test]
     fn outer_prove_evaluate_zero_arg_lambda3() {
         let s = &mut Store::<Fr>::default();

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -1541,6 +1541,18 @@ mod tests {
     }
 
     #[test]
+    fn outer_prove_nested_let_closure_regression() {
+        let s = &mut Store::<Fr>::default();
+        let terminal = s.get_cont_terminal();
+        let expected = s.num(6);
+        let expr = "(let ((data-function (lambda () 123))
+                          (x 6)
+                          (data (data-function)))
+                      x)";
+        nova_test_aux(s, expr, Some(expected), None, Some(terminal), None, 14);
+    }
+
+    #[test]
     #[ignore]
     fn outer_prove_evaluate_minimal_tail_call() {
         let s = &mut Store::<Fr>::default();

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -160,8 +160,13 @@ impl<F: LurkField> Write<F> for Continuation<F> {
     fn fmt<W: io::Write>(&self, store: &Store<F>, w: &mut W) -> io::Result<()> {
         match self {
             Continuation::Outermost => write!(w, "Outermost"),
-            Continuation::Call0 { continuation } => {
-                write!(w, "Call0{{ continuation: ")?;
+            Continuation::Call0 {
+                saved_env,
+                continuation,
+            } => {
+                write!(w, "Call0{{ saved_env: ")?;
+                saved_env.fmt(store, w)?;
+                write!(w, ", ")?;
                 continuation.fmt(store, w)?;
                 write!(w, " }}")
             }


### PR DESCRIPTION
This PR fixes a bug I discovered while writing some elaborate examples, then minimized and fixed. Previously, zero-arg functions were being called with a `Call0` continuation which did not save and restore the lexical environment. For more detail, see the test — which also includes a case which always works and helps clarify exactly what was failing.

I've fixed this behavior by extending `Call0` to include the saved env and modified the handling in `eval.rs`. The circuit still needs to be adjusted for these changes, and @emmorais will take over from here.