### PR TITLE
Allow '?' in symbols to enable predicate names like 'odd?'

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -651,7 +651,7 @@ pub fn names_keyword(name: &str) -> (bool, &str) {
 fn is_symbol_char(c: &char, initial: bool) -> bool {
     match c {
         c if is_initial_symbol_marker(c) => initial,
-        'a'..='z' | 'A'..='Z' | '+' | '-' | '*' | '/' | '%' | '=' | '<' | '>' | '_' => true,
+        'a'..='z' | 'A'..='Z' | '+' | '-' | '*' | '/' | '%' | '=' | '<' | '>' | '_' | '?' => true,
         _ => {
             if initial {
                 false


### PR DESCRIPTION
There's several possible conventions for predicate names, and appending a `?` is one of them, which needs this change to allow.