### PR TITLE
Optimize circuit by minimizing Cons hashes.

### DIFF
--- a/fcomm/tests/proof_tests.rs
+++ b/fcomm/tests/proof_tests.rs
@@ -286,7 +286,6 @@ fn test_create_open_and_verify_chained_functional_commitment() {
 
 #[test]
 #[ignore]
-#[allow(dead_code)]
 fn test_create_open_and_verify_complicated_higher_order_functional_commitment1() {
     let function_source = "(let ((nums '(1 2 3 4 5))) (lambda (f) (f nums)))";
     let function_input = "(letrec ((sum-aux (lambda (acc nums)

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1058,8 +1058,7 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
         witness.as_ref().and_then(|w| w.closure_to_extend.as_ref()),
     )?;
 
-    let extended_env_not_dummy0 = and!(cs, &val2_is_fun, not_dummy)?;
-    let extended_env_not_dummy = and!(cs, &extended_env_not_dummy0, &v2_is_expr_real)?;
+    let extended_env_not_dummy = and!(cs, &val2_is_fun, not_dummy, &v2_is_expr_real)?;
     let extended_env = AllocatedPtr::construct_cons_named(
         &mut cs.namespace(|| "extended_env"),
         g,
@@ -1091,9 +1090,12 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
         smaller_rec_env.alloc_equal(&mut cs.namespace(|| "smaller_rec_env_is_nil"), &g.nil_ptr)?;
     let smaller_rec_env_not_nil = Boolean::not(&smaller_rec_env_is_nil);
 
-    let smaller_rec_env_not_dummy0 = and!(cs, &smaller_rec_env_not_nil, not_dummy)?;
-    let smaller_rec_env_not_dummy =
-        and!(cs, &smaller_rec_env_not_dummy0, &otherwise_and_v2_not_expr)?;
+    let smaller_rec_env_not_dummy = and!(
+        cs,
+        &smaller_rec_env_not_nil,
+        not_dummy,
+        &otherwise_and_v2_not_expr
+    )?;
 
     let with_smaller_rec_env = AllocatedPtr::construct_cons_named(
         &mut cs.namespace(|| "with_smaller_rec_env"),
@@ -1450,8 +1452,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
         let cdr_args_not_nil = Boolean::not(&cdr_args_is_nil);
 
-        let lambda_not_dummy0 = and!(cs, &head_is_lambda, not_dummy)?;
-        let lambda_not_dummy = and!(cs, &lambda_not_dummy0, &cdr_args_not_nil)?;
+        let lambda_not_dummy = and!(cs, &head_is_lambda, not_dummy, &cdr_args_not_nil)?;
 
         let arg = AllocatedPtr::pick(
             &mut cs.namespace(|| "maybe dummy arg"),

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -22,6 +22,7 @@ use super::gadgets::constraints::{
 };
 use crate::circuit::{gadgets::hashes::AllocatedHashWitness, ToInputs};
 use crate::eval::{Frame, Witness, IO};
+use crate::hash_witness::HashWitness;
 use crate::proof::Provable;
 use crate::store::{ContPtr, ContTag, Op1, Op2, Ptr, Store, Tag, Thunk};
 
@@ -200,7 +201,7 @@ impl<F: LurkField> CircuitFrame<'_, F, IO<F>, Witness<F>> {
         let mut reduce = |store| {
             let hash_witness = match self.witness.map(|x| x.hashes) {
                 Some(hw) => hw,
-                None => Default::default(),
+                None => HashWitness::new_blank(),
             };
             let allocated_hash_witness = AllocatedHashWitness::from_hash_witness(
                 &mut cs.namespace(|| format!("allocated_hash_witness {}", i)),

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -385,9 +385,6 @@ pub fn enforce_true<CS: ConstraintSystem<F>, F: PrimeField>(
     cs: CS,
     prop: &Boolean,
 ) -> Result<(), SynthesisError> {
-    // if let Some(val) = prop.get_value() {
-    //     debug_assert!(val);
-    // }
     Boolean::enforce_equal(cs, &Boolean::Constant(true), prop)
 }
 

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -295,7 +295,6 @@ impl<F: LurkField> GlobalAllocations<F> {
         defsym!(if_sym, "if");
         defsym!(current_env_sym, "current-env");
 
-        // cons strcons hide commit open secret num comm char begin car cdr atom emit + - * / % = eq < <= > >= if current-env
         let true_num = allocate_constant(&mut cs.namespace(|| "true"), F::one())?;
         let false_num = allocate_constant(&mut cs.namespace(|| "false"), F::zero())?;
         let default_num = allocate_constant(&mut cs.namespace(|| "default"), F::zero())?;

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -9,7 +9,9 @@ use neptune::{
 
 use super::pointer::AsAllocatedHashComponents;
 use crate::field::LurkField;
-use crate::store::{ContPtr, ContTag, Expression, Op1, Op2, Pointer, Ptr, Store, Tag, Thunk};
+use crate::store::{
+    ContPtr, ContTag, Expression, HashScalar, Op1, Op2, Pointer, Ptr, Store, Tag, Thunk,
+};
 use crate::store::{IntoHashComponents, ScalarPtr};
 use crate::store::{ScalarContPtr, ScalarPointer};
 
@@ -26,6 +28,7 @@ pub struct GlobalAllocations<F: LurkField> {
     pub t_ptr: AllocatedPtr<F>,
     pub lambda_ptr: AllocatedPtr<F>,
     pub dummy_arg_ptr: AllocatedPtr<F>,
+    pub empty_str_ptr: AllocatedPtr<F>,
 
     pub sym_tag: AllocatedNum<F>,
     pub thunk_tag: AllocatedNum<F>,
@@ -76,6 +79,39 @@ pub struct GlobalAllocations<F: LurkField> {
     pub op2_greater_tag: AllocatedNum<F>,
     pub op2_greater_equal_tag: AllocatedNum<F>,
 
+    pub lambda_sym: AllocatedPtr<F>,
+
+    pub let_sym: AllocatedPtr<F>,
+    pub letrec_sym: AllocatedPtr<F>,
+    pub eval_sym: AllocatedPtr<F>,
+    pub quote_sym: AllocatedPtr<F>,
+    pub cons_sym: AllocatedPtr<F>,
+    pub strcons_sym: AllocatedPtr<F>,
+    pub hide_sym: AllocatedPtr<F>,
+    pub commit_sym: AllocatedPtr<F>,
+    pub open_sym: AllocatedPtr<F>,
+    pub secret_sym: AllocatedPtr<F>,
+    pub num_sym: AllocatedPtr<F>,
+    pub comm_sym: AllocatedPtr<F>,
+    pub char_sym: AllocatedPtr<F>,
+    pub begin_sym: AllocatedPtr<F>,
+    pub car_sym: AllocatedPtr<F>,
+    pub cdr_sym: AllocatedPtr<F>,
+    pub atom_sym: AllocatedPtr<F>,
+    pub emit_sym: AllocatedPtr<F>,
+    pub plus_sym: AllocatedPtr<F>,
+    pub minus_sym: AllocatedPtr<F>,
+    pub times_sym: AllocatedPtr<F>,
+    pub div_sym: AllocatedPtr<F>,
+    pub equal_sym: AllocatedPtr<F>,
+    pub eq_sym: AllocatedPtr<F>,
+    pub less_sym: AllocatedPtr<F>,
+    pub less_equal_sym: AllocatedPtr<F>,
+    pub greater_sym: AllocatedPtr<F>,
+    pub greater_equal_sym: AllocatedPtr<F>,
+    pub if_sym: AllocatedPtr<F>,
+    pub current_env_sym: AllocatedPtr<F>,
+
     pub true_num: AllocatedNum<F>,
     pub false_num: AllocatedNum<F>,
     pub default_num: AllocatedNum<F>,
@@ -124,6 +160,12 @@ impl<F: LurkField> GlobalAllocations<F> {
             &mut cs.namespace(|| "_"),
             store,
             &store.get_lurk_sym("_", true).unwrap(),
+        )?;
+
+        let empty_str_ptr = AllocatedPtr::alloc_constant_ptr(
+            &mut cs.namespace(|| "empty_str_ptr"),
+            store,
+            &store.get_str("").unwrap(),
         )?;
 
         let sym_tag = Tag::Sym.allocate_constant(&mut cs.namespace(|| "sym_tag"))?;
@@ -201,6 +243,59 @@ impl<F: LurkField> GlobalAllocations<F> {
             Ok(Op2::Equal.as_field())
         })?;
 
+        let hash_sym = |name: &str| {
+            store
+                .get_lurk_sym(name, true)
+                .and_then(|s| store.hash_sym(s, HashScalar::Get))
+                .unwrap()
+        };
+
+        macro_rules! defsym {
+            ($var:ident, $name:expr) => {
+                let $var =
+                    AllocatedPtr::alloc_constant(&mut cs.namespace(|| $name), hash_sym($name))?;
+            };
+            ($var:ident, $name:expr, $namespace:expr) => {
+                let $var = AllocatedPtr::alloc_constant(
+                    &mut cs.namespace(|| $namespace),
+                    hash_sym($name),
+                )?;
+            };
+        }
+
+        defsym!(lambda_sym, "lambda");
+        defsym!(let_sym, "let");
+        defsym!(letrec_sym, "letrec");
+        defsym!(eval_sym, "eval");
+        defsym!(quote_sym, "quote");
+        defsym!(cons_sym, "cons");
+        defsym!(strcons_sym, "strcons");
+        defsym!(hide_sym, "hide");
+        defsym!(commit_sym, "commit");
+        defsym!(open_sym, "open");
+        defsym!(secret_sym, "secret");
+        defsym!(num_sym, "num");
+        defsym!(comm_sym, "comm");
+        defsym!(char_sym, "char");
+        defsym!(begin_sym, "begin");
+        defsym!(car_sym, "car");
+        defsym!(cdr_sym, "cdr");
+        defsym!(atom_sym, "atom");
+        defsym!(emit_sym, "emit");
+        defsym!(plus_sym, "+");
+        defsym!(minus_sym, "-");
+        defsym!(times_sym, "*");
+        defsym!(div_sym, "/", "div");
+        defsym!(equal_sym, "=");
+        defsym!(eq_sym, "eq");
+        defsym!(less_sym, "<");
+        defsym!(less_equal_sym, "<=");
+        defsym!(greater_sym, ">");
+        defsym!(greater_equal_sym, ">=");
+        defsym!(if_sym, "if");
+        defsym!(current_env_sym, "current-env");
+
+        // cons strcons hide commit open secret num comm char begin car cdr atom emit + - * / % = eq < <= > >= if current-env
         let true_num = allocate_constant(&mut cs.namespace(|| "true"), F::one())?;
         let false_num = allocate_constant(&mut cs.namespace(|| "false"), F::zero())?;
         let default_num = allocate_constant(&mut cs.namespace(|| "default"), F::zero())?;
@@ -215,6 +310,7 @@ impl<F: LurkField> GlobalAllocations<F> {
             t_ptr,
             lambda_ptr,
             dummy_arg_ptr,
+            empty_str_ptr,
             sym_tag,
             thunk_tag,
             cons_tag,
@@ -262,6 +358,37 @@ impl<F: LurkField> GlobalAllocations<F> {
             op2_less_equal_tag,
             op2_greater_tag,
             op2_greater_equal_tag,
+            lambda_sym,
+            let_sym,
+            letrec_sym,
+            eval_sym,
+            quote_sym,
+            cons_sym,
+            strcons_sym,
+            hide_sym,
+            commit_sym,
+            open_sym,
+            secret_sym,
+            num_sym,
+            comm_sym,
+            char_sym,
+            begin_sym,
+            car_sym,
+            cdr_sym,
+            atom_sym,
+            emit_sym,
+            plus_sym,
+            minus_sym,
+            times_sym,
+            div_sym,
+            equal_sym,
+            eq_sym,
+            less_sym,
+            less_equal_sym,
+            greater_sym,
+            greater_equal_sym,
+            if_sym,
+            current_env_sym,
             true_num,
             false_num,
             default_num,

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -1,0 +1,137 @@
+use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+
+use neptune::circuit2::poseidon_hash_allocated as poseidon_hash;
+
+use crate::circuit::gadgets::pointer::{AllocatedPtr, AsAllocatedHashComponents};
+
+use crate::field::LurkField;
+use crate::hash_witness::{ConsName, HashStub, HashWitness, MAX_CONSES_PER_REDUCTION};
+use crate::store::{HashConst, HashConstants, ScalarPointer, ScalarPtr, Store};
+
+pub struct AllocatedHash<F: LurkField> {
+    preimage: Vec<AllocatedPtr<F>>,
+    digest: AllocatedNum<F>,
+}
+
+pub struct AllocatedHashWitness<'a, F: LurkField> {
+    #[allow(dead_code)]
+    pub(crate) hash_witness: &'a HashWitness<F>, // Sometimes used for debugging.
+    slots: Vec<(Result<ConsName, ()>, AllocatedHash<F>)>,
+}
+
+impl<F: LurkField> AllocatedHash<F> {
+    fn alloc<CS: ConstraintSystem<F>>(
+        cs: &mut CS,
+        constants: &HashConstants<F>,
+        preimage: Vec<AllocatedPtr<F>>,
+    ) -> Result<AllocatedHash<F>, SynthesisError> {
+        let constants = constants.constants((2 * preimage.len()).into());
+
+        let pr: Vec<AllocatedNum<F>> = preimage
+            .iter()
+            .flat_map(|x| x.as_allocated_hash_components())
+            .cloned()
+            .collect();
+
+        let digest = constants.hash(cs, pr)?;
+
+        Ok(Self { preimage, digest })
+    }
+}
+
+impl<'a, F: LurkField> HashConst<'a, F> {
+    fn hash<CS: ConstraintSystem<F>>(
+        &self,
+        cs: &mut CS,
+        preimage: Vec<AllocatedNum<F>>,
+    ) -> Result<AllocatedNum<F>, SynthesisError> {
+        match self {
+            HashConst::A3(c) => poseidon_hash(cs, preimage, c),
+            HashConst::A4(c) => poseidon_hash(cs, preimage, c),
+            HashConst::A6(c) => poseidon_hash(cs, preimage, c),
+            HashConst::A8(c) => poseidon_hash(cs, preimage, c),
+        }
+    }
+}
+
+impl<'a, F: LurkField> AllocatedHashWitness<'a, F> {
+    pub fn from_hash_witness<CS: ConstraintSystem<F>>(
+        cs0: &mut CS,
+        s: &Store<F>,
+        hw: &'a HashWitness<F>,
+    ) -> Result<Self, SynthesisError> {
+        let mut slots = Vec::with_capacity(MAX_CONSES_PER_REDUCTION);
+        // FIXME:
+        // Then we need to ensure the correct ordering, and that get_cons called on missing names
+        // returns that name's consistent slot hash.
+        for (i, (name, p)) in hw.slots.iter().enumerate() {
+            let cs = &mut cs0.namespace(|| format!("slot-{}", i));
+
+            let (car_ptr, cdr_ptr, cons_hash) = match p {
+                HashStub::Dummy => (
+                    Some(ScalarPtr::from_parts(F::zero(), F::zero())),
+                    Some(ScalarPtr::from_parts(F::zero(), F::zero())),
+                    None,
+                ),
+                HashStub::Blank => (None, None, None),
+                HashStub::Value(hash) => (
+                    s.hash_expr(&hash.car),
+                    s.hash_expr(&hash.cdr),
+                    s.hash_expr(&hash.cons),
+                ),
+            };
+
+            let allocated_car =
+                AllocatedPtr::alloc(&mut cs.namespace(|| "car"), || match car_ptr {
+                    Some(p) => Ok(p),
+                    None => Err(SynthesisError::AssignmentMissing),
+                })?;
+
+            let allocated_cdr =
+                AllocatedPtr::alloc(&mut cs.namespace(|| "cdr"), || match cdr_ptr {
+                    Some(p) => Ok(p),
+                    None => Err(SynthesisError::AssignmentMissing),
+                })?;
+
+            let allocated_hash = AllocatedHash::alloc(
+                &mut cs.namespace(|| "cons"),
+                s.poseidon_constants(),
+                vec![allocated_car, allocated_cdr],
+            )?;
+
+            if cons_hash.is_some() {
+                slots.push((Ok(*name), allocated_hash));
+            } else {
+                slots.push((Err(()), allocated_hash));
+            }
+        }
+
+        Ok(Self {
+            hash_witness: hw,
+            slots,
+        })
+    }
+
+    pub fn get_cons(
+        &self,
+        name: ConsName,
+        expect_dummy: bool,
+    ) -> (&AllocatedPtr<F>, &AllocatedPtr<F>, &AllocatedNum<F>) {
+        let (allocated_name, allocated_hash) = &self.slots[name.index()];
+        if !expect_dummy {
+            match allocated_name {
+                Err(_) => panic!("requested {:?} but found a dummy allocation", name),
+                Ok(alloc_name) => assert_eq!(
+                    name, *alloc_name,
+                    "requested and allocated names don't match."
+                ),
+            };
+        }
+        assert_eq!(2, allocated_hash.preimage.len());
+        (
+            &allocated_hash.preimage[0],
+            &allocated_hash.preimage[1],
+            &allocated_hash.digest,
+        )
+    }
+}

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -61,9 +61,6 @@ impl<'a, F: LurkField> AllocatedHashWitness<'a, F> {
         hw: &'a HashWitness<F>,
     ) -> Result<Self, SynthesisError> {
         let mut slots = Vec::with_capacity(MAX_CONSES_PER_REDUCTION);
-        // FIXME:
-        // Then we need to ensure the correct ordering, and that get_cons called on missing names
-        // returns that name's consistent slot hash.
         for (i, (name, p)) in hw.slots.iter().enumerate() {
             let cs = &mut cs0.namespace(|| format!("slot-{}", i));
 

--- a/src/circuit/gadgets/macros.rs
+++ b/src/circuit/gadgets/macros.rs
@@ -115,7 +115,7 @@ macro_rules! implies_equal_t {
     };
 }
 
-// Returns a Boolean which is true if a and b are true.
+// Returns a Boolean which is true if all of its arguments are true.
 macro_rules! and {
     ($cs:ident, $a:expr, $b:expr) => {
         Boolean::and(
@@ -124,6 +124,17 @@ macro_rules! and {
             $b,
         )
     };
+
+    ($cs:ident, $a:expr, $($x:expr),+) => {{
+        // This namespace isn't necessarily unique, so some debugging/tuning could be required,
+        // if multiple `and!`s at the same level have the same first argument.
+        //
+        // If lack of explicit namespaces becomes an issue, we can add a new arg.
+        let and_tmp_cs_ =  &mut $cs.namespace(|| format!("{} and ", stringify!($a)));
+        let and_tmp_ = and!(and_tmp_cs_, $($x),*)?;
+        and!(and_tmp_cs_, $a, &and_tmp_)
+    }};
+
 }
 
 macro_rules! tag_and_hash_equal {
@@ -160,7 +171,7 @@ macro_rules! equal_t {
     }};
 }
 
-// Returns a Boolean which is true if a or b are true.
+// Returns a Boolean which is true if any of its arguments are true.
 macro_rules! or {
     ($cs:ident, $a:expr, $b:expr) => {
         or(
@@ -169,6 +180,16 @@ macro_rules! or {
             $b,
         )
     };
+    ($cs:ident, $a:expr, $($x:expr),+) => {{
+        // This namespace isn't necessarily unique, so some debugging/tuning could be required,
+        // if multiple `or!`s at the same level have the same first argument.
+        //
+        // If lack of explicit namespaces becomes an issue, we can add a new arg.
+
+        let or_tmp_cs_ =  &mut $cs.namespace(|| format!("or {}", stringify!($a)));
+        let or_tmp_ = or!(or_tmp_cs_, $($x),*)?;
+        or!(or_tmp_cs_, $a, &or_tmp_)
+    }};
 }
 
 // Enforce that x is true.

--- a/src/circuit/gadgets/mod.rs
+++ b/src/circuit/gadgets/mod.rs
@@ -4,4 +4,5 @@ pub mod macros;
 pub mod case;
 pub mod constraints;
 pub mod data;
+pub mod hashes;
 pub mod pointer;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -673,7 +673,6 @@ fn reduce_with_witness<F: LurkField>(
                                     body,
                                 );
                                 hash_witness.cons_named(ConsName::Expanded, store, head, expanded0)
-                                //store.cons(head, expanded0)
                             };
                             let cont = if head == store.lurk_sym("let") {
                                 store.intern_cont_let(var, expanded, env, cont)
@@ -973,8 +972,6 @@ fn reduce_with_witness<F: LurkField>(
     let control = apply_continuation(control, store, &mut witness)?;
     let ctrl = make_thunk(control, store, &mut witness)?;
 
-    // Why does this pass, when we need MAX_CONSES_PER_REDUCTION to be 11 to not hit the unreachable in hash_witness.rs?
-    // Some conses are seemingly getting lost somewhere.
     witness.hashes.assert_invariants(store);
 
     Ok((ctrl, witness))

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,5 +1,6 @@
 use crate::error::LurkError;
 use crate::field::LurkField;
+use crate::hash_witness::{ConsName, HashWitness};
 use crate::num::Num;
 use crate::store::{
     ContPtr, ContTag, Continuation, Expression, Op1, Op2, Pointer, Ptr, ScalarPointer, Store, Tag,
@@ -353,14 +354,13 @@ impl<'a, F: LurkField> Iterator for FrameIt<'a, Witness<F>, F> {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Witness<F: LurkField> {
-    // TODO: Many of these fields ended up not being used.
-    // once circuit is done, remove the excess.
     pub(crate) prethunk_output_expr: Ptr<F>,
     pub(crate) prethunk_output_env: Ptr<F>,
     pub(crate) prethunk_output_cont: ContPtr<F>,
 
-    pub(crate) extended_closure: Option<Ptr<F>>,
+    pub(crate) closure_to_extend: Option<Ptr<F>>,
     pub(crate) apply_continuation_cont: Option<ContPtr<F>>,
+    pub(crate) hashes: HashWitness<F>,
 }
 
 fn reduce<F: LurkField>(
@@ -416,7 +416,8 @@ fn reduce_with_witness<F: LurkField>(
     cont: ContPtr<F>,
     store: &mut Store<F>,
 ) -> Result<(Control<F>, Witness<F>), LurkError> {
-    let mut extended_closure = None;
+    let hash_witness = &mut HashWitness::<F>::default();
+    let mut closure_to_extend = None;
     let control = if cont.tag() == ContTag::Terminal {
         Control::Return(expr, env, cont)
     } else {
@@ -454,7 +455,8 @@ fn reduce_with_witness<F: LurkField>(
                         //     //assert!(!env.is_nil(), "Unbound variable: {:?}", expr);
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
-                        let (binding, smaller_env) = store.car_cdr(&env);
+                        let (binding, smaller_env) =
+                            hash_witness.car_cdr_named(ConsName::Env, store, &env);
                         if binding.is_nil() {
                             // If binding is NIL, it's empty. There is no match. Return an error due to unbound variable.
 
@@ -467,7 +469,9 @@ fn reduce_with_witness<F: LurkField>(
 
                             // CIRCUIT: binding_not_nil
                             //          otherwise_and_binding_not_nil
-                            let (var_or_rec_binding, val_or_more_rec_env) = store.car_cdr(&binding);
+                            let (var_or_rec_binding, val_or_more_rec_env) =
+                                hash_witness.car_cdr_named(ConsName::EnvCar, store, &binding);
+
                             match var_or_rec_binding.tag() {
                                 Tag::Sym => {
                                     // We are in a simple env (not a recursive env),
@@ -524,7 +528,12 @@ fn reduce_with_witness<F: LurkField>(
                                     let rec_env = binding;
                                     let smaller_rec_env = val_or_more_rec_env;
 
-                                    let (v2, val2) = store.car_cdr(&var_or_rec_binding);
+                                    let (v2, val2) = hash_witness.car_cdr_named(
+                                        ConsName::EnvCaar,
+                                        store,
+                                        &var_or_rec_binding,
+                                    );
+
                                     if v2 == expr {
                                         // CIRCUIT: v2_is_expr
                                         //          v2_is_expr_real
@@ -533,17 +542,21 @@ fn reduce_with_witness<F: LurkField>(
                                             // CIRCUIT: val_to_use
                                             match val2.tag() {
                                                 Tag::Fun => {
-                                                    // TODO: This is a misnomer. It's actually the closure *to be extended*.
-                                                    extended_closure = Some(val2);
+                                                    closure_to_extend = Some(val2);
                                                     // CIRCUIT: val2_is_fun
 
                                                     // We just found a closure in a recursive env.
                                                     // We need to extend its environment to include that recursive env.
 
-                                                    extend_closure(&val2, &rec_env, store)?
+                                                    extend_closure(
+                                                        &val2,
+                                                        &rec_env,
+                                                        store,
+                                                        hash_witness,
+                                                    )?
                                                 }
                                                 _ => {
-                                                    extended_closure = None;
+                                                    closure_to_extend = None;
                                                     val2
                                                 }
                                             }
@@ -558,7 +571,12 @@ fn reduce_with_witness<F: LurkField>(
                                             smaller_env
                                         } else {
                                             // CIRCUIT: with_smaller_rec_env
-                                            store.cons(smaller_rec_env, smaller_env)
+                                            hash_witness.cons_named(
+                                                ConsName::EnvToUse,
+                                                store,
+                                                smaller_rec_env,
+                                                smaller_env,
+                                            )
                                         };
                                         match cont.tag() {
                                             ContTag::Lookup => {
@@ -585,98 +603,88 @@ fn reduce_with_witness<F: LurkField>(
             }
             Tag::Cons => {
                 // This should not fail, since expr is a Cons.
-                let (head, rest) = store.car_cdr(&expr);
+                let (head, rest) = hash_witness.car_cdr_named(ConsName::Expr, store, &expr);
+
                 let lambda = store.lurk_sym("lambda");
                 let quote = store.lurk_sym("quote");
                 let dummy_arg = store.lurk_sym("_");
 
                 if head == lambda {
-                    let (args, body) = store.car_cdr(&rest);
+                    let (args, body) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     let (arg, _rest) = if args.is_nil() {
                         // (LAMBDA () STUFF)
                         // becomes (LAMBDA (DUMMY) STUFF)
                         (dummy_arg, store.nil())
                     } else {
-                        store.car_cdr(&args)
+                        hash_witness.car_cdr_named(ConsName::ExprCadr, store, &args)
                     };
-                    let cdr_args = store.cdr(&args);
+                    let (_, cdr_args) =
+                        hash_witness.car_cdr_named(ConsName::ExprCadr, store, &args);
                     let inner_body = if cdr_args.is_nil() {
                         body
                     } else {
                         // (LAMBDA (A B) STUFF)
                         // becomes (LAMBDA (A) (LAMBDA (B) STUFF))
-                        let inner = store.cons(cdr_args, body);
-                        let l = store.cons(lambda, inner);
-                        store.list(&[l])
+                        let inner =
+                            hash_witness.cons_named(ConsName::InnerLambda, store, cdr_args, body);
+                        let l = hash_witness.cons_named(ConsName::Lambda, store, lambda, inner);
+                        let nil = store.nil();
+                        hash_witness.cons_named(ConsName::InnerBody, store, l, nil)
                     };
                     let function = store.intern_fun(arg, inner_body, env);
 
                     Control::ApplyContinuation(function, env, cont)
                 } else if head == quote {
-                    let (quoted, end) = store.car_cdr(&rest);
+                    let (quoted, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::ApplyContinuation(quoted, env, cont)
                     }
-                } else if head == store.lurk_sym("let") {
-                    let (bindings, body) = store.car_cdr(&rest);
-                    let (body1, rest_body) = store.car_cdr(&body);
+                } else if head == store.lurk_sym("let") || head == store.lurk_sym("letrec") {
+                    let (bindings, body) =
+                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
+                    let (body1, rest_body) =
+                        hash_witness.car_cdr_named(ConsName::ExprCddr, store, &body);
                     // Only a single body form allowed for now.
                     if !rest_body.is_nil() || body.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else if bindings.is_nil() {
                         Control::Return(body1, env, cont)
                     } else {
-                        let (binding1, rest_bindings) = store.car_cdr(&bindings);
-                        let (var, vals) = store.car_cdr(&binding1);
-                        let (val, end) = store.car_cdr(&vals);
+                        let (binding1, rest_bindings) =
+                            hash_witness.car_cdr_named(ConsName::ExprCadr, store, &bindings);
+                        let (var, vals) =
+                            hash_witness.car_cdr_named(ConsName::ExprCaadr, store, &binding1);
+                        let (val, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCaaadr, store, &vals);
+
                         if !end.is_nil() {
                             Control::Return(expr, env, store.intern_cont_error())
                         } else {
                             let expanded = if rest_bindings.is_nil() {
                                 body1
                             } else {
-                                let lt = store.lurk_sym("let");
-                                store.list(&[lt, rest_bindings, body1])
+                                // We know body is a proper list equivalent to (body1), if this branch was taken, since end is nil.
+                                let expanded0 = hash_witness.cons_named(
+                                    ConsName::ExpandedInner,
+                                    store,
+                                    rest_bindings,
+                                    body,
+                                );
+                                hash_witness.cons_named(ConsName::Expanded, store, head, expanded0)
+                                //store.cons(head, expanded0)
                             };
-                            Control::Return(
-                                val,
-                                env,
-                                store.intern_cont_let(var, expanded, env, cont),
-                            )
-                        }
-                    }
-                } else if head == store.lurk_sym("letrec") {
-                    let (bindings, body) = store.car_cdr(&rest);
-                    let (body1, rest_body) = store.car_cdr(&body);
-                    // Only a single body form allowed for now.
-                    if !rest_body.is_nil() || body.is_nil() {
-                        Control::Return(expr, env, store.intern_cont_error())
-                    } else if bindings.is_nil() {
-                        Control::Return(body1, env, cont)
-                    } else {
-                        let (binding1, rest_bindings) = store.car_cdr(&bindings);
-                        let (var, vals) = store.car_cdr(&binding1);
-                        let (val, end) = store.car_cdr(&vals);
-                        if !end.is_nil() {
-                            Control::Return(expr, env, store.intern_cont_error())
-                        } else {
-                            let expanded = if rest_bindings.is_nil() {
-                                body1
+                            let cont = if head == store.lurk_sym("let") {
+                                store.intern_cont_let(var, expanded, env, cont)
                             } else {
-                                let lt = store.lurk_sym("letrec");
-                                store.list(&[lt, rest_bindings, body1])
+                                store.intern_cont_let_rec(var, expanded, env, cont)
                             };
-                            Control::Return(
-                                val,
-                                env,
-                                store.intern_cont_let_rec(var, expanded, env, cont),
-                            )
+                            Control::Return(val, env, cont)
                         }
                     }
                 } else if head == store.lurk_sym("cons") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if more.is_nil() {
                         Control::Return(arg1, env, store.intern_cont_error())
                     } else {
@@ -687,7 +695,7 @@ fn reduce_with_witness<F: LurkField>(
                         )
                     }
                 } else if head == store.lurk_sym("strcons") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if more.is_nil() {
                         Control::Return(arg1, env, store.intern_cont_error())
                     } else {
@@ -698,7 +706,7 @@ fn reduce_with_witness<F: LurkField>(
                         )
                     }
                 } else if head == store.lurk_sym("hide") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if more.is_nil() {
                         Control::Return(arg1, env, store.intern_cont_error())
                     } else {
@@ -709,7 +717,7 @@ fn reduce_with_witness<F: LurkField>(
                         )
                     }
                 } else if head == store.lurk_sym("begin") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if more.is_nil() {
                         Control::Return(arg1, env, cont)
                     } else {
@@ -720,80 +728,64 @@ fn reduce_with_witness<F: LurkField>(
                         )
                     }
                 } else if head == store.lurk_sym("car") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) =
+                        match hash_witness.car_cdr_mut_named(ConsName::ExprCdr, store, &rest) {
+                            Ok((car, cdr)) => (car, cdr),
+                            Err(e) => return Err(LurkError::Reduce(e)),
+                        };
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Car, cont))
                     }
                 } else if head == store.lurk_sym("cdr") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) =
+                        match hash_witness.car_cdr_mut_named(ConsName::ExprCdr, store, &rest) {
+                            Ok((car, cdr)) => (car, cdr),
+                            Err(e) => return Err(LurkError::Reduce(e)),
+                        };
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Cdr, cont))
                     }
                 } else if head == store.lurk_sym("commit") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Commit, cont))
                     }
                 } else if head == store.lurk_sym("num") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Num, cont))
                     }
                 } else if head == store.lurk_sym("u64") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::U64, cont))
                     }
                 } else if head == store.lurk_sym("comm") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Comm, cont))
                     }
                 } else if head == store.lurk_sym("char") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Char, cont))
                     }
                 } else if head == store.lurk_sym("eval") {
-                    let (arg1, more) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if more.is_nil() {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Eval, cont))
                     } else {
@@ -804,118 +796,113 @@ fn reduce_with_witness<F: LurkField>(
                         )
                     }
                 } else if head == store.lurk_sym("open") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Open, cont))
                     }
                 } else if head == store.lurk_sym("secret") {
-                    let (arg1, end) = match store.car_cdr_mut(&rest) {
-                        Ok((car, cdr)) => (car, cdr),
-                        Err(e) => return Err(LurkError::Reduce(e.into())),
-                    };
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Secret, cont))
                     }
                 } else if head == store.lurk_sym("atom") {
-                    let (arg1, end) = store.car_cdr(&rest);
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Atom, cont))
                     }
                 } else if head == store.lurk_sym("emit") {
-                    let (arg1, end) = store.car_cdr(&rest);
+                    let (arg1, end) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
                         Control::Return(arg1, env, store.intern_cont_unop(Op1::Emit, cont))
                     }
                 } else if head == store.lurk_sym("+") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::Sum, env, more, cont),
                     )
                 } else if head == store.lurk_sym("-") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::Diff, env, more, cont),
                     )
                 } else if head == store.lurk_sym("*") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::Product, env, more, cont),
                     )
                 } else if head == store.lurk_sym("/") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::Quotient, env, more, cont),
                     )
                 } else if head == store.lurk_sym("%") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::Modulo, env, more, cont),
                     )
                 } else if head == store.lurk_sym("=") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::NumEqual, env, more, cont),
                     )
                 } else if head == store.lurk_sym("eq") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::Equal, env, more, cont),
                     )
                 } else if head == store.lurk_sym("<") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::Less, env, more, cont),
                     )
                 } else if head == store.lurk_sym(">") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::Greater, env, more, cont),
                     )
                 } else if head == store.lurk_sym("<=") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::LessEqual, env, more, cont),
                     )
                 } else if head == store.lurk_sym(">=") {
-                    let (arg1, more) = store.car_cdr(&rest);
+                    let (arg1, more) = hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(
                         arg1,
                         env,
                         store.intern_cont_binop(Op2::GreaterEqual, env, more, cont),
                     )
                 } else if head == store.lurk_sym("if") {
-                    let (condition, more) = store.car_cdr(&rest);
+                    let (condition, more) =
+                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest);
                     Control::Return(condition, env, store.intern_cont_if(more, cont))
                 } else if head == store.lurk_sym("current-env") {
                     if !rest.is_nil() {
@@ -930,7 +917,8 @@ fn reduce_with_witness<F: LurkField>(
                     if args.is_nil() {
                         Control::Return(fun_form, env, store.intern_cont_call0(env, cont))
                     } else {
-                        let (arg, more_args) = store.car_cdr(&args);
+                        let (arg, more_args) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &args);
                         match more_args.tag() {
                             // (fn arg)
                             // Interpreting as call.
@@ -942,8 +930,25 @@ fn reduce_with_witness<F: LurkField>(
                             _ => {
                                 // Interpreting as multi-arg call.
                                 // (fn arg . more_args) => ((fn arg) . more_args)
-                                let expanded_inner = store.list(&[fun_form, arg]);
-                                let expanded = store.cons(expanded_inner, more_args);
+                                let nil = store.nil();
+                                let expanded_inner0 = hash_witness.cons_named(
+                                    ConsName::ExpandedInner0,
+                                    store,
+                                    arg,
+                                    nil,
+                                );
+                                let expanded_inner = hash_witness.cons_named(
+                                    ConsName::ExpandedInner,
+                                    store,
+                                    fun_form,
+                                    expanded_inner0,
+                                );
+                                let expanded = hash_witness.cons_named(
+                                    ConsName::FunExpanded,
+                                    store,
+                                    expanded_inner,
+                                    more_args,
+                                );
                                 Control::Return(expanded, env, cont)
                             }
                         }
@@ -960,12 +965,17 @@ fn reduce_with_witness<F: LurkField>(
         prethunk_output_env: *new_env,
         prethunk_output_cont: *new_cont,
 
-        extended_closure,
+        closure_to_extend,
         apply_continuation_cont: None,
+        hashes: *hash_witness,
     };
 
     let control = apply_continuation(control, store, &mut witness)?;
     let ctrl = make_thunk(control, store, &mut witness)?;
+
+    // Why does this pass, when we need MAX_CONSES_PER_REDUCTION to be 11 to not hit the unreachable in hash_witness.rs?
+    // Some conses are seemingly getting lost somewhere.
+    witness.hashes.assert_invariants(store);
 
     Ok((ctrl, witness))
 }
@@ -978,6 +988,8 @@ fn apply_continuation<F: LurkField>(
     if !control.is_apply_continuation() {
         return Ok(control);
     }
+
+    let hash_witness = &mut witness.hashes;
 
     let (result, env, cont) = control.as_results();
     witness.apply_continuation_cont = Some(*cont);
@@ -1009,7 +1021,8 @@ fn apply_continuation<F: LurkField>(
                 {
                     Expression::Fun(arg, body, closed_env) => {
                         if arg == store.lurk_sym("_") {
-                            let body_form = store.car(&body);
+                            let (body_form, _) =
+                                hash_witness.car_cdr_named(ConsName::FunBody, store, &body);
                             let cont = make_tail_continuation(saved_env, continuation, store);
 
                             Control::Return(body_form, closed_env, cont)
@@ -1065,8 +1078,15 @@ fn apply_continuation<F: LurkField>(
                         if arg == store.lurk_sym("_") {
                             return Ok(Control::Return(*result, *env, store.intern_cont_error()));
                         }
-                        let body_form = store.car(&body);
-                        let newer_env = extend(closed_env, arg, *result, store);
+                        let (body_form, _) =
+                            hash_witness.car_cdr_named(ConsName::FunBody, store, &body);
+                        let newer_env = hash_witness.extend_named(
+                            ConsName::ClosedEnv,
+                            closed_env,
+                            arg,
+                            *result,
+                            store,
+                        );
                         let cont = make_tail_continuation(saved_env, continuation, store);
                         Control::Return(body_form, newer_env, cont)
                     }
@@ -1089,7 +1109,8 @@ fn apply_continuation<F: LurkField>(
                 saved_env,
                 continuation,
             } => {
-                let extended_env = extend(*env, var, *result, store);
+                let extended_env =
+                    hash_witness.extend_named(ConsName::Env, *env, var, *result, store);
                 let c = make_tail_continuation(saved_env, continuation, store);
 
                 Control::Return(body, extended_env, c)
@@ -1106,7 +1127,8 @@ fn apply_continuation<F: LurkField>(
                 saved_env,
                 continuation,
             } => {
-                let extended_env = extend_rec(*env, var, *result, store);
+                let extended_env = extend_rec(*env, var, *result, store, witness);
+
                 let c = make_tail_continuation(saved_env, continuation, store);
 
                 Control::Return(body, extended_env?, c)
@@ -1122,19 +1144,33 @@ fn apply_continuation<F: LurkField>(
                 continuation,
             } => {
                 let val = match operator {
-                    Op1::Car => match store.car_cdr_mut(result) {
-                        Ok((car, _)) => car,
-                        //TODO: Replace with ControlError or StoreError
-                        Err(_) => {
-                            return Ok(Control::Return(*result, *env, store.intern_cont_error()))
-                        } //Err(_) => store.nil(),
-                    },
-                    Op1::Cdr => match store.car_cdr_mut(result) {
-                        Ok((_, cdr)) => cdr,
-                        Err(_) => {
-                            return Ok(Control::Return(*result, *env, store.intern_cont_error()))
+                    Op1::Car => {
+                        match hash_witness.car_cdr_mut_named(ConsName::UnopConsLike, store, result)
+                        {
+                            Ok((car, _)) => car,
+                            //TODO: Replace with ControlError or StoreError
+                            Err(_) => {
+                                return Ok(Control::Return(
+                                    *result,
+                                    *env,
+                                    store.intern_cont_error(),
+                                ))
+                            } //Err(_) => store.nil(),
                         }
-                    },
+                    }
+                    Op1::Cdr => {
+                        match hash_witness.car_cdr_mut_named(ConsName::UnopConsLike, store, result)
+                        {
+                            Ok((_, cdr)) => cdr,
+                            Err(_) => {
+                                return Ok(Control::Return(
+                                    *result,
+                                    *env,
+                                    store.intern_cont_error(),
+                                ))
+                            }
+                        }
+                    }
                     Op1::Atom => match result.tag() {
                         Tag::Cons => store.nil(),
                         _ => store.t(),
@@ -1231,13 +1267,15 @@ fn apply_continuation<F: LurkField>(
                 unevaled_args,
                 continuation,
             } => {
-                let (arg2, rest) = store.car_cdr(&unevaled_args);
+                let (arg2, rest) =
+                    hash_witness.car_cdr_named(ConsName::UnevaledArgs, store, &unevaled_args);
                 if operator == Op2::Begin {
                     if rest.is_nil() {
                         Control::Return(arg2, saved_env, continuation)
                     } else {
                         let begin = store.lurk_sym("begin");
-                        let begin_again = store.cons(begin, unevaled_args);
+                        let begin_again =
+                            hash_witness.cons_named(ConsName::Begin, store, begin, unevaled_args);
                         Control::Return(begin_again, saved_env, continuation)
                     }
                 } else if !rest.is_nil() {
@@ -1364,11 +1402,13 @@ fn apply_continuation<F: LurkField>(
                     (Expression::Char(_), Expression::Str(_))
                         if matches!(operator, Op2::StrCons) =>
                     {
-                        store.strcons(evaled_arg, *arg2)
+                        hash_witness.strcons_named(ConsName::TheCons, store, evaled_arg, *arg2)
                     }
                     _ => match operator {
                         Op2::Equal => store.as_lurk_boolean(store.ptr_eq(&evaled_arg, arg2)?),
-                        Op2::Cons => store.cons(evaled_arg, *arg2),
+                        Op2::Cons => {
+                            hash_witness.cons_named(ConsName::TheCons, store, evaled_arg, *arg2)
+                        }
                         Op2::Eval => {
                             return Ok(Control::Return(evaled_arg, *arg2, continuation));
                         }
@@ -1390,7 +1430,9 @@ fn apply_continuation<F: LurkField>(
                 continuation,
             } => {
                 let condition = result;
-                let (arg1, more) = store.car_cdr(&unevaled_args);
+                let (arg1, more) =
+                    hash_witness.car_cdr_named(ConsName::UnevaledArgs, store, &unevaled_args);
+
                 // NOTE: as formulated here, IF operates on any condition. Every
                 // value but NIL is considered true.
                 //
@@ -1419,7 +1461,8 @@ fn apply_continuation<F: LurkField>(
                 // value being checked against is not zero, so that value should
                 // first be subtracted from the value being checked.
 
-                let (arg2, end) = store.car_cdr(&more);
+                let (arg2, end) =
+                    hash_witness.car_cdr_named(ConsName::UnevaledArgsCdr, store, &more);
                 if !end.is_nil() {
                     Control::Return(arg1, *env, store.intern_cont_error())
                 } else if condition.is_nil() {
@@ -1620,6 +1663,8 @@ pub fn empty_sym_env<F: LurkField>(store: &Store<F>) -> Ptr<F> {
     store.get_nil()
 }
 
+// Only used in tests. Real evalution should use extend_name.
+#[allow(dead_code)]
 fn extend<F: LurkField>(env: Ptr<F>, var: Ptr<F>, val: Ptr<F>, store: &mut Store<F>) -> Ptr<F> {
     let cons = store.cons(var, val);
     store.cons(cons, env)
@@ -1630,21 +1675,30 @@ fn extend_rec<F: LurkField>(
     var: Ptr<F>,
     val: Ptr<F>,
     store: &mut Store<F>,
+    witness: &mut Witness<F>,
 ) -> Result<Ptr<F>, LurkError> {
-    let (binding_or_env, rest) = store.car_cdr(&env);
-    let (var_or_binding, _val_or_more_bindings) = store.car_cdr(&binding_or_env);
+    let hash_witness = &mut witness.hashes;
+
+    let (binding_or_env, rest) = hash_witness.car_cdr_named(ConsName::Env, store, &env);
+    let (var_or_binding, _val_or_more_bindings) =
+        hash_witness.car_cdr_named(ConsName::EnvCar, store, &binding_or_env);
     match var_or_binding.tag() {
         // It's a var, so we are extending a simple env with a recursive env.
         Tag::Sym | Tag::Nil => {
-            let cons = store.cons(var, val);
-            let list = store.list(&[cons]);
-            Ok(store.cons(list, env))
+            let cons = hash_witness.cons_named(ConsName::NewRecCadr, store, var, val);
+            let nil = store.nil();
+            let list = hash_witness.cons_named(ConsName::NewRec, store, cons, nil);
+            let res = hash_witness.cons_named(ConsName::ExtendedRec, store, list, env);
+
+            Ok(res)
         }
         // It's a binding, so we are extending a recursive env.
         Tag::Cons => {
-            let cons = store.cons(var, val);
-            let cons2 = store.cons(cons, binding_or_env);
-            Ok(store.cons(cons2, rest))
+            let cons = hash_witness.cons_named(ConsName::NewRecCadr, store, var, val);
+            let cons2 = hash_witness.cons_named(ConsName::NewRec, store, cons, binding_or_env);
+            let res = hash_witness.cons_named(ConsName::ExtendedRec, store, cons2, rest);
+
+            Ok(res)
         }
         _ => Err(LurkError::Store("Bad input form.".into())),
     }
@@ -1654,6 +1708,7 @@ fn extend_closure<F: LurkField>(
     fun: &Ptr<F>,
     rec_env: &Ptr<F>,
     store: &mut Store<F>,
+    hash_witness: &mut HashWitness<F>,
 ) -> Result<Ptr<F>, LurkError> {
     match fun.tag() {
         Tag::Fun => match store
@@ -1661,7 +1716,12 @@ fn extend_closure<F: LurkField>(
             .ok_or_else(|| LurkError::Store("Fetch failed".into()))?
         {
             Expression::Fun(arg, body, closed_env) => {
-                let extended = store.cons(*rec_env, closed_env);
+                let extended = hash_witness.cons_named(
+                    ConsName::ExtendedClosureEnv,
+                    store,
+                    *rec_env,
+                    closed_env,
+                );
                 Ok(store.intern_fun(arg, body, extended))
             }
             _ => unreachable!(),
@@ -1684,6 +1744,7 @@ impl<F: LurkField> Store<F> {
 }
 
 #[allow(dead_code)]
+// This clarifies the lookup logic and is used in tests.
 fn lookup<F: LurkField>(env: &Ptr<F>, var: &Ptr<F>, store: &Store<F>) -> Result<Ptr<F>, LurkError> {
     assert!(matches!(var.tag(), Tag::Sym));
     match env.tag() {
@@ -1762,10 +1823,6 @@ mod test {
         ) = Evaluator::new(*expr, env, s, limit).eval().unwrap();
 
         if let Some(expected_result) = expected_result {
-            dbg!(
-                &expected_result.fmt_to_string(&s),
-                &new_expr.fmt_to_string(&s),
-            );
             assert!(s.ptr_eq(&expected_result, &new_expr).unwrap());
         }
         if let Some(expected_env) = expected_env {
@@ -1962,7 +2019,7 @@ mod test {
     fn evaluate_lambda4() {
         let s = &mut Store::<Fr>::default();
         let expr =
-            // NOTE: We pass two different values. This tests which is returned.
+        // NOTE: We pass two different values. This tests which is returned.
             "((lambda (y) ((lambda (x) ((lambda (z) z) x)) 888)) 999)";
 
         let expected = s.num(888);
@@ -1974,7 +2031,7 @@ mod test {
     fn evaluate_lambda5() {
         let s = &mut Store::<Fr>::default();
         let expr =
-            // Bind a function to the name FN, then call it.
+        // Bind a function to the name FN, then call it.
             "(((lambda (fn) (lambda (x) (fn x))) (lambda (y) y)) 999)";
 
         let expected = s.num(999);
@@ -2344,7 +2401,7 @@ mod test {
     fn evaluate_tail_recursion_somewhat_optimized() {
         let s = &mut Store::<Fr>::default();
         let expr =
-                "(letrec ((exp (lambda (base)
+            "(letrec ((exp (lambda (base)
                              (letrec ((base-inner
                                         (lambda (exponent-remaining)
                                           (lambda (acc)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -416,7 +416,7 @@ fn reduce_with_witness<F: LurkField>(
     cont: ContPtr<F>,
     store: &mut Store<F>,
 ) -> Result<(Control<F>, Witness<F>), LurkError> {
-    let hash_witness = &mut HashWitness::<F>::default();
+    let hash_witness = &mut HashWitness::<F>::new_dummy();
     let mut closure_to_extend = None;
     let control = if cont.tag() == ContTag::Terminal {
         Control::Return(expr, env, cont)

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -1,0 +1,325 @@
+use crate::field::LurkField;
+use crate::store::{Ptr, Store};
+
+pub const MAX_CONSES_PER_REDUCTION: usize = 11;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Stub<T> {
+    #[default]
+    Dummy,
+    Blank,
+    Value(T),
+}
+
+pub type HashStub<F> = Stub<Cons<F>>;
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Default)]
+pub enum ConsName {
+    #[default]
+    NeverUsed,
+    Env,
+    EnvCar,
+    EnvCaar,
+    Expr,
+    ExprCdr,
+    ExprCadr,
+    ExprCaadr,
+    ExprCaaadr,
+    ExprCddr,
+    UnopConsLike,
+    FunBody,
+    NewRec,
+    NewRecCadr,
+    ExtendedRec,
+    UnevaledArgs,
+    UnevaledArgsCdr,
+    Begin,
+    EnvToUse,
+    InnerBody,
+    Lambda,
+    InnerLambda,
+    TheCons,
+    FunExpanded,
+    ExtendedClosureEnv,
+    Binding,
+    ClosedEnv,
+    ExpandedInner0,
+    ExpandedInner,
+    Expanded,
+}
+
+impl ConsName {
+    pub fn index(&self) -> usize {
+        match self {
+            Self::NeverUsed => MAX_CONSES_PER_REDUCTION + 1,
+            Self::Expr => 0,
+            Self::ExprCdr => 1,
+            Self::UnevaledArgsCdr => 1,
+            Self::ExprCadr => 2,
+            Self::ExprCddr => 3,
+            Self::UnopConsLike => 3,
+            Self::UnevaledArgs => 3,
+            Self::Lambda => 3,
+            Self::ExprCaadr => 4,
+            Self::Begin => 4,
+            Self::InnerBody => 4,
+            Self::ExtendedClosureEnv => 4,
+            Self::ClosedEnv => 4,
+            Self::ExprCaaadr => 5,
+            Self::ExtendedRec => 5,
+            Self::EnvToUse => 5,
+            Self::Binding => 5,
+            Self::FunBody => 6,
+            Self::NewRecCadr => 6,
+            Self::NewRec => 7,
+            Self::Env => 8,
+            Self::ExpandedInner0 => 8,
+            Self::FunExpanded => 9,
+            Self::Expanded => 9,
+            Self::EnvCar => 9,
+            Self::InnerLambda => 10,
+            Self::TheCons => 10,
+            Self::EnvCaar => 10,
+            Self::ExpandedInner => 10,
+        }
+    }
+}
+
+impl<F: LurkField> HashStub<F> {
+    pub fn car_cdr(&mut self, s: &mut Store<F>, cons: &Ptr<F>) -> (Ptr<F>, Ptr<F>) {
+        match self {
+            Self::Dummy => {
+                let (car, cdr) = Cons::get_car_cdr(s, cons);
+
+                *self = Self::Value(Cons {
+                    car,
+                    cdr,
+                    cons: *cons,
+                });
+
+                (car, cdr)
+            }
+            Self::Blank => todo!(),
+            Self::Value(h) => h.car_cdr(cons),
+        }
+    }
+
+    pub fn car_cdr_mut(
+        &mut self,
+        s: &mut Store<F>,
+        cons: &Ptr<F>,
+    ) -> Result<(Ptr<F>, Ptr<F>), String> {
+        match self {
+            Self::Dummy => {
+                let (car, cdr) = Cons::get_car_cdr_mut(s, cons)?;
+
+                *self = Self::Value(Cons {
+                    car,
+                    cdr,
+                    cons: *cons,
+                });
+
+                Ok((car, cdr))
+            }
+            Self::Blank => todo!(),
+            Self::Value(h) => Ok(h.car_cdr(cons)),
+        }
+    }
+
+    pub fn cons(&mut self, store: &mut Store<F>, car: Ptr<F>, cdr: Ptr<F>) -> Ptr<F> {
+        match self {
+            Self::Dummy => {
+                let cons = Cons::cons(store, car, cdr);
+
+                *self = Self::Value(Cons { car, cdr, cons });
+
+                cons
+            }
+            Self::Blank => todo!(),
+            Self::Value(_) => Cons::cons(store, car, cdr),
+        }
+    }
+    pub fn strcons(&mut self, store: &mut Store<F>, car: Ptr<F>, cdr: Ptr<F>) -> Ptr<F> {
+        match self {
+            Self::Dummy => {
+                let cons = Cons::strcons(store, car, cdr);
+
+                *self = Self::Value(Cons { car, cdr, cons });
+
+                cons
+            }
+            Self::Blank => todo!(),
+            Self::Value(_) => Cons::strcons(store, car, cdr),
+        }
+    }
+
+    fn is_dummy(&self) -> bool {
+        matches!(self, Self::Dummy)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub struct HashWitness<F: LurkField> {
+    pub slots: [(ConsName, HashStub<F>); MAX_CONSES_PER_REDUCTION],
+}
+
+impl<F: LurkField> HashWitness<F> {
+    pub fn get_assigned_slot(&mut self, name: ConsName) -> &mut HashStub<F> {
+        let i = name.index();
+        let (slot_name, p) = self.slots[i];
+        if p.is_dummy() {
+            self.slots[i].0 = name;
+            return &mut self.slots[i].1;
+        }
+        if slot_name == name {
+            &mut self.slots[i].1
+        } else {
+            panic!(
+                "double booked: found {:?} when getting {:?}",
+                &slot_name, &name
+            );
+        }
+    }
+
+    pub fn get_named_cons(&self, name: &ConsName) -> HashStub<F> {
+        for (slot_name, p) in &self.slots {
+            if slot_name == name {
+                return *p;
+            }
+        }
+
+        Stub::Dummy
+    }
+
+    pub fn car_cdr_named(
+        &mut self,
+        name: ConsName,
+        store: &mut Store<F>,
+        cons: &Ptr<F>,
+    ) -> (Ptr<F>, Ptr<F>) {
+        self.get_assigned_slot(name).car_cdr(store, cons)
+    }
+
+    pub fn cons_named(
+        &mut self,
+        name: ConsName,
+        store: &mut Store<F>,
+        car: Ptr<F>,
+        cdr: Ptr<F>,
+    ) -> Ptr<F> {
+        self.get_assigned_slot(name).cons(store, car, cdr)
+    }
+
+    pub fn strcons_named(
+        &mut self,
+        name: ConsName,
+        store: &mut Store<F>,
+        car: Ptr<F>,
+        cdr: Ptr<F>,
+    ) -> Ptr<F> {
+        self.get_assigned_slot(name).strcons(store, car, cdr)
+    }
+
+    pub fn car_cdr_mut_named(
+        &mut self,
+        name: ConsName,
+        store: &mut Store<F>,
+        cons: &Ptr<F>,
+    ) -> Result<(Ptr<F>, Ptr<F>), String> {
+        self.get_assigned_slot(name).car_cdr_mut(store, cons)
+    }
+
+    pub fn extend_named(
+        &mut self,
+        name: ConsName,
+        env: Ptr<F>,
+        var: Ptr<F>,
+        val: Ptr<F>,
+        store: &mut Store<F>,
+    ) -> Ptr<F> {
+        let binding = self.cons_named(ConsName::Binding, store, var, val);
+
+        self.cons_named(name, store, binding, env)
+    }
+
+    pub fn assert_invariants(&self, _store: &Store<F>) {
+        // Use the commented code below to search for (non-nil) duplicated conses, which could indicate that two
+        // different Cons are being used to reference the identical structural value. In that case, they could be
+        // coalesced, potentially leading to fewer slots being required.
+        //
+        // As of the initial optimization pass, Env and ExtendedClosureEnv appear to be duplicated in this way. However,
+        // it's not clear why that is, and coalescing them does not obviously lead to a potential savings, so we will
+        // leave them distinct for now.
+
+        // let mut digests = HashMap::new();
+
+        // for (name, p) in self.slots.iter() {
+        //     match p {
+        //         Stub::Value(hash) => {
+        //             if let Some(existing_name) = digests.insert(hash.cons, name) {
+        //                 use crate::writer::Write;
+        //                 let nil = store.get_nil();
+        //                 if !store.ptr_eq(&hash.cons, &nil).unwrap() {
+        //                     let cons = hash.cons.fmt_to_string(store);
+        //                     dbg!(hash.cons, cons, name, existing_name);
+        //                     panic!("duplicate");
+        //                 }
+        //             };
+        //         }
+        //         _ => (),
+        //     };
+        // }
+
+        assert!(self.conses_used_count() <= MAX_CONSES_PER_REDUCTION);
+    }
+
+    fn all_conses(&self) -> Vec<HashStub<F>> {
+        self.slots.iter().map(|x| x.1).collect()
+    }
+
+    pub fn conses_used(&self) -> Vec<HashStub<F>> {
+        self.all_conses()
+            .into_iter()
+            .filter(|c| !c.is_dummy())
+            .collect()
+    }
+
+    pub fn conses_used_count(&self) -> usize {
+        self.all_conses().iter().filter(|c| !c.is_dummy()).count()
+    }
+
+    pub fn total_conses(&self) -> usize {
+        self.all_conses().len()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Cons<F: LurkField> {
+    pub car: Ptr<F>,
+    pub cdr: Ptr<F>,
+    pub cons: Ptr<F>,
+}
+
+impl<F: LurkField> Cons<F> {
+    fn cons(store: &mut Store<F>, car: Ptr<F>, cdr: Ptr<F>) -> Ptr<F> {
+        store.cons(car, cdr)
+    }
+
+    fn strcons(store: &mut Store<F>, car: Ptr<F>, cdr: Ptr<F>) -> Ptr<F> {
+        store.strcons(car, cdr)
+    }
+
+    fn car_cdr(&self, cons: &Ptr<F>) -> (Ptr<F>, Ptr<F>) {
+        assert_eq!(cons, &self.cons, "wrong cons found when destructuring");
+
+        (self.car, self.cdr)
+    }
+
+    fn get_car_cdr(s: &mut Store<F>, cons: &Ptr<F>) -> (Ptr<F>, Ptr<F>) {
+        s.car_cdr(cons)
+    }
+
+    fn get_car_cdr_mut(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), String> {
+        s.car_cdr_mut(cons)
+    }
+}

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -98,7 +98,7 @@ impl<F: LurkField> HashStub<F> {
 
                 (car, cdr)
             }
-            Self::Blank => todo!(),
+            Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
             Self::Value(h) => h.car_cdr(cons),
         }
     }
@@ -120,7 +120,7 @@ impl<F: LurkField> HashStub<F> {
 
                 Ok((car, cdr))
             }
-            Self::Blank => todo!(),
+            Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
             Self::Value(h) => Ok(h.car_cdr(cons)),
         }
     }
@@ -134,7 +134,7 @@ impl<F: LurkField> HashStub<F> {
 
                 cons
             }
-            Self::Blank => todo!(),
+            Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
             Self::Value(_) => Cons::cons(store, car, cdr),
         }
     }
@@ -147,7 +147,7 @@ impl<F: LurkField> HashStub<F> {
 
                 cons
             }
-            Self::Blank => todo!(),
+            Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
             Self::Value(_) => Cons::strcons(store, car, cdr),
         }
     }

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -3,9 +3,8 @@ use crate::store::{Ptr, Store};
 
 pub const MAX_CONSES_PER_REDUCTION: usize = 11;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Stub<T> {
-    #[default]
     Dummy,
     Blank,
     Value(T),
@@ -158,12 +157,26 @@ impl<F: LurkField> HashStub<F> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HashWitness<F: LurkField> {
     pub slots: [(ConsName, HashStub<F>); MAX_CONSES_PER_REDUCTION],
 }
 
 impl<F: LurkField> HashWitness<F> {
+    pub fn new_from_stub(stub: HashStub<F>) -> Self {
+        Self {
+            slots: [(ConsName::NeverUsed, stub); MAX_CONSES_PER_REDUCTION],
+        }
+    }
+
+    pub fn new_dummy() -> Self {
+        Self::new_from_stub(HashStub::Dummy)
+    }
+
+    pub fn new_blank() -> Self {
+        Self::new_from_stub(HashStub::Blank)
+    }
+
     pub fn get_assigned_slot(&mut self, name: ConsName) -> &mut HashStub<F> {
         let i = name.index();
         let (slot_name, p) = self.slots[i];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate quickcheck_macros;
 pub mod circuit;
 pub mod eval;
 pub mod field;
+pub mod hash_witness;
 pub mod package;
 pub mod parser;
 pub mod proof;


### PR DESCRIPTION
This PR optimizes the hashes used to represent Cons in the circuit and also likely fixes soundness problems. The latter probably existed because the decision as to whether or not a particular Cons is 'real' (and therefore constrained to be equal to an expected value) depended on whether it was present in the store, rather than being deterministically calculated from the inputs.

NOTE: this problem likely still affects other parts of the circuit where hashes are similar constructed. This will be addressed in subsequent work extending the method used here to include them. The result should be that all hashing gadgets/functions should take an explicit boolean argument signaling whether the hash is a 'dummy' or not, and there should not be allocations without corresponding constraints enforced.

The performance upshot is that we went from 20,522 constraints to 12,529 constraints. That's a 40% reduction corresponding to a 1.6x speedup and cost reduction for proving.

---

The technique used is as follows:
- An enum (`ConsName`) is used to label every instance of constructing (`cons()`) or destructuring (`car_cdr()`) a `Cons` during evaluation in `eval.rs`.
- The manifest hash preimages and digests (as `Ptr`s within a `Store`) are stored in a fixed number (11, in this case) of slots.
- Each is assigned an index into the slots, such that a given name is always stored in the same slot.
- Names are assigned indexes so that within the set of named conses actually required for any given execution path, there are no collisions. This is checked at evaluation time.
- Before the circuit is created, all hashes (preimage and digest) are resolved to field elements.
- Unused slots are filled with dummy values (all zeroes).
- When a cons is needed in  the circuit, it is referred to and fetched by name.
- The resulting digest or preimage is constrained to equal that which is 'expected' by the gadget's (`car_cdr_named` or `construct_cons_named`) caller, iff this instance is not a dummy.
- The dummy status of each instance must be calculated explicitly from the context in which the named cons is used in the circuit.
