### PR TITLE
Support modulo operator for u64.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -480,7 +480,7 @@ impl<F: LurkField> Store<F> {
 fn is_symbol_char(c: &char, initial: bool) -> bool {
     match c {
         // FIXME: suppport more than just alpha.
-        'a'..='z' | 'A'..='Z' | '+' | '-' | '*' | '/' | '=' | '<' | '>' | ':' | '_' => true,
+        'a'..='z' | 'A'..='Z' | '+' | '-' | '*' | '/' | '%' | '=' | '<' | '>' | ':' | '_' => true,
         _ => {
             if initial {
                 false

--- a/src/store.rs
+++ b/src/store.rs
@@ -638,6 +638,7 @@ pub enum Op2 {
     StrCons,
     Begin,
     Hide,
+    Modulo,
 }
 
 impl Op2 {
@@ -656,6 +657,7 @@ impl Op2 {
             x if x == Op2::Cons as u16 => Some(Op2::Cons),
             x if x == Op2::Begin as u16 => Some(Op2::Begin),
             x if x == Op2::Hide as u16 => Some(Op2::Hide),
+            x if x == Op2::Modulo as u16 => Some(Op2::Modulo),
             _ => None,
         }
     }
@@ -675,6 +677,7 @@ impl Op2 {
                 | Op2::LessEqual
                 | Op2::GreaterEqual
                 | Op2::NumEqual
+                | Op2::Modulo
         )
     }
 }
@@ -696,6 +699,7 @@ impl fmt::Display for Op2 {
             Op2::StrCons => write!(f, "StrCons"),
             Op2::Begin => write!(f, "Begin"),
             Op2::Hide => write!(f, "Hide"),
+            Op2::Modulo => write!(f, "Modulo"),
         }
     }
 }


### PR DESCRIPTION
Now that we have `U64`, supporting mod is easy. The implementation assumes that both args are `U64` and returns a `U64`.

This PR also adds some missing tests showing that it is an error to apply a numeric operator to a non-numeric argument. These should be ported to the circuit, since explicit proof of error conditions needs to be tested.