### PR TITLE
Only print the welcome message when running actual REPL

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -73,7 +73,9 @@ impl<F: LurkField> Repl<F> {
 
 // For the moment, input must be on a single line.
 pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
-    println!("Lurk REPL welcomes you.");
+    if lurk_file.is_none() {
+        println!("Lurk REPL welcomes you.");
+    }
 
     let mut s = Store::<F>::default();
     let limit = 100_000_000;


### PR DESCRIPTION
When running from a file, it's a non-interactive mode, so no need to print the REPL welcome message (there is no REPL).

```
~/workspace/lurk-rs $ cargo run ../lurk-lib/foo.lurk
    Finished dev [unoptimized + debuginfo] target(s) in 0.84s
     Running `target/debug/lurkrs ../lurk-lib/foo.lurk`
Running from ../lurk-lib/foo.lurk.
Read from ../lurk-lib/foo.lurk: (let ((foo (lambda () "foo")))
  (current-env))


[3 iterations] => ((FOO . <FUNCTION () "foo">))

~/workspace/lurk-rs $ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/lurkrs`
Lurk REPL welcomes you.
> "foo"
[1 iterations] => "foo"
> Exiting...
~/workspace/lurk-rs $ 
```