### PR TITLE
Fix defaults length

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2636,12 +2636,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                     },
                 ],
             ],
-            &[
-                &g.default_num,
-                &g.default_num,
-                &g.default_num,
-                &g.default_num,
-            ],
+            &[&g.default_num, &g.default_num],
         )?;
 
         (AllocatedPtr::by_index(0, &res), unop_continuation)
@@ -2679,7 +2674,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         binop_components,
     );
 
-    let defaults = [
+    let preimage_defaults = [
+        &g.default_num,
+        &g.default_num,
         &g.default_num,
         &g.default_num,
         &g.default_num,
@@ -2706,7 +2703,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         &mut cs.namespace(|| "hash preimage selection"),
         cont.tag(),
         &all_hash_input_clauses,
-        &defaults,
+        &preimage_defaults,
     )?;
 
     // construct newer continuation from multicase results
@@ -3799,11 +3796,21 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         &results.make_thunk_num_clauses[..],
     ];
 
+    let apply_cont_defaults = [
+        &g.default_num,
+        &g.default_num,
+        &g.default_num,
+        &g.default_num,
+        &g.default_num,
+        &g.default_num,
+        &g.false_num,
+    ];
+
     let case_results = multi_case(
         &mut cs.namespace(|| "apply_continuation multicase"),
         cont.tag(),
         &all_clauses,
-        &defaults,
+        &apply_cont_defaults,
     )?;
 
     let result_expr = AllocatedPtr::by_index(0, &case_results);
@@ -4146,9 +4153,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(20443, cs.num_constraints());
+            assert_eq!(20461, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(20358, cs.aux().len());
+            assert_eq!(20378, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/gadgets/case.rs
+++ b/src/circuit/gadgets/case.rs
@@ -368,11 +368,13 @@ mod tests {
                 value: &val0,
             }];
 
+        let default_chosen =
+            AllocatedNum::alloc(cs.namespace(|| "default chosen"), || Ok(Fr::from(999))).unwrap();
             let result = case(
                 &mut cs.namespace(|| "default case"),
                 &selected,
                 &clauses,
-                &default,
+                &default_chosen,
             )
             .unwrap();
 

--- a/src/circuit/gadgets/case.rs
+++ b/src/circuit/gadgets/case.rs
@@ -368,8 +368,9 @@ mod tests {
                 value: &val0,
             }];
 
-        let default_chosen =
-            AllocatedNum::alloc(cs.namespace(|| "default chosen"), || Ok(Fr::from(999))).unwrap();
+            let default_chosen =
+                AllocatedNum::alloc(cs.namespace(|| "default chosen"), || Ok(Fr::from(999)))
+                    .unwrap();
             let result = case(
                 &mut cs.namespace(|| "default case"),
                 &selected,

--- a/src/circuit/gadgets/case.rs
+++ b/src/circuit/gadgets/case.rs
@@ -280,6 +280,7 @@ pub fn multi_case_aux<F: PrimeField, CS: ConstraintSystem<F>>(
         (selector, is_default)
     };
 
+    assert_eq!(cases.len(), defaults.len());
     // Now that we constrained the selector, we can constrain the selection
     // of the corresponding values in next clauses
     // 1..n


### PR DESCRIPTION
For all multi_case gadgets, the size of defaults must be equal to the number of cases. We added an `assert_eq!` to guarantee this condition. 

It allowed us to find 2 places where this condition didn't hold. This PR fixes this problem. 