### PR TITLE
Fix call to handle_form to pass dir and not file path

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -195,9 +195,9 @@ impl<F: LurkField> ReplState<F> {
                             "LOAD" => match store.read_string(&mut chars) {
                                 Ok(s) => match s.tag() {
                                     Tag::Str => {
-                                        let path = store.fetch(&s).unwrap();
-                                        let path = PathBuf::from(path.as_str().unwrap());
-                                        self.handle_load(store, path, package)?;
+                                        let file_path = store.fetch(&s).unwrap();
+                                        let file_path = PathBuf::from(file_path.as_str().unwrap());
+                                        self.handle_load(store, file_path, package)?;
                                         (true, true)
                                     }
                                     other => {
@@ -211,9 +211,9 @@ impl<F: LurkField> ReplState<F> {
                             "RUN" => {
                                 if let Ok(s) = store.read_string(&mut chars) {
                                     if s.tag() == Tag::Str {
-                                        let path = store.fetch(&s).unwrap();
-                                        let path = PathBuf::from(path.as_str().unwrap());
-                                        self.handle_run(store, &path, package)?;
+                                        let file_path = store.fetch(&s).unwrap();
+                                        let file_path = PathBuf::from(file_path.as_str().unwrap());
+                                        self.handle_run(store, &file_path, package)?;
                                     }
                                 }
                                 (true, true)
@@ -239,38 +239,49 @@ impl<F: LurkField> ReplState<F> {
     pub fn handle_load<P: AsRef<Path>>(
         &mut self,
         store: &mut Store<F>,
-        path: P,
+        file_path: P,
         package: &Package,
     ) -> Result<()> {
-        println!("Loading from {}.", path.as_ref().to_str().unwrap());
-        self.handle_file(store, path.as_ref(), package, true)
+        println!("Loading from {}.", file_path.as_ref().to_str().unwrap());
+        self.handle_file(store, file_path.as_ref(), package, true)
     }
 
     pub fn handle_run<P: AsRef<Path> + Copy>(
         &mut self,
         store: &mut Store<F>,
-        path: P,
+        file_path: P,
         package: &Package,
     ) -> Result<()> {
-        println!("Running from {}.", path.as_ref().to_str().unwrap());
-        self.handle_file(store, path, package, false)
+        println!("Running from {}.", file_path.as_ref().to_str().unwrap());
+        self.handle_file(store, file_path, package, false)
     }
 
     pub fn handle_file<P: AsRef<Path> + Copy>(
         &mut self,
         store: &mut Store<F>,
-        path: P,
+        file_path: P,
         package: &Package,
         update_env: bool,
     ) -> Result<()> {
-        let p = path;
+        let file_path = file_path;
 
-        let input = read_to_string(path)?;
-        println!("Read from {}: {}", path.as_ref().to_str().unwrap(), input);
+        let input = read_to_string(file_path)?;
+        println!(
+            "Read from {}: {}",
+            file_path.as_ref().to_str().unwrap(),
+            input
+        );
         let mut chars = input.chars().peekmore();
 
         while self
-            .handle_form(store, &mut chars, package, p, update_env)
+            .handle_form(
+                store,
+                &mut chars,
+                package,
+                // use this file's dir as pwd for further loading
+                file_path.as_ref().parent().unwrap(),
+                update_env,
+            )
             .is_ok()
         {}
 
@@ -282,14 +293,14 @@ impl<F: LurkField> ReplState<F> {
         store: &mut Store<F>,
         chars: &mut peekmore::PeekMoreIterator<T>,
         package: &Package,
-        p: P,
+        pwd: P,
         update_env: bool,
     ) -> Result<()> {
         let (ptr, is_meta) = store.read_maybe_meta(chars, package)?;
 
         if is_meta {
-            let p: &Path = p.as_ref();
-            self.handle_meta(store, ptr, package, p)
+            let pwd: &Path = pwd.as_ref();
+            self.handle_meta(store, ptr, package, pwd)
         } else {
             self.handle_non_meta(store, ptr, update_env)
         }


### PR DESCRIPTION
Also make variable names more specific, to avoid further confusion.

The problem was detected in the CI tests for another PR, see #194. 

We get
```
Lurk REPL welcomes you.
Running from lurk-lib/example/test.lurk.
Read from lurk-lib/example/test.lurk: !(:load "lib.lurk")

!(:assert-eq (square 8) 64)

!(:assert-eq (square 9) 81)

!(:assert (eq (square 10) 100))


Loading from lurk-lib/example/test.lurk/lib.lurk.
thread 'lurk_tests' panicked at 'called `Result::unwrap()` on an `Err` value: Not a directory (os error 20)
```

Note the `Loading from lurk-lib/example/test.lurk/lib.lurk` - we forgot to drop the filename part of the path before continuing to handle forms. `test.lurk` is the name of the current file, and `lib.lurk` is the one being loaded.

I am not sure though, why CI tests did not start failing earlier.