### PR TITLE
Don't swallow parsing errors when reading from file

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -278,6 +278,7 @@ impl<F: LurkField> ReplState<F> {
                 store,
                 &mut chars,
                 package,
+                // use this file's dir as pwd for further loading
                 file_path.as_ref().parent().unwrap(),
                 update_env,
             ) {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -271,13 +271,12 @@ impl<F: LurkField> ReplState<F> {
 
         loop {
             if let Err(e) = self.handle_form(store, &mut chars, package, p, update_env) {
-                if let Some(pe) = e.downcast_ref::<ParserError>() {
-                    if let ParserError::NoInput = pe {
-                        // It's ok, it just means we've hit the EOF
-                        return Ok(());
-                    }
+                if let Some(ParserError::NoInput) = e.downcast_ref::<ParserError>() {
+                    // It's ok, it just means we've hit the EOF
+                    return Ok(());
+                } else {
+                    return Err(e);
                 }
-                return Err(e);
             }
         }
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -274,7 +274,13 @@ impl<F: LurkField> ReplState<F> {
         let mut chars = input.chars().peekmore();
 
         loop {
-            if let Err(e) = self.handle_form(store, &mut chars, package, file_path, update_env) {
+            if let Err(e) = self.handle_form(
+                store,
+                &mut chars,
+                package,
+                file_path.as_ref().parent().unwrap(),
+                update_env,
+            ) {
                 if let Some(ParserError::NoInput) = e.downcast_ref::<ParserError>() {
                     // It's ok, it just means we've hit the EOF
                     return Ok(());

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -270,18 +270,14 @@ impl<F: LurkField> ReplState<F> {
         let mut chars = input.chars().peekmore();
 
         loop {
-            let result = self.handle_form(store, &mut chars, package, p, update_env);
-            if let Err(e) = result {
+            if let Err(e) = self.handle_form(store, &mut chars, package, p, update_env) {
                 if let Some(pe) = e.downcast_ref::<ParserError>() {
                     if let ParserError::NoInput = pe {
                         // It's ok, it just means we've hit the EOF
                         return Ok(());
-                    } else {
-                        return Err(e);
                     }
-                } else {
-                    return Err(e);
                 }
+                return Err(e);
             }
         }
     }


### PR DESCRIPTION
When loading a file, if there's a parse error, return it instead of returning Ok. The exception is `ParserError::NoInput` which is what we expect at EOF. If we get that, just return `Ok`.

To reproduce:

* put some bad input in a file called `foo.lurk` (I just put one double-quote character in it, so parsing will fail).
* `cargo run foo.lurk`

You'll get empty output and lurkrs returns 0 exit code as if the run was successful. I stumbled upon this when I had a typo in one of my files, it looked like it executed but it actually had just swallowed the error.