### PR TITLE
Improve equality testing.

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1362,7 +1362,7 @@ fn apply_continuation<F: LurkField>(
                         store.strcons(evaled_arg, *arg2)
                     }
                     _ => match operator {
-                        Op2::Equal => store.as_lurk_boolean(store.ptr_eq(&evaled_arg, arg2)),
+                        Op2::Equal => store.as_lurk_boolean(store.ptr_eq(&evaled_arg, arg2)?),
                         Op2::Cons => store.cons(evaled_arg, *arg2),
                         Op2::Eval => {
                             return Ok(Control::Return(evaled_arg, *arg2, continuation));
@@ -1761,10 +1761,10 @@ mod test {
                 &expected_result.fmt_to_string(&s),
                 &new_expr.fmt_to_string(&s),
             );
-            assert!(s.ptr_eq(&expected_result, &new_expr));
+            assert!(s.ptr_eq(&expected_result, &new_expr).unwrap());
         }
         if let Some(expected_env) = expected_env {
-            assert!(s.ptr_eq(&expected_env, &new_env));
+            assert!(s.ptr_eq(&expected_env, &new_env).unwrap());
         }
         if let Some(expected_cont) = expected_cont {
             assert_eq!(expected_cont, new_cont);
@@ -1777,7 +1777,7 @@ mod test {
             assert!(expected_emitted
                 .iter()
                 .zip(emitted)
-                .all(|(a, b)| s.ptr_eq(a, &b)));
+                .all(|(a, b)| s.ptr_eq(a, &b).unwrap()));
         }
         assert_eq!(expected_iterations, iterations);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -603,7 +603,7 @@ asdf(", "ASDF",
             let mut store = Store::<Fr>::default();
             let expr = store.read(input).unwrap();
             let expected = store.intern_num(expected);
-            assert!(store.ptr_eq(&expected, &expr));
+            assert!(store.ptr_eq(&expected, &expr).unwrap());
         };
         test("123", 123);
         test("0987654321", 987654321);
@@ -621,7 +621,7 @@ asdf(", "ASDF",
             let mut store = Store::<Fr>::default();
             let expr = store.read(input).unwrap();
             let expected = store.intern_num(crate::num::Num::from_scalar(expected));
-            assert!(store.ptr_eq(&expected, &expr));
+            assert!(store.ptr_eq(&expected, &expr).unwrap());
         };
         test("0x10", Fr::from(16));
         test("0x22", Fr::from(34));
@@ -658,7 +658,7 @@ asdf(", "ASDF",
             let a_num = store.read(a).unwrap();
             let b_num = store.read(b).unwrap();
             dbg!(a_num.fmt_to_string(&store), b_num.fmt_to_string(&store));
-            assert!(store.ptr_eq(&a_num, &b_num));
+            assert!(store.ptr_eq(&a_num, &b_num).unwrap());
         };
 
         test("18446744073709551616", "0x10000000000000000");
@@ -695,7 +695,7 @@ asdf(", "ASDF",
             let mut store = Store::<Fr>::default();
             let expr = store.read(input).unwrap();
             let expected = store.get_u64(expected);
-            assert!(store.ptr_eq(&expected, &expr));
+            assert!(store.ptr_eq(&expected, &expr).unwrap());
         };
 
         test("123u64", 123);
@@ -941,7 +941,7 @@ asdf(", "ASDF",
         let test = |store: &mut Store<Fr>, a: &str, b: &str| {
             let res_a = store.read(a).unwrap();
             let res_b = store.read(b).unwrap();
-            assert!(store.ptr_eq(&res_a, &res_b));
+            assert!(store.ptr_eq(&res_a, &res_b).unwrap());
         };
         // These tests demonstrate that '/' behaves like other arithmetic operators
         // when a fraction is not being parsed.

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -379,7 +379,9 @@ mod tests {
                 // all the padding logic required for SnarkPack. It might be nice to eventually refactor such taht it does,
                 // in which case this check will be useful. So let's leave it around for now.
                 // assert_eq!(adjusted_iterations, cs.len());
-                assert_eq!(expected_result, cs[cs.len() - 1].0.output.unwrap().expr);
+                assert!(s
+                    .ptr_eq(&expected_result, &cs[cs.len() - 1].0.output.unwrap().expr)
+                    .unwrap());
             }
 
             let constraint_systems_verified = verify_sequential_css::<Scalar>(&cs).unwrap();

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -366,7 +366,6 @@ mod tests {
         let mut previous_frame: Option<MultiFrame<Fr, IO<Fr>, Witness<Fr>>> = None;
 
         let mut cs_blank = MetricCS::<Fr>::new();
-        let store = Store::<Fr>::default();
 
         let blank = MultiFrame::<Fr, IO<Fr>, Witness<Fr>>::blank(chunk_frame_count);
         blank
@@ -400,10 +399,10 @@ mod tests {
         }
 
         if let Some(expected_result) = expected_result {
-            assert!(store.ptr_eq(&expected_result, &output.expr));
+            assert!(s.ptr_eq(&expected_result, &output.expr).unwrap());
         }
         if let Some(expected_env) = expected_env {
-            assert!(store.ptr_eq(&expected_env, &output.env));
+            assert!(s.ptr_eq(&expected_env, &output.env).unwrap());
         }
         if let Some(expected_cont) = expected_cont {
             assert_eq!(expected_cont, output.cont);
@@ -424,6 +423,17 @@ mod tests {
     fn test_outer_prove_binop() {
         let s = &mut Store::<Fr>::default();
         let expected = s.num(3);
+        let terminal = s.get_cont_terminal();
+        nova_test_aux(s, "(+ 1 2)", Some(expected), None, Some(terminal), None, 3);
+    }
+
+    #[test]
+    #[should_panic]
+    // This tests the testing mechanism. Since the supplied expected value is wrong,
+    // the test should panic on an assertion failure.
+    fn test_outer_prove_binop_fail() {
+        let s = &mut Store::<Fr>::default();
+        let expected = s.num(2);
         let terminal = s.get_cont_terminal();
         nova_test_aux(s, "(+ 1 2)", Some(expected), None, Some(terminal), None, 3);
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -308,7 +308,7 @@ impl<F: LurkField> ReplState<F> {
                                 assert!(rest.is_nil());
                                 let (first_evaled, _, _, _) = self.eval_expr(first, store);
                                 let (second_evaled, _, _, _) = self.eval_expr(second, store);
-                                assert!(store.ptr_eq(&first_evaled, &second_evaled));
+                                assert!(store.ptr_eq(&first_evaled, &second_evaled)?);
                             } else if s == &":ASSERT" {
                                 let (first, rest) = store.car_cdr(&rest);
                                 assert!(rest.is_nil());

--- a/src/store.rs
+++ b/src/store.rs
@@ -1415,7 +1415,6 @@ impl<F: LurkField> Store<F> {
             }
             Num::U64(_) => num,
         };
-
         let (ptr, _) = self.num_store.insert_full(num);
 
         Ptr(Tag::Num, RawPtr::new(ptr))
@@ -1968,6 +1967,7 @@ impl<F: LurkField> Store<F> {
     // and the 'get' versions of hash_cons, hash_sym, etc.
     pub fn get_expr_hash(&self, ptr: &Ptr<F>) -> Option<ScalarPtr<F>> {
         use Tag::*;
+
         match ptr.tag() {
             Nil => self.get_hash_nil(),
             Cons => self.get_hash_cons(*ptr),
@@ -2569,10 +2569,15 @@ impl<F: LurkField> Store<F> {
         RawPtr((p, true), Default::default())
     }
 
-    pub fn ptr_eq(&self, a: &Ptr<F>, b: &Ptr<F>) -> bool {
+    pub fn ptr_eq(&self, a: &Ptr<F>, b: &Ptr<F>) -> Result<bool, LurkError> {
         // In order to compare Ptrs, we *must* resolve the hashes. Otherwise, we risk failing to recognize equality of
         // compound data with opaque data in either element's transitive closure.
-        self.get_expr_hash(a) == self.get_expr_hash(b)
+        match (self.get_expr_hash(a), self.get_expr_hash(b)) {
+            (Some(a_hash), Some(b_hash)) => Ok(a.0 == b.0 && a_hash == b_hash),
+            _ => Err(LurkError::Store(
+                "one or more values missing when comparing Ptrs for equality".into(),
+            )),
+        }
     }
 
     pub fn cons_eq(&self, a: &Ptr<F>, b: &Ptr<F>) -> bool {


### PR DESCRIPTION
There was a bug in the tests, such that an empty store was being used to check output values. On top of that, equality tests were returning `true` when neither value was in the store. So the equality checks in those proof tests (in `nova.rs`) were always succeeding.

This PR fixes the tests and the underlying equality test by:
- Making `ptr_eq()` return a `Result`, with an error if either `Ptr` is missing from the store.
- Checking tag equality in `ptr_eq()`.
- *Not* mistakenly creating and using a new empty store (!?) in the nova tests.
- Using `ptr_eq` (rather than Rust equality checking) in the Groth16 tests.

It also adds a test which would have failed with the previous code. Specifically, we now check that a test which passes the wrong expected value to the helper function indeed fails (checked with `#[should_panic]`).

