### PR TITLE
Support U64

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1279,10 +1279,7 @@ fn apply_continuation<F: LurkField>(
                         Op2::Greater => Ok(store.less_than(b, a)),
                         Op2::LessEqual => Ok(store.less_equal(a, b)),
                         Op2::GreaterEqual => Ok(store.less_equal(b, a)),
-                        Op2::Hide => unreachable!(),
-                        Op2::StrCons => unreachable!(),
-                        Op2::Cons => unreachable!(),
-                        Op2::Begin => unreachable!(),
+                        _ => unreachable!(),
                     }
                 };
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3392,6 +3392,17 @@ mod test {
     }
 
     #[test]
+    fn test_u64_self_evaluating() {
+        let s = &mut Store::<Fr>::default();
+
+        let expr = "123u64";
+        let res = s.uint64(123);
+        let terminal = s.get_cont_terminal();
+
+        test_aux(s, expr, Some(res), None, Some(terminal), None, 1);
+    }
+
+    #[test]
     fn test_u64_mul() {
         let s = &mut Store::<Fr>::default();
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1274,11 +1274,11 @@ fn apply_continuation<F: LurkField>(
                                 Ok(store.intern_num(tmp))
                             }
                         }
-                        Op2::Equal | Op2::NumEqual => Ok(store.as_lurk_boolean(a.is_equal(b))),
-                        Op2::Less => Ok(store.less_than(a, b)),
-                        Op2::Greater => Ok(store.less_than(b, a)),
-                        Op2::LessEqual => Ok(store.less_equal(a, b)),
-                        Op2::GreaterEqual => Ok(store.less_equal(b, a)),
+                        Op2::Equal | Op2::NumEqual => Ok(store.as_lurk_boolean(a == b)),
+                        Op2::Less => Ok(store.as_lurk_boolean(a < b)),
+                        Op2::Greater => Ok(store.as_lurk_boolean(a > b)),
+                        Op2::LessEqual => Ok(store.as_lurk_boolean(a <= b)),
+                        Op2::GreaterEqual => Ok(store.as_lurk_boolean(a >= b)),
                         _ => unreachable!(),
                     }
                 };
@@ -1652,13 +1652,6 @@ impl<F: LurkField> Store<F> {
         } else {
             self.nil()
         }
-    }
-    fn less_than(&mut self, a: Num<F>, b: Num<F>) -> Ptr<F> {
-        self.as_lurk_boolean(a.is_less_than(b))
-    }
-
-    fn less_equal(&mut self, a: Num<F>, b: Num<F>) -> Ptr<F> {
-        self.as_lurk_boolean(a.is_less_than(b) || a.is_equal(b))
     }
 }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -44,6 +44,17 @@ pub trait LurkField: PrimeField + PrimeFieldBits {
         byte_array.copy_from_slice(&self.to_repr().as_ref()[0..8]);
         Some(u64::from_le_bytes(byte_array))
     }
+    // Return a u64 corresponding to the first 8 little-endian bytes of this field element, discarding the remaining bytes.
+    fn to_u64_unchecked(&self) -> u64 {
+        let mut byte_array = [0u8; 8];
+        byte_array.copy_from_slice(&self.to_repr().as_ref()[0..8]);
+        u64::from_le_bytes(byte_array)
+    }
+    fn from_u64(x: u64) -> Option<Self> {
+        let mut bytes = vec![0; 32];
+        bytes[0..8].as_mut().copy_from_slice(&x.to_le_bytes());
+        Self::from_bytes(&bytes)
+    }
 
     fn most_negative() -> Self {
         Self::most_positive() + Self::one()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(unchecked_math)]
 #![allow(clippy::single_match, clippy::type_complexity)]
 
 extern crate core;
@@ -19,11 +20,13 @@ pub mod proof;
 pub mod repl;
 pub mod scalar_store;
 pub mod store;
+pub mod uint;
 pub mod writer;
 
 mod error;
 mod num;
 pub use num::Num;
+pub use uint::UInt;
 
 pub const TEST_SEED: [u8; 16] = [
     0x62, 0x59, 0x5d, 0xbe, 0x3d, 0x76, 0x3d, 0x8d, 0xdb, 0x17, 0x32, 0x37, 0x06, 0x54, 0xe5, 0xbc,

--- a/src/num.rs
+++ b/src/num.rs
@@ -7,8 +7,9 @@ use std::{
 };
 
 use crate::field::LurkField;
+use crate::uint::UInt;
 
-/// Number type for Lurk. Has different internal representations to optimize evaluation.
+/// Finite field element type for Lurk. Has different internal representations to optimize evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Num<F: LurkField> {
     Scalar(F),
@@ -215,6 +216,14 @@ impl<F: LurkField> Num<F> {
 impl<F: LurkField> From<u64> for Num<F> {
     fn from(n: u64) -> Self {
         Num::<F>::U64(n)
+    }
+}
+
+impl<F: LurkField> From<UInt> for Num<F> {
+    fn from(n: UInt) -> Self {
+        match n {
+            UInt::U64(n) => Num::<F>::U64(n),
+        }
     }
 }
 

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,6 +1,7 @@
 use crate::field::FWrap;
 use serde::{Deserialize, Serialize};
 use std::{
+    cmp::Ordering,
     fmt::Display,
     hash::Hash,
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
@@ -46,6 +47,20 @@ impl<F: LurkField> Hash for Num<F> {
                 bytes.as_mut()[..8].copy_from_slice(&n.to_le_bytes());
                 bytes.as_ref().hash(state);
             }
+        }
+    }
+}
+
+impl<F: LurkField> PartialOrd for Num<F> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self == other {
+            return Some(Ordering::Equal);
+        };
+
+        if self.is_less_than(other) {
+            Some(Ordering::Less)
+        } else {
+            Some(Ordering::Greater)
         }
     }
 }
@@ -160,10 +175,10 @@ impl<F: LurkField> Num<F> {
         }
     }
 
-    pub fn is_less_than(&self, other: Num<F>) -> bool {
+    fn is_less_than(&self, other: &Num<F>) -> bool {
         match (self.is_negative(), other.is_negative()) {
             // Both positive or both negative
-            (true, true) | (false, false) => self.is_less_than_aux(other),
+            (true, true) | (false, false) => self.is_less_than_aux(*other),
             (true, false) => true,
             (false, true) => false,
         }
@@ -173,14 +188,7 @@ impl<F: LurkField> Num<F> {
         match (self, other) {
             (Num::U64(s), Num::U64(other)) => s < &other,
             (Num::Scalar(s), Num::Scalar(other)) => Num::Scalar(*s - other).is_negative(),
-            (a, b) => Num::Scalar(a.into_scalar()).is_less_than(Num::Scalar(b.into_scalar())),
-        }
-    }
-
-    pub fn is_equal(&self, other: Num<F>) -> bool {
-        match (self, other) {
-            (Num::U64(s), Num::U64(other)) => s == &other,
-            (a, b) => a.into_scalar() == b.into_scalar(),
+            (a, b) => Num::Scalar(a.into_scalar()) < Num::Scalar(b.into_scalar()),
         }
     }
 

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use crate::field::LurkField;
 
 use crate::store::{Op1, Op2, Pointer, Ptr, ScalarContPtr, ScalarPtr, Store, Tag};
-use crate::Num;
+use crate::{Num, UInt};
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -90,6 +90,7 @@ impl<'a, F: LurkField> ScalarStore<F> {
             ScalarExpression::Str(_) => None,
             ScalarExpression::Thunk(_) => None,
             ScalarExpression::Char(_) => None,
+            ScalarExpression::UInt(_) => None,
         }
     }
 
@@ -191,6 +192,7 @@ impl<'a, F: LurkField> ScalarExpression<F> {
                 .fetch_str(ptr)
                 .map(|str| ScalarExpression::Str(str.to_string())),
             Tag::Char => store.fetch_char(ptr).map(ScalarExpression::Char),
+            Tag::U64 => store.fetch_uint(ptr).map(ScalarExpression::UInt),
             Tag::Thunk => unimplemented!(),
         }
     }
@@ -211,6 +213,7 @@ pub enum ScalarExpression<F: LurkField> {
     Str(String),
     Thunk(ScalarThunk<F>),
     Char(char),
+    UInt(UInt),
 }
 
 impl<'a, F: LurkField> Default for ScalarExpression<F> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -662,6 +662,21 @@ impl Op2 {
     pub fn as_field<F: From<u64> + ff::Field>(&self) -> F {
         F::from(*self as u64)
     }
+
+    pub fn is_numeric(&self) -> bool {
+        matches!(
+            self,
+            Op2::Sum
+                | Op2::Diff
+                | Op2::Product
+                | Op2::Quotient
+                | Op2::Less
+                | Op2::Greater
+                | Op2::LessEqual
+                | Op2::GreaterEqual
+                | Op2::NumEqual
+        )
+    }
 }
 
 impl fmt::Display for Op2 {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::Display,
+    ops::{Add, Div, Mul, Rem, Sub},
+};
+
+/// Unsigned fixed-width integer type for Lurk.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Serialize, Deserialize)]
+pub enum UInt {
+    U64(u64),
+}
+
+impl UInt {
+    pub fn is_zero(&self) -> bool {
+        match self {
+            UInt::U64(n) => *n == 0,
+        }
+    }
+}
+
+impl From<u64> for UInt {
+    fn from(n: u64) -> Self {
+        Self::U64(n)
+    }
+}
+
+impl From<UInt> for u64 {
+    fn from(u: UInt) -> u64 {
+        match u {
+            UInt::U64(n) => n,
+        }
+    }
+}
+
+impl Display for UInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UInt::U64(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+impl Add for UInt {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        match (self, other) {
+            (UInt::U64(a), UInt::U64(b)) => UInt::U64(unsafe { a.unchecked_add(b) }),
+        }
+    }
+}
+
+impl Sub for UInt {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        match (self, other) {
+            (UInt::U64(a), UInt::U64(b)) => UInt::U64(unsafe { a.unchecked_sub(b) }),
+        }
+    }
+}
+impl Div for UInt {
+    type Output = Self;
+    fn div(self, other: Self) -> Self {
+        match (self, other) {
+            (UInt::U64(a), UInt::U64(b)) => UInt::U64(a / b),
+        }
+    }
+}
+impl Mul for UInt {
+    type Output = Self;
+    fn mul(self, other: Self) -> Self {
+        match (self, other) {
+            (UInt::U64(a), UInt::U64(b)) => UInt::U64(unsafe { a.unchecked_mul(b) }),
+        }
+    }
+}
+impl Rem for UInt {
+    type Output = Self;
+    fn rem(self, other: Self) -> Self {
+        match (self, other) {
+            (UInt::U64(a), UInt::U64(b)) => UInt::U64(a % b),
+        }
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -100,6 +100,7 @@ impl<F: LurkField> Write<F> for Expression<'_, F> {
             Char(c) => {
                 write!(w, "#\\{}", c)
             }
+            UInt(n) => write!(w, "{}u64", n),
         }
     }
 }


### PR DESCRIPTION
This PR adds support for fixed-width (64-bit) unsigned integers. With an eye to potential future work, it defines a general `UInt` enum, of which `UInt::U64` is the only initial variant.

Arithmetic behaves as though `mod 2^64`. Division is 'integer division'.

Literal `U64`s are denoted with a suffix, either `u64` or `U64` directly following a valid number. It is a reader/parser error to specify a `U64` from a number greater than the maximum `U64`.

The `num` operator coerces `U64` to `Num`, with no loss of precision.

The `u64` operator coerces `Num` to `U64`, preserving only the least-significant 8 bytes.

Arithmetic operations that mix `U64` and `Num` yield `Num`s and are performed by first coercing the `U64` to `Num`.

The `u64` suffix cannot be combined with negative or fractional notation.






