### PR TITLE
Fix cons literal causing panic

### DIFF
--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -30,7 +30,7 @@ use lurk::{
     store::{Pointer, Ptr, ScalarPointer, ScalarPtr, Store, Tag},
     writer::Write,
 };
-use once_cell::sync::OnceCell;
+pub(crate) use once_cell::sync::OnceCell;
 use pairing_lib::{Engine, MultiMillerLoop};
 use rand::rngs::OsRng;
 use serde::de::DeserializeOwned;
@@ -687,8 +687,8 @@ impl Opening<Scalar> {
 
             // public_output = (result_expr (secret . new_fun))
             let cons = public_output.expr;
-            let result_expr = s.car(&cons);
-            let new_comm = s.cdr(&cons);
+            let result_expr = s.car(&cons).map_err(|_| Error::EvaluationFailure)?;
+            let new_comm = s.cdr(&cons).map_err(|_| Error::EvaluationFailure)?;
 
             let new_secret0 = s.secret(new_comm).expect("secret missing");
             let new_secret = *s.get_expr_hash(&new_secret0).expect("hash missing").value();

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -30,7 +30,7 @@ use lurk::{
     store::{Pointer, Ptr, ScalarPointer, ScalarPtr, Store, Tag},
     writer::Write,
 };
-pub(crate) use once_cell::sync::OnceCell;
+use once_cell::sync::OnceCell;
 use pairing_lib::{Engine, MultiMillerLoop};
 use rand::rngs::OsRng;
 use serde::de::DeserializeOwned;

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -329,7 +329,7 @@ pub enum Error {
     SynthesisError(SynthesisError),
     CommitmentParseError(hex::FromHexError),
     UnknownCommitment,
-    OpeningFailure,
+    OpeningFailure(String),
     EvaluationFailure,
 }
 
@@ -687,8 +687,18 @@ impl Opening<Scalar> {
 
             // public_output = (result_expr (secret . new_fun))
             let cons = public_output.expr;
-            let result_expr = s.car(&cons).map_err(|_| Error::EvaluationFailure)?;
-            let new_comm = s.cdr(&cons).map_err(|_| Error::EvaluationFailure)?;
+            let result_expr = s.car(&cons).map_err(|e| {
+                Error::OpeningFailure(format!(
+                    "Failed desctructuring failed commitment output: {}",
+                    e.to_string()
+                ))
+            })?;
+            let new_comm = s.cdr(&cons).map_err(|e| {
+                Error::OpeningFailure(format!(
+                    "Failed desctructuring failed commitment output: {}",
+                    e.to_string()
+                ))
+            })?;
 
             let new_secret0 = s.secret(new_comm).expect("secret missing");
             let new_secret = *s.get_expr_hash(&new_secret0).expect("hash missing").value();
@@ -842,7 +852,7 @@ impl Proof<Bls12> {
         match &proof.claim {
             Claim::Opening(o) => {
                 if o.status != Status::Terminal {
-                    return Err(Error::OpeningFailure);
+                    return Err(Error::OpeningFailure("Claim status is not Terminal".into()));
                 };
             }
             Claim::Evaluation(e) => {

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -690,13 +690,13 @@ impl Opening<Scalar> {
             let result_expr = s.car(&cons).map_err(|e| {
                 Error::OpeningFailure(format!(
                     "Failed desctructuring failed commitment output: {}",
-                    e.to_string()
+                    e
                 ))
             })?;
             let new_comm = s.cdr(&cons).map_err(|e| {
                 Error::OpeningFailure(format!(
                     "Failed desctructuring failed commitment output: {}",
-                    e.to_string()
+                    e
                 ))
             })?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,8 +18,8 @@ pub enum ProofError {
 
 #[derive(Error, Debug, Clone)]
 pub enum LurkError {
-    #[error("Evaluation error: {0}")]
-    Eval(String),
+    #[error("Reduction error: {0}")]
+    Reduce(String),
     #[error("Lookup error: {0}")]
     Store(#[from] store::Error),
     #[error("Parser error: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use crate::eval;
+use crate::field::LurkField;
 use crate::parser;
 use crate::store;
 use bellperson::SynthesisError;
@@ -22,6 +24,12 @@ pub enum LurkError {
     Store(#[from] store::Error),
     #[error("Parser error: {0}")]
     Parser(#[from] parser::Error),
-    #[error("Parser error: {0}")]
-    Provable(String),
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum ReduceError<F: LurkField> {
+    #[error("Lurk error: {0}")]
+    Lurk(#[from] LurkError),
+    #[error("Provable error: {0}")]
+    Provable(#[from] eval::ProvableError<F>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,5 +31,5 @@ pub enum ReduceError<F: LurkField> {
     #[error("Lurk error: {0}")]
     Lurk(#[from] LurkError),
     #[error("Provable error: {0}")]
-    Provable(#[from] eval::ProvableError<F>),
+    Explicit(#[from] eval::ExplicitError<F>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use nova::errors::NovaError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum Error {
+pub enum ProofError {
     #[error("Nova error")]
     Nova(NovaError),
     #[error("Synthesis error: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::parser;
 use crate::store;
 use bellperson::SynthesisError;
 use nova::errors::NovaError;
@@ -22,13 +23,5 @@ pub enum LurkError {
     #[error("Lookup error: {0}")]
     Store(#[from] store::Error),
     #[error("Parser error: {0}")]
-    Parser(#[from] ParserError),
-}
-
-#[derive(Error, Debug, Clone)]
-pub enum ParserError {
-    #[error("Empty input error")]
-    NoInput,
-    #[error("Syntax error: {0}")]
-    Syntax(String),
+    Parser(#[from] parser::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::store;
 use bellperson::SynthesisError;
 use nova::errors::NovaError;
 use thiserror::Error;
@@ -19,7 +20,7 @@ pub enum LurkError {
     #[error("Reduction error: {0}")]
     Reduce(String),
     #[error("Lookup error: {0}")]
-    Store(String),
+    Store(#[from] store::Error),
     #[error("Parser error: {0}")]
     Parser(#[from] ParserError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,4 +22,6 @@ pub enum LurkError {
     Store(#[from] store::Error),
     #[error("Parser error: {0}")]
     Parser(#[from] parser::Error),
+    #[error("Parser error: {0}")]
+    Provable(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,8 +18,6 @@ pub enum ProofError {
 pub enum LurkError {
     #[error("Evaluation error: {0}")]
     Eval(String),
-    #[error("Reduction error: {0}")]
-    Reduce(String),
     #[error("Lookup error: {0}")]
     Store(#[from] store::Error),
     #[error("Parser error: {0}")]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -603,7 +603,7 @@ fn reduce_with_witness_control<F: LurkField>(
                                         }
                                     }
                                     _ => {
-                                        return Err(ReduceError::Lurk(LurkError::Eval(
+                                        return Err(ReduceError::Lurk(LurkError::Reduce(
                                             "Bad form.".into(),
                                         )))
                                     }
@@ -1292,12 +1292,10 @@ fn apply_continuation<F: LurkField>(
                                 .get_expr_hash(result)
                                 .ok_or_else(|| store::Error("expr hash missing".into()))?;
                             store.get_char(
-                                char::from_u32(
-                                    scalar_ptr.value().to_u32().ok_or_else(|| {
-                                        LurkError::Eval("Ptr is invalid u32".into())
-                                    })?,
-                                )
-                                .ok_or_else(|| LurkError::Eval("u32 is invalid char".into()))?,
+                                char::from_u32(scalar_ptr.value().to_u32().ok_or_else(|| {
+                                    LurkError::Reduce("Ptr is invalid u32".into())
+                                })?)
+                                .ok_or_else(|| LurkError::Reduce("u32 is invalid char".into()))?,
                             )
                         }
                         _ => return Ok(Control::Return(*result, *env, store.intern_cont_error())),
@@ -1791,7 +1789,7 @@ fn extend_closure<F: LurkField>(
             }
             _ => unreachable!(),
         },
-        _ => Err(LurkError::Eval(format!(
+        _ => Err(LurkError::Reduce(format!(
             "extend_closure received non-Fun: {:?}",
             fun
         ))),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -423,22 +423,23 @@ fn reduce_with_witness_control<F: LurkField>(
     hash_witness: &mut HashWitness<F>,
 ) -> Result<(Control<F>, Option<Ptr<F>>), ReduceError<F>> {
     let mut closure_to_extend: Option<Ptr<F>> = None;
-    
-    Ok((if cont.tag() == ContTag::Terminal {
-        Control::Return(expr, env, cont)
-    } else {
-        match expr.tag() {
-            Tag::Thunk => match store
-                .fetch(&expr)
-                .ok_or_else(|| LurkError::Store(store::Error("Fetch failed".into())))?
-            {
-                Expression::Thunk(thunk) => {
-                    Control::ApplyContinuation(thunk.value, env, thunk.continuation)
-                }
-                _ => unreachable!(),
-            },
-            // Self-evaluating
-            Tag::Nil
+
+    Ok((
+        if cont.tag() == ContTag::Terminal {
+            Control::Return(expr, env, cont)
+        } else {
+            match expr.tag() {
+                Tag::Thunk => match store
+                    .fetch(&expr)
+                    .ok_or_else(|| LurkError::Store(store::Error("Fetch failed".into())))?
+                {
+                    Expression::Thunk(thunk) => {
+                        Control::ApplyContinuation(thunk.value, env, thunk.continuation)
+                    }
+                    _ => unreachable!(),
+                },
+                // Self-evaluating
+                Tag::Nil
                 | Tag::Num
                 | Tag::Fun
                 | Tag::Char
@@ -446,526 +447,525 @@ fn reduce_with_witness_control<F: LurkField>(
                 | Tag::Comm
                 | Tag::U64
                 | Tag::Key => Control::ApplyContinuation(expr, env, cont),
-            Tag::Sym => {
-                if expr == store.lurk_sym("nil") || (expr == store.t()) {
-                    // NIL and T are self-evaluating symbols, pass them to the continuation in a thunk.
+                Tag::Sym => {
+                    if expr == store.lurk_sym("nil") || (expr == store.t()) {
+                        // NIL and T are self-evaluating symbols, pass them to the continuation in a thunk.
 
-                    // CIRCUIT: sym_is_self_evaluating
-                    //          cond1
-                    Control::ApplyContinuation(expr, env, cont)
-                } else {
-                    // Otherwise, look for a matching binding in env.
-
-                    // CIRCUIT: sym_otherwise
-                    if env.is_nil() {
-                        //     //assert!(!env.is_nil(), "Unbound variable: {:?}", expr);
-                        Err(ProvableError("Evaluation error".into(), expr))?
+                        // CIRCUIT: sym_is_self_evaluating
+                        //          cond1
+                        Control::ApplyContinuation(expr, env, cont)
                     } else {
-                        let (binding, smaller_env) =
-                            hash_witness.car_cdr_named(ConsName::Env, store, &env)?;
-                        if binding.is_nil() {
-                            // If binding is NIL, it's empty. There is no match. Return an error due to unbound variable.
+                        // Otherwise, look for a matching binding in env.
 
-                            // CIRCUIT: binding_is_nil
-                            //          otherwise_and_binding_is_nil
-                            //          cond2
+                        // CIRCUIT: sym_otherwise
+                        if env.is_nil() {
+                            //     //assert!(!env.is_nil(), "Unbound variable: {:?}", expr);
                             Err(ProvableError("Evaluation error".into(), expr))?
                         } else {
-                            // Binding is not NIL, so it is either a normal binding or a recursive environment.
+                            let (binding, smaller_env) =
+                                hash_witness.car_cdr_named(ConsName::Env, store, &env)?;
+                            if binding.is_nil() {
+                                // If binding is NIL, it's empty. There is no match. Return an error due to unbound variable.
 
-                            // CIRCUIT: binding_not_nil
-                            //          otherwise_and_binding_not_nil
-                            let (var_or_rec_binding, val_or_more_rec_env) = hash_witness
-                                .car_cdr_named(ConsName::EnvCar, store, &binding)?;
+                                // CIRCUIT: binding_is_nil
+                                //          otherwise_and_binding_is_nil
+                                //          cond2
+                                Err(ProvableError("Evaluation error".into(), expr))?
+                            } else {
+                                // Binding is not NIL, so it is either a normal binding or a recursive environment.
 
-                            match var_or_rec_binding.tag() {
-                                Tag::Sym => {
-                                    // We are in a simple env (not a recursive env),
-                                    // looking at a binding's variable.
+                                // CIRCUIT: binding_not_nil
+                                //          otherwise_and_binding_not_nil
+                                let (var_or_rec_binding, val_or_more_rec_env) = hash_witness
+                                    .car_cdr_named(ConsName::EnvCar, store, &binding)?;
 
-                                    // CIRCUIT: var_or_rec_binding_is_sym
-                                    //          otherwise_and_sym
-                                    let v = var_or_rec_binding;
-                                    let val = val_or_more_rec_env;
+                                match var_or_rec_binding.tag() {
+                                    Tag::Sym => {
+                                        // We are in a simple env (not a recursive env),
+                                        // looking at a binding's variable.
 
-                                    if v == expr {
-                                        // expr matches the binding's var.
+                                        // CIRCUIT: var_or_rec_binding_is_sym
+                                        //          otherwise_and_sym
+                                        let v = var_or_rec_binding;
+                                        let val = val_or_more_rec_env;
 
-                                        // CIRCUIT: v_is_expr1
-                                        //          v_is_expr1_real
-                                        //          otherwise_and_v_expr_and_sym
-                                        //          cond3
+                                        if v == expr {
+                                            // expr matches the binding's var.
 
-                                        // Pass the binding's value to the continuation in a thunk.
-                                        Control::ApplyContinuation(val, env, cont)
-                                    } else {
-                                        // expr does not match the binding's var.
+                                            // CIRCUIT: v_is_expr1
+                                            //          v_is_expr1_real
+                                            //          otherwise_and_v_expr_and_sym
+                                            //          cond3
 
-                                        // CIRCUIT: otherwise_and_v_not_expr
-                                        match cont.tag() {
-                                            ContTag::Lookup => {
-                                                // If performing a lookup, continue with remaining env.
-
-                                                // CIRCUIT: cont_is_lookup
-                                                //          cont_is_lookup_sym
-                                                //          cond4
-                                                Control::Return(expr, smaller_env, cont)
-                                            }
-                                            _ =>
-                                            // Otherwise, create a lookup continuation, packaging current env
-                                            // to be restored later.
-
-                                            // CIRCUIT: cont_not_lookup_sym
-                                            //          cond5
-                                            {
-                                                Control::Return(
-                                                    expr,
-                                                    smaller_env,
-                                                    store.intern_cont_lookup(env, cont),
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                                // Start of a recursive_env.
-                                Tag::Cons => {
-                                    // CIRCUIT: var_or_rec_binding_is_cons
-                                    //          otherwise_and_cons
-                                    let rec_env = binding;
-                                    let smaller_rec_env = val_or_more_rec_env;
-
-                                    let (v2, val2) = hash_witness.car_cdr_named(
-                                        ConsName::EnvCaar,
-                                        store,
-                                        &var_or_rec_binding,
-                                    )?;
-
-                                    if v2 == expr {
-                                        // CIRCUIT: v2_is_expr
-                                        //          v2_is_expr_real
-                                        //          cond6
-                                        let val_to_use = {
-                                            // CIRCUIT: val_to_use
-                                            match val2.tag() {
-                                                Tag::Fun => {
-                                                    closure_to_extend = Some(val2);
-                                                    // CIRCUIT: val2_is_fun
-
-                                                    // We just found a closure in a recursive env.
-                                                    // We need to extend its environment to include that recursive env.
-
-                                                    extend_closure(
-                                                        &val2,
-                                                        &rec_env,
-                                                        store,
-                                                        hash_witness,
-                                                    )?
-                                                }
-                                                _ => {
-                                                    closure_to_extend = None;
-                                                    val2
-                                                }
-                                            }
-                                        };
-                                        Control::ApplyContinuation(val_to_use, env, cont)
-                                    } else {
-                                        // CIRCUIT: v2_not_expr
-                                        //          otherwise_and_v2_not_expr
-                                        //          cond7
-                                        let env_to_use = if smaller_rec_env.is_nil() {
-                                            // CIRCUIT: smaller_rec_env_is_nil
-                                            smaller_env
+                                            // Pass the binding's value to the continuation in a thunk.
+                                            Control::ApplyContinuation(val, env, cont)
                                         } else {
-                                            // CIRCUIT: with_smaller_rec_env
-                                            hash_witness.cons_named(
-                                                ConsName::EnvToUse,
-                                                store,
-                                                smaller_rec_env,
-                                                smaller_env,
-                                            )
-                                        };
-                                        match cont.tag() {
-                                            ContTag::Lookup => {
-                                                // CIRCUIT: cont_is_lookup
-                                                //          cont_is_lookup_cons
-                                                //          cond8
-                                                Control::Return(expr, env_to_use, cont)
+                                            // expr does not match the binding's var.
+
+                                            // CIRCUIT: otherwise_and_v_not_expr
+                                            match cont.tag() {
+                                                ContTag::Lookup => {
+                                                    // If performing a lookup, continue with remaining env.
+
+                                                    // CIRCUIT: cont_is_lookup
+                                                    //          cont_is_lookup_sym
+                                                    //          cond4
+                                                    Control::Return(expr, smaller_env, cont)
+                                                }
+                                                _ =>
+                                                // Otherwise, create a lookup continuation, packaging current env
+                                                // to be restored later.
+
+                                                // CIRCUIT: cont_not_lookup_sym
+                                                //          cond5
+                                                {
+                                                    Control::Return(
+                                                        expr,
+                                                        smaller_env,
+                                                        store.intern_cont_lookup(env, cont),
+                                                    )
+                                                }
                                             }
-                                            _ => Control::Return(
-                                                // CIRCUIT: cont_not_lookup_cons
-                                                //          cond9
-                                                expr,
-                                                env_to_use,
-                                                store.intern_cont_lookup(env, cont),
-                                            ),
                                         }
                                     }
-                                }
-                                _ => {
-                                    return Err(ReduceError::Lurk(LurkError::Eval(
-                                        "Bad form.".into(),
-                                    )))
+                                    // Start of a recursive_env.
+                                    Tag::Cons => {
+                                        // CIRCUIT: var_or_rec_binding_is_cons
+                                        //          otherwise_and_cons
+                                        let rec_env = binding;
+                                        let smaller_rec_env = val_or_more_rec_env;
+
+                                        let (v2, val2) = hash_witness.car_cdr_named(
+                                            ConsName::EnvCaar,
+                                            store,
+                                            &var_or_rec_binding,
+                                        )?;
+
+                                        if v2 == expr {
+                                            // CIRCUIT: v2_is_expr
+                                            //          v2_is_expr_real
+                                            //          cond6
+                                            let val_to_use = {
+                                                // CIRCUIT: val_to_use
+                                                match val2.tag() {
+                                                    Tag::Fun => {
+                                                        closure_to_extend = Some(val2);
+                                                        // CIRCUIT: val2_is_fun
+
+                                                        // We just found a closure in a recursive env.
+                                                        // We need to extend its environment to include that recursive env.
+
+                                                        extend_closure(
+                                                            &val2,
+                                                            &rec_env,
+                                                            store,
+                                                            hash_witness,
+                                                        )?
+                                                    }
+                                                    _ => {
+                                                        closure_to_extend = None;
+                                                        val2
+                                                    }
+                                                }
+                                            };
+                                            Control::ApplyContinuation(val_to_use, env, cont)
+                                        } else {
+                                            // CIRCUIT: v2_not_expr
+                                            //          otherwise_and_v2_not_expr
+                                            //          cond7
+                                            let env_to_use = if smaller_rec_env.is_nil() {
+                                                // CIRCUIT: smaller_rec_env_is_nil
+                                                smaller_env
+                                            } else {
+                                                // CIRCUIT: with_smaller_rec_env
+                                                hash_witness.cons_named(
+                                                    ConsName::EnvToUse,
+                                                    store,
+                                                    smaller_rec_env,
+                                                    smaller_env,
+                                                )
+                                            };
+                                            match cont.tag() {
+                                                ContTag::Lookup => {
+                                                    // CIRCUIT: cont_is_lookup
+                                                    //          cont_is_lookup_cons
+                                                    //          cond8
+                                                    Control::Return(expr, env_to_use, cont)
+                                                }
+                                                _ => Control::Return(
+                                                    // CIRCUIT: cont_not_lookup_cons
+                                                    //          cond9
+                                                    expr,
+                                                    env_to_use,
+                                                    store.intern_cont_lookup(env, cont),
+                                                ),
+                                            }
+                                        }
+                                    }
+                                    _ => {
+                                        return Err(ReduceError::Lurk(LurkError::Eval(
+                                            "Bad form.".into(),
+                                        )))
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-            Tag::Cons => {
-                let (head, rest) = hash_witness
-                    .car_cdr_named(ConsName::Expr, store, &expr)
-                    .or_else(|_| {
-                        Err(ProvableError("Could not destructure Cons".into(), expr))
-                    })?;
-                let lambda = store.lurk_sym("lambda");
-                let quote = store.lurk_sym("quote");
-                let dummy_arg = store.lurk_sym("_");
+                Tag::Cons => {
+                    let (head, rest) = hash_witness
+                        .car_cdr_named(ConsName::Expr, store, &expr)
+                        .map_err(|_| ProvableError("Could not destructure Cons".into(), expr))?;
+                    let lambda = store.lurk_sym("lambda");
+                    let quote = store.lurk_sym("quote");
+                    let dummy_arg = store.lurk_sym("_");
 
-                if head == lambda {
-                    let (args, body) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    let (arg, _rest) = if args.is_nil() {
-                        // (LAMBDA () STUFF)
-                        // becomes (LAMBDA (DUMMY) STUFF)
-                        (dummy_arg, store.nil())
-                    } else {
-                        hash_witness.car_cdr_named(ConsName::ExprCadr, store, &args)?
-                    };
-                    let (_, cdr_args) =
-                        hash_witness.car_cdr_named(ConsName::ExprCadr, store, &args)?;
-                    let inner_body = if cdr_args.is_nil() {
-                        body
-                    } else {
-                        // (LAMBDA (A B) STUFF)
-                        // becomes (LAMBDA (A) (LAMBDA (B) STUFF))
-                        let inner = hash_witness.cons_named(
-                            ConsName::InnerLambda,
-                            store,
-                            cdr_args,
-                            body,
-                        );
-                        let l = hash_witness.cons_named(ConsName::Lambda, store, lambda, inner);
-                        let nil = store.nil();
-                        hash_witness.cons_named(ConsName::InnerBody, store, l, nil)
-                    };
-                    let function = store.intern_fun(arg, inner_body, env);
+                    if head == lambda {
+                        let (args, body) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        let (arg, _rest) = if args.is_nil() {
+                            // (LAMBDA () STUFF)
+                            // becomes (LAMBDA (DUMMY) STUFF)
+                            (dummy_arg, store.nil())
+                        } else {
+                            hash_witness.car_cdr_named(ConsName::ExprCadr, store, &args)?
+                        };
+                        let (_, cdr_args) =
+                            hash_witness.car_cdr_named(ConsName::ExprCadr, store, &args)?;
+                        let inner_body = if cdr_args.is_nil() {
+                            body
+                        } else {
+                            // (LAMBDA (A B) STUFF)
+                            // becomes (LAMBDA (A) (LAMBDA (B) STUFF))
+                            let inner = hash_witness.cons_named(
+                                ConsName::InnerLambda,
+                                store,
+                                cdr_args,
+                                body,
+                            );
+                            let l = hash_witness.cons_named(ConsName::Lambda, store, lambda, inner);
+                            let nil = store.nil();
+                            hash_witness.cons_named(ConsName::InnerBody, store, l, nil)
+                        };
+                        let function = store.intern_fun(arg, inner_body, env);
 
-                    Control::ApplyContinuation(function, env, cont)
-                } else if head == quote {
-                    let (quoted, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::ApplyContinuation(quoted, env, cont)
-                    }
-                } else if head == store.lurk_sym("let") || head == store.lurk_sym("letrec") {
-                    let (bindings, body) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    let (body1, rest_body) =
-                        hash_witness.car_cdr_named(ConsName::ExprCddr, store, &body)?;
-                    // Only a single body form allowed for now.
-                    if !rest_body.is_nil() || body.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else if bindings.is_nil() {
-                        Control::Return(body1, env, cont)
-                    } else {
-                        let (binding1, rest_bindings) =
-                            hash_witness.car_cdr_named(ConsName::ExprCadr, store, &bindings)?;
-                        let (var, vals) = hash_witness.car_cdr_named(
-                            ConsName::ExprCaadr,
-                            store,
-                            &binding1,
-                        )?;
-                        let (val, end) =
-                            hash_witness.car_cdr_named(ConsName::ExprCaaadr, store, &vals)?;
-
+                        Control::ApplyContinuation(function, env, cont)
+                    } else if head == quote {
+                        let (quoted, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
                         if !end.is_nil() {
                             Err(ProvableError("Evaluation error".into(), expr))?
                         } else {
-                            let expanded = if rest_bindings.is_nil() {
-                                body1
-                            } else {
-                                // We know body is a proper list equivalent to (body1), if this branch was taken, since end is nil.
-                                let expanded0 = hash_witness.cons_named(
-                                    ConsName::ExpandedInner,
-                                    store,
-                                    rest_bindings,
-                                    body,
-                                );
-                                hash_witness.cons_named(
-                                    ConsName::Expanded,
-                                    store,
-                                    head,
-                                    expanded0,
-                                )
-                            };
-                            let cont = if head == store.lurk_sym("let") {
-                                store.intern_cont_let(var, expanded, env, cont)
-                            } else {
-                                store.intern_cont_let_rec(var, expanded, env, cont)
-                            };
-                            Control::Return(val, env, cont)
+                            Control::ApplyContinuation(quoted, env, cont)
                         }
-                    }
-                } else if head == store.lurk_sym("cons") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if more.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), arg1))?
-                    } else {
+                    } else if head == store.lurk_sym("let") || head == store.lurk_sym("letrec") {
+                        let (bindings, body) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        let (body1, rest_body) =
+                            hash_witness.car_cdr_named(ConsName::ExprCddr, store, &body)?;
+                        // Only a single body form allowed for now.
+                        if !rest_body.is_nil() || body.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else if bindings.is_nil() {
+                            Control::Return(body1, env, cont)
+                        } else {
+                            let (binding1, rest_bindings) =
+                                hash_witness.car_cdr_named(ConsName::ExprCadr, store, &bindings)?;
+                            let (var, vals) = hash_witness.car_cdr_named(
+                                ConsName::ExprCaadr,
+                                store,
+                                &binding1,
+                            )?;
+                            let (val, end) =
+                                hash_witness.car_cdr_named(ConsName::ExprCaaadr, store, &vals)?;
+
+                            if !end.is_nil() {
+                                Err(ProvableError("Evaluation error".into(), expr))?
+                            } else {
+                                let expanded = if rest_bindings.is_nil() {
+                                    body1
+                                } else {
+                                    // We know body is a proper list equivalent to (body1), if this branch was taken, since end is nil.
+                                    let expanded0 = hash_witness.cons_named(
+                                        ConsName::ExpandedInner,
+                                        store,
+                                        rest_bindings,
+                                        body,
+                                    );
+                                    hash_witness.cons_named(
+                                        ConsName::Expanded,
+                                        store,
+                                        head,
+                                        expanded0,
+                                    )
+                                };
+                                let cont = if head == store.lurk_sym("let") {
+                                    store.intern_cont_let(var, expanded, env, cont)
+                                } else {
+                                    store.intern_cont_let_rec(var, expanded, env, cont)
+                                };
+                                Control::Return(val, env, cont)
+                            }
+                        }
+                    } else if head == store.lurk_sym("cons") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if more.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), arg1))?
+                        } else {
+                            Control::Return(
+                                arg1,
+                                env,
+                                store.intern_cont_binop(Op2::Cons, env, more, cont),
+                            )
+                        }
+                    } else if head == store.lurk_sym("strcons") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if more.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), arg1))?
+                        } else {
+                            Control::Return(
+                                arg1,
+                                env,
+                                store.intern_cont_binop(Op2::StrCons, env, more, cont),
+                            )
+                        }
+                    } else if head == store.lurk_sym("hide") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if more.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), arg1))?
+                        } else {
+                            Control::Return(
+                                arg1,
+                                env,
+                                store.intern_cont_binop(Op2::Hide, env, more, cont),
+                            )
+                        }
+                    } else if head == store.lurk_sym("begin") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if more.is_nil() {
+                            Control::Return(arg1, env, cont)
+                        } else {
+                            Control::Return(
+                                arg1,
+                                env,
+                                store.intern_cont_binop(Op2::Begin, env, more, cont),
+                            )
+                        }
+                    } else if head == store.lurk_sym("car") {
+                        let (arg1, end) = hash_witness
+                            .car_cdr_mut_named(ConsName::ExprCdr, store, &rest)
+                            .map_err(|e| ReduceError::Lurk(LurkError::Store(e)))?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Car, cont))
+                        }
+                    } else if head == store.lurk_sym("cdr") {
+                        let (arg1, end) = hash_witness
+                            .car_cdr_mut_named(ConsName::ExprCdr, store, &rest)
+                            .map_err(|e| ReduceError::Lurk(LurkError::Store(e)))?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Cdr, cont))
+                        }
+                    } else if head == store.lurk_sym("commit") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Commit, cont))
+                        }
+                    } else if head == store.lurk_sym("num") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Num, cont))
+                        }
+                    } else if head == store.lurk_sym("u64") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::U64, cont))
+                        }
+                    } else if head == store.lurk_sym("comm") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Comm, cont))
+                        }
+                    } else if head == store.lurk_sym("char") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Char, cont))
+                        }
+                    } else if head == store.lurk_sym("eval") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if more.is_nil() {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Eval, cont))
+                        } else {
+                            Control::Return(
+                                arg1,
+                                env,
+                                store.intern_cont_binop(Op2::Eval, env, more, cont),
+                            )
+                        }
+                    } else if head == store.lurk_sym("open") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Open, cont))
+                        }
+                    } else if head == store.lurk_sym("secret") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Secret, cont))
+                        }
+                    } else if head == store.lurk_sym("atom") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Atom, cont))
+                        }
+                    } else if head == store.lurk_sym("emit") {
+                        let (arg1, end) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        if !end.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), expr))?
+                        } else {
+                            Control::Return(arg1, env, store.intern_cont_unop(Op1::Emit, cont))
+                        }
+                    } else if head == store.lurk_sym("+") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
                         Control::Return(
                             arg1,
                             env,
-                            store.intern_cont_binop(Op2::Cons, env, more, cont),
+                            store.intern_cont_binop(Op2::Sum, env, more, cont),
                         )
-                    }
-                } else if head == store.lurk_sym("strcons") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if more.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), arg1))?
-                    } else {
+                    } else if head == store.lurk_sym("-") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
                         Control::Return(
                             arg1,
                             env,
-                            store.intern_cont_binop(Op2::StrCons, env, more, cont),
+                            store.intern_cont_binop(Op2::Diff, env, more, cont),
                         )
-                    }
-                } else if head == store.lurk_sym("hide") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if more.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), arg1))?
-                    } else {
+                    } else if head == store.lurk_sym("*") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
                         Control::Return(
                             arg1,
                             env,
-                            store.intern_cont_binop(Op2::Hide, env, more, cont),
+                            store.intern_cont_binop(Op2::Product, env, more, cont),
                         )
-                    }
-                } else if head == store.lurk_sym("begin") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if more.is_nil() {
-                        Control::Return(arg1, env, cont)
-                    } else {
+                    } else if head == store.lurk_sym("/") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
                         Control::Return(
                             arg1,
                             env,
-                            store.intern_cont_binop(Op2::Begin, env, more, cont),
+                            store.intern_cont_binop(Op2::Quotient, env, more, cont),
                         )
-                    }
-                } else if head == store.lurk_sym("car") {
-                    let (arg1, end) = hash_witness
-                        .car_cdr_mut_named(ConsName::ExprCdr, store, &rest)
-                        .map_err(|e| ReduceError::Lurk(LurkError::Store(e)))?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Car, cont))
-                    }
-                } else if head == store.lurk_sym("cdr") {
-                    let (arg1, end) = hash_witness
-                        .car_cdr_mut_named(ConsName::ExprCdr, store, &rest)
-                        .map_err(|e| ReduceError::Lurk(LurkError::Store(e)))?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Cdr, cont))
-                    }
-                } else if head == store.lurk_sym("commit") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Commit, cont))
-                    }
-                } else if head == store.lurk_sym("num") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Num, cont))
-                    }
-                } else if head == store.lurk_sym("u64") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::U64, cont))
-                    }
-                } else if head == store.lurk_sym("comm") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Comm, cont))
-                    }
-                } else if head == store.lurk_sym("char") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Char, cont))
-                    }
-                } else if head == store.lurk_sym("eval") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if more.is_nil() {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Eval, cont))
-                    } else {
+                    } else if head == store.lurk_sym("%") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
                         Control::Return(
                             arg1,
                             env,
-                            store.intern_cont_binop(Op2::Eval, env, more, cont),
+                            store.intern_cont_binop(Op2::Modulo, env, more, cont),
                         )
-                    }
-                } else if head == store.lurk_sym("open") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
+                    } else if head == store.lurk_sym("=") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        Control::Return(
+                            arg1,
+                            env,
+                            store.intern_cont_binop(Op2::NumEqual, env, more, cont),
+                        )
+                    } else if head == store.lurk_sym("eq") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        Control::Return(
+                            arg1,
+                            env,
+                            store.intern_cont_binop(Op2::Equal, env, more, cont),
+                        )
+                    } else if head == store.lurk_sym("<") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        Control::Return(
+                            arg1,
+                            env,
+                            store.intern_cont_binop(Op2::Less, env, more, cont),
+                        )
+                    } else if head == store.lurk_sym(">") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        Control::Return(
+                            arg1,
+                            env,
+                            store.intern_cont_binop(Op2::Greater, env, more, cont),
+                        )
+                    } else if head == store.lurk_sym("<=") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        Control::Return(
+                            arg1,
+                            env,
+                            store.intern_cont_binop(Op2::LessEqual, env, more, cont),
+                        )
+                    } else if head == store.lurk_sym(">=") {
+                        let (arg1, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        Control::Return(
+                            arg1,
+                            env,
+                            store.intern_cont_binop(Op2::GreaterEqual, env, more, cont),
+                        )
+                    } else if head == store.lurk_sym("if") {
+                        let (condition, more) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
+                        Control::Return(condition, env, store.intern_cont_if(more, cont))
+                    } else if head == store.lurk_sym("current-env") {
+                        if !rest.is_nil() {
+                            Err(ProvableError("Evaluation error".into(), env))?
+                        } else {
+                            Control::ApplyContinuation(env, env, cont)
+                        }
                     } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Open, cont))
-                    }
-                } else if head == store.lurk_sym("secret") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Secret, cont))
-                    }
-                } else if head == store.lurk_sym("atom") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Atom, cont))
-                    }
-                } else if head == store.lurk_sym("emit") {
-                    let (arg1, end) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    if !end.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), expr))?
-                    } else {
-                        Control::Return(arg1, env, store.intern_cont_unop(Op1::Emit, cont))
-                    }
-                } else if head == store.lurk_sym("+") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::Sum, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("-") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::Diff, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("*") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::Product, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("/") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::Quotient, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("%") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::Modulo, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("=") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::NumEqual, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("eq") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::Equal, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("<") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::Less, env, more, cont),
-                    )
-                } else if head == store.lurk_sym(">") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::Greater, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("<=") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::LessEqual, env, more, cont),
-                    )
-                } else if head == store.lurk_sym(">=") {
-                    let (arg1, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(
-                        arg1,
-                        env,
-                        store.intern_cont_binop(Op2::GreaterEqual, env, more, cont),
-                    )
-                } else if head == store.lurk_sym("if") {
-                    let (condition, more) =
-                        hash_witness.car_cdr_named(ConsName::ExprCdr, store, &rest)?;
-                    Control::Return(condition, env, store.intern_cont_if(more, cont))
-                } else if head == store.lurk_sym("current-env") {
-                    if !rest.is_nil() {
-                        Err(ProvableError("Evaluation error".into(), env))?
-                    } else {
-                        Control::ApplyContinuation(env, env, cont)
-                    }
-                } else {
-                    // (fn . args)
-                    let fun_form = head;
-                    let args = rest;
-                    if args.is_nil() {
-                        Control::Return(fun_form, env, store.intern_cont_call0(env, cont))
-                    } else {
-                        if let Ok((arg, more_args)) =
-                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &args)
-                        {
+                        // (fn . args)
+                        let fun_form = head;
+                        let args = rest;
+                        if args.is_nil() {
+                            Control::Return(fun_form, env, store.intern_cont_call0(env, cont))
+                        } else {
+                            let (arg, more_args) = hash_witness
+                                .car_cdr_named(ConsName::ExprCdr, store, &args)
+                                .map_err(|_| ProvableError("Evaluation error".into(), env))?;
+
                             match more_args.tag() {
                                 // (fn arg)
                                 // Interpreting as call.
@@ -999,15 +999,13 @@ fn reduce_with_witness_control<F: LurkField>(
                                     Control::Return(expanded, env, cont)
                                 }
                             }
-                        } else {
-                            Err(ProvableError("Evaluation error".into(), env))?
                         }
                     }
                 }
             }
-        }
-    },
-	closure_to_extend))
+        },
+        closure_to_extend,
+    ))
 }
 
 fn reduce_with_witness<F: LurkField>(

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -669,8 +669,9 @@ fn reduce_with_witness_control<F: LurkField>(
                         } else if bindings.is_nil() {
                             Control::Return(body1, env, cont)
                         } else {
-                            let (binding1, rest_bindings) =
-                                hash_witness.car_cdr_named(ConsName::ExprCadr, store, &bindings)?;
+                            let (binding1, rest_bindings) = hash_witness
+                                .car_cdr_named(ConsName::ExprCadr, store, &bindings)
+                                .map_err(|_| ProvableError("Evaluation error".into(), expr))?;
                             let (var, vals) = hash_witness.car_cdr_named(
                                 ConsName::ExprCaadr,
                                 store,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -729,10 +729,7 @@ fn reduce_with_witness<F: LurkField>(
                     }
                 } else if head == store.lurk_sym("car") {
                     let (arg1, end) =
-                        match hash_witness.car_cdr_mut_named(ConsName::ExprCdr, store, &rest) {
-                            Ok((car, cdr)) => (car, cdr),
-                            Err(e) => return Err(LurkError::Reduce(e)),
-                        };
+                        hash_witness.car_cdr_mut_named(ConsName::ExprCdr, store, &rest)?;
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {
@@ -740,10 +737,7 @@ fn reduce_with_witness<F: LurkField>(
                     }
                 } else if head == store.lurk_sym("cdr") {
                     let (arg1, end) =
-                        match hash_witness.car_cdr_mut_named(ConsName::ExprCdr, store, &rest) {
-                            Ok((car, cdr)) => (car, cdr),
-                            Err(e) => return Err(LurkError::Reduce(e)),
-                        };
+                        hash_witness.car_cdr_mut_named(ConsName::ExprCdr, store, &rest)?;
                     if !end.is_nil() {
                         Control::Return(expr, env, store.intern_cont_error())
                     } else {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -938,40 +938,44 @@ fn reduce_with_witness<F: LurkField>(
                     if args.is_nil() {
                         Control::Return(fun_form, env, store.intern_cont_call0(env, cont))
                     } else {
-                        let (arg, more_args) =
-                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &args)?;
-                        match more_args.tag() {
-                            // (fn arg)
-                            // Interpreting as call.
-                            Tag::Nil => Control::Return(
-                                fun_form,
-                                env,
-                                store.intern_cont_call(arg, env, cont),
-                            ),
-                            _ => {
-                                // Interpreting as multi-arg call.
-                                // (fn arg . more_args) => ((fn arg) . more_args)
-                                let nil = store.nil();
-                                let expanded_inner0 = hash_witness.cons_named(
-                                    ConsName::ExpandedInner0,
-                                    store,
-                                    arg,
-                                    nil,
-                                );
-                                let expanded_inner = hash_witness.cons_named(
-                                    ConsName::ExpandedInner,
-                                    store,
+                        if let Ok((arg, more_args)) =
+                            hash_witness.car_cdr_named(ConsName::ExprCdr, store, &args)
+                        {
+                            match more_args.tag() {
+                                // (fn arg)
+                                // Interpreting as call.
+                                Tag::Nil => Control::Return(
                                     fun_form,
-                                    expanded_inner0,
-                                );
-                                let expanded = hash_witness.cons_named(
-                                    ConsName::FunExpanded,
-                                    store,
-                                    expanded_inner,
-                                    more_args,
-                                );
-                                Control::Return(expanded, env, cont)
+                                    env,
+                                    store.intern_cont_call(arg, env, cont),
+                                ),
+                                _ => {
+                                    // Interpreting as multi-arg call.
+                                    // (fn arg . more_args) => ((fn arg) . more_args)
+                                    let nil = store.nil();
+                                    let expanded_inner0 = hash_witness.cons_named(
+                                        ConsName::ExpandedInner0,
+                                        store,
+                                        arg,
+                                        nil,
+                                    );
+                                    let expanded_inner = hash_witness.cons_named(
+                                        ConsName::ExpandedInner,
+                                        store,
+                                        fun_form,
+                                        expanded_inner0,
+                                    );
+                                    let expanded = hash_witness.cons_named(
+                                        ConsName::FunExpanded,
+                                        store,
+                                        expanded_inner,
+                                        more_args,
+                                    );
+                                    Control::Return(expanded, env, cont)
+                                }
                             }
+                        } else {
+                            Control::Return(env, env, store.intern_cont_error())
                         }
                     }
                 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -596,7 +596,7 @@ fn reduce_with_witness<F: LurkField>(
                                         }
                                     }
                                 }
-                                _ => return Err(LurkError::Reduce("Bad form.".into())),
+                                _ => return Err(LurkError::Eval("Bad form.".into())),
                             }
                         }
                     }

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -1,4 +1,5 @@
 use crate::field::LurkField;
+use crate::store;
 use crate::store::{Ptr, Store};
 
 pub const MAX_CONSES_PER_REDUCTION: usize = 11;
@@ -107,7 +108,7 @@ impl<F: LurkField> HashStub<F> {
         &mut self,
         s: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), String> {
+    ) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         match self {
             Self::Dummy => {
                 let (car, cdr) = Cons::get_car_cdr_mut(s, cons)?;
@@ -238,7 +239,7 @@ impl<F: LurkField> HashWitness<F> {
         name: ConsName,
         store: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), String> {
+    ) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         self.get_assigned_slot(name).car_cdr_mut(store, cons)
     }
 
@@ -332,7 +333,7 @@ impl<F: LurkField> Cons<F> {
         s.car_cdr(cons)
     }
 
-    fn get_car_cdr_mut(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), String> {
+    fn get_car_cdr_mut(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         s.car_cdr_mut(cons)
     }
 }

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -1,3 +1,4 @@
+use crate::error::LurkError;
 use crate::field::LurkField;
 use crate::store;
 use crate::store::{Ptr, Store};
@@ -86,10 +87,14 @@ impl ConsName {
 }
 
 impl<F: LurkField> HashStub<F> {
-    pub fn car_cdr(&mut self, s: &mut Store<F>, cons: &Ptr<F>) -> (Ptr<F>, Ptr<F>) {
+    pub fn car_cdr(
+        &mut self,
+        s: &mut Store<F>,
+        cons: &Ptr<F>,
+    ) -> Result<(Ptr<F>, Ptr<F>), LurkError> {
         match self {
             Self::Dummy => {
-                let (car, cdr) = Cons::get_car_cdr(s, cons);
+                let (car, cdr) = Cons::get_car_cdr(s, cons)?;
 
                 *self = Self::Value(Cons {
                     car,
@@ -97,10 +102,10 @@ impl<F: LurkField> HashStub<F> {
                     cons: *cons,
                 });
 
-                (car, cdr)
+                Ok((car, cdr))
             }
             Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
-            Self::Value(h) => h.car_cdr(cons),
+            Self::Value(h) => Ok(h.car_cdr(cons)),
         }
     }
 
@@ -210,7 +215,7 @@ impl<F: LurkField> HashWitness<F> {
         name: ConsName,
         store: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> (Ptr<F>, Ptr<F>) {
+    ) -> Result<(Ptr<F>, Ptr<F>), LurkError> {
         self.get_assigned_slot(name).car_cdr(store, cons)
     }
 
@@ -329,7 +334,7 @@ impl<F: LurkField> Cons<F> {
         (self.car, self.cdr)
     }
 
-    fn get_car_cdr(s: &mut Store<F>, cons: &Ptr<F>) -> (Ptr<F>, Ptr<F>) {
+    fn get_car_cdr(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), LurkError> {
         s.car_cdr(cons)
     }
 

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -334,7 +334,7 @@ impl<F: LurkField> Cons<F> {
         (self.car, self.cdr)
     }
 
-    fn get_car_cdr(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), LurkError> {
+    fn get_car_cdr(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         s.car_cdr(cons)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub mod sym;
 pub mod uint;
 pub mod writer;
 
-mod error;
+pub mod error;
 mod num;
 pub use num::Num;
 pub use sym::{Sym, Symbol};

--- a/src/proof/groth16.rs
+++ b/src/proof/groth16.rs
@@ -19,7 +19,7 @@ use rand_xorshift::XorShiftRng;
 use serde::{Deserialize, Serialize};
 
 use crate::circuit::MultiFrame;
-use crate::error::Error;
+use crate::error::ProofError;
 use crate::eval::{Evaluator, Witness, IO};
 use crate::proof::{Provable, Prover, PublicParameters};
 use crate::store::{Ptr, Store};
@@ -117,7 +117,7 @@ impl Groth16Prover<Bls12> {
         store: &mut Store<Scalar>,
         limit: usize,
         mut rng: R,
-    ) -> Result<(Proof<Bls12>, IO<Scalar>, IO<Scalar>), Error> {
+    ) -> Result<(Proof<Bls12>, IO<Scalar>, IO<Scalar>), ProofError> {
         let padding_predicate = |count| self.needs_frame_padding(count);
         let frames = Evaluator::generate_frames(expr, env, store, limit, padding_predicate)?;
         store.hydrate_scalar_cache();

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -102,14 +102,12 @@ impl<F: LurkField> NovaProver<F> {
         limit: usize,
     ) -> Result<(Proof, Vec<S1>, Vec<S1>, usize), ProofError> {
         let frames = self.get_evaluation_frames(expr, env, store, limit)?;
-        let z0 = frames[0]
-            .input_vector(store)
-            .map_err(|e| LurkError::Store(e))?;
+        let z0 = frames[0].input_vector(store).map_err(LurkError::Store)?;
         let zi = frames
             .last()
             .unwrap()
             .output_vector(store)
-            .map_err(|e| LurkError::Store(e))?;
+            .map_err(LurkError::Store)?;
         let circuits = MultiFrame::from_frames(self.chunk_frame_count(), &frames, store);
         let num_steps = circuits.len();
         let proof =
@@ -220,7 +218,7 @@ impl<'a> Proof<'a> {
                     .input
                     .unwrap()
                     .to_vector(store)
-                    .map_err(|e| LurkError::Store(e))?;
+                    .map_err(LurkError::Store)?;
                 let mut zi_allocated = Vec::with_capacity(zi.len());
 
                 for (i, x) in zi.iter().enumerate() {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -120,7 +120,10 @@ pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
                         if is_meta {
                             repl.state.handle_meta(&mut s, expr, &package, p)?
                         } else {
-                            repl.state.handle_non_meta(&mut s, expr, false)?
+                            if let Err(e) = repl.state.handle_non_meta(&mut s, expr, false) {
+                                println!("Evaluation error: {}", e);
+                            }
+                            continue;
                         }
                     }
                     Err(parser::Error::NoInput) => {
@@ -351,10 +354,7 @@ impl<F: LurkField> ReplState<F> {
 
                 Ok(())
             }
-            Err(e) => {
-                println!("Evaluation error: {:?}", e);
-                Err(e.into())
-            }
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -372,7 +372,7 @@ impl<F: LurkField> ReplState<F> {
                 Expression::Sym(s) => {
                     if let Some(name) = s.simple_keyword_name() {
                         if &name == "LOAD" {
-                            match store.fetch(&store.car(&rest)).unwrap() {
+                            match store.fetch(&store.car(&rest)?).unwrap() {
                                 Expression::Str(path) => {
                                     let joined = p.as_ref().join(Path::new(&path));
                                     self.handle_load(store, &joined, package)?
@@ -382,7 +382,7 @@ impl<F: LurkField> ReplState<F> {
                             io::stdout().flush().unwrap();
                         } else if &name == "RUN" {
                             // Running and loading are equivalent, except that :RUN does not modify the env.
-                            match store.fetch(&store.car(&rest)).unwrap() {
+                            match store.fetch(&store.car(&rest)?).unwrap() {
                                 Expression::Str(path) => {
                                     let joined = p.as_ref().join(Path::new(&path));
                                     self.handle_run(store, &joined, package)?
@@ -391,8 +391,8 @@ impl<F: LurkField> ReplState<F> {
                             }
                             io::stdout().flush().unwrap();
                         } else if &name == "ASSERT-EQ" {
-                            let (first, rest) = store.car_cdr(&rest);
-                            let (second, rest) = store.car_cdr(&rest);
+                            let (first, rest) = store.car_cdr(&rest)?;
+                            let (second, rest) = store.car_cdr(&rest)?;
                             assert!(rest.is_nil());
                             let (first_evaled, _, _, _) = self.eval_expr(first, store);
                             let (second_evaled, _, _, _) = self.eval_expr(second, store);
@@ -405,27 +405,27 @@ impl<F: LurkField> ReplState<F> {
                                 second_evaled.fmt_to_string(store)
                             );
                         } else if &name == "ASSERT" {
-                            let (first, rest) = store.car_cdr(&rest);
+                            let (first, rest) = store.car_cdr(&rest)?;
                             assert!(rest.is_nil());
                             let (first_evaled, _, _, _) = self.eval_expr(first, store);
                             assert!(!first_evaled.is_nil());
                         } else if &name == "CLEAR" {
                             self.env = empty_sym_env(store);
                         } else if &name == "ASSERT-ERROR" {
-                            let (first, rest) = store.car_cdr(&rest);
+                            let (first, rest) = store.car_cdr(&rest)?;
 
                             assert!(rest.is_nil());
                             let (_, _, continuation, _) = self.clone().eval_expr(first, store);
                             assert!(continuation.is_error());
                         } else if name == "ASSERT-EMITTED" {
-                            let (first, rest) = store.car_cdr(&rest);
-                            let (second, rest) = store.car_cdr(&rest);
+                            let (first, rest) = store.car_cdr(&rest)?;
+                            let (second, rest) = store.car_cdr(&rest)?;
 
                             assert!(rest.is_nil());
                             let (first_evaled, _, _, _) = self.clone().eval_expr(first, store);
                             let (_, _, _, emitted) = self.eval_expr(second, store);
                             let (mut first_emitted, mut rest_emitted) =
-                                store.car_cdr(&first_evaled);
+                                store.car_cdr(&first_evaled)?;
                             for (i, elem) in emitted.iter().enumerate() {
                                 if elem != &first_emitted {
                                     panic!(
@@ -435,7 +435,7 @@ impl<F: LurkField> ReplState<F> {
                                             elem.fmt_to_string(store),
                                         );
                                 }
-                                (first_emitted, rest_emitted) = store.car_cdr(&rest_emitted);
+                                (first_emitted, rest_emitted) = store.car_cdr(&rest_emitted)?;
                             }
                         } else {
                             panic!("!({} ...) is unsupported.", s.name());

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -120,10 +120,7 @@ pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
                         if is_meta {
                             repl.state.handle_meta(&mut s, expr, &package, p)?
                         } else {
-                            if let Err(e) = repl.state.handle_non_meta(&mut s, expr, false) {
-                                println!("Evaluation error: {}", e);
-                            }
-                            continue;
+                            repl.state.handle_non_meta(&mut s, expr, false)?
                         }
                     }
                     Err(parser::Error::NoInput) => {
@@ -354,7 +351,10 @@ impl<F: LurkField> ReplState<F> {
 
                 Ok(())
             }
-            Err(e) => Err(e.into()),
+            Err(e) => {
+                println!("Evaluation error: {:?}", e);
+                Err(e.into())
+            }
         }
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,7 +1,7 @@
-use crate::error::ParserError;
 use crate::eval::{empty_sym_env, Evaluator, IO};
 use crate::field::LurkField;
 use crate::package::Package;
+use crate::parser;
 use crate::store::{ContPtr, ContTag, Expression, Pointer, Ptr, Store, Tag};
 use crate::writer::Write;
 use anyhow::Result;
@@ -123,7 +123,7 @@ pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
                             repl.state.handle_non_meta(&mut s, expr, false)?
                         }
                     }
-                    Err(ParserError::NoInput) => {
+                    Err(parser::Error::NoInput) => {
                         continue;
                     }
                     Err(e) => {
@@ -284,7 +284,7 @@ impl<F: LurkField> ReplState<F> {
                 file_path.as_ref().parent().unwrap(),
                 update_env,
             ) {
-                if let Some(ParserError::NoInput) = e.downcast_ref::<ParserError>() {
+                if let Some(parser::Error::NoInput) = e.downcast_ref::<parser::Error>() {
                     // It's ok, it just means we've hit the EOF
                     return Ok(());
                 } else {

--- a/src/store.rs
+++ b/src/store.rs
@@ -11,6 +11,7 @@ use once_cell::sync::OnceCell;
 
 use libipld::Cid;
 
+use crate::error::LurkError;
 use crate::field::{FWrap, LurkField};
 use crate::package::{Package, LURK_EXTERNAL_SYMBOL_NAMES};
 use crate::parser::{convert_sym_case, names_keyword};
@@ -1992,7 +1993,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub fn car_cdr(&self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), LurkError> {
+    pub fn car_cdr(&self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), Error> {
         // FIXME: Maybe make error.
         match ptr.0 {
             Tag::Nil => Ok((self.get_nil(), self.get_nil())),
@@ -2018,9 +2019,7 @@ impl<F: LurkField> Store<F> {
             _ => {
                 // FIXME: Don't panic. This can happen at runtime in a valid Lurk program,
                 // so it should result in an explicit error.
-                Err(LurkError::Store(
-                    "Can only extract car_cdr from Cons".into(),
-                ))
+                Err(Error("Can only extract car_cdr from Cons".into()))
             }
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1966,12 +1966,12 @@ impl<F: LurkField> Store<F> {
     }
 
     /// Mutable version of car_cdr to handle Str. `(cdr str)` may return a new str (the tail), which must be allocated.
-    pub fn car_cdr_mut(&mut self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), String> {
+    pub fn car_cdr_mut(&mut self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), Error> {
         match ptr.0 {
             Tag::Nil => Ok((self.get_nil(), self.get_nil())),
             Tag::Cons => match self.fetch(ptr) {
                 Some(Expression::Cons(car, cdr)) => Ok((car, cdr)),
-                Some(Expression::Opaque(_)) => Err("cannot destructure opaque Cons".into()),
+                Some(Expression::Opaque(_)) => Err(Error("cannot destructure opaque Cons".into())),
                 _ => unreachable!(),
             },
             Tag::Str => {
@@ -1988,7 +1988,7 @@ impl<F: LurkField> Store<F> {
                     panic!();
                 }
             }
-            _ => Err("Invalid tag".into()),
+            _ => Err(Error("Invalid tag".into())),
         }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,13 +4,13 @@ use rayon::prelude::*;
 use std::hash::Hash;
 use std::{fmt, marker::PhantomData};
 use string_interner::symbol::{Symbol, SymbolUsize};
+use thiserror;
 
 use neptune::poseidon::PoseidonConstants;
 use once_cell::sync::OnceCell;
 
 use libipld::Cid;
 
-use crate::error::LurkError;
 use crate::field::{FWrap, LurkField};
 use crate::package::{Package, LURK_EXTERNAL_SYMBOL_NAMES};
 use crate::parser::{convert_sym_case, names_keyword};
@@ -898,6 +898,15 @@ impl<F: LurkField> Default for Store<F> {
     }
 }
 
+#[derive(thiserror::Error, Debug, Clone)]
+pub struct Error(pub String);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "StoreError: {}", self.0)
+    }
+}
+
 /// These methods provide a more ergonomic means of constructing and manipulating Lurk data.
 /// They can be thought of as a minimal DSL for working with Lurk data in Rust code.
 /// Prefer these methods when constructing literal data or assembling program fragments in
@@ -950,7 +959,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub fn open_mut(&mut self, ptr: Ptr<F>) -> Result<(F, Ptr<F>), LurkError> {
+    pub fn open_mut(&mut self, ptr: Ptr<F>) -> Result<(F, Ptr<F>), Error> {
         let p = match ptr.0 {
             Tag::Comm => ptr,
             Tag::Num => {
@@ -958,17 +967,13 @@ impl<F: LurkField> Store<F> {
 
                 self.intern_maybe_opaque_comm(scalar)
             }
-            _ => {
-                return Err(LurkError::Store(
-                    "wrong type for commitment specifier".into(),
-                ))
-            }
+            _ => return Err(Error("wrong type for commitment specifier".into())),
         };
 
         if let Some((secret, payload)) = self.fetch_comm(&p) {
             Ok((secret.0, *payload))
         } else {
-            Err(LurkError::Store("hidden value could not be opened".into()))
+            Err(Error("hidden value could not be opened".into()))
         }
     }
 
@@ -982,14 +987,10 @@ impl<F: LurkField> Store<F> {
             .and_then(|(secret, _payload)| self.get_num(Num::Scalar(secret.0)))
     }
 
-    pub fn secret_mut(&mut self, ptr: Ptr<F>) -> Result<Ptr<F>, LurkError> {
+    pub fn secret_mut(&mut self, ptr: Ptr<F>) -> Result<Ptr<F>, Error> {
         let p = match ptr.0 {
             Tag::Comm => ptr,
-            _ => {
-                return Err(LurkError::Store(
-                    "wrong type for commitment specifier".into(),
-                ))
-            }
+            _ => return Err(Error("wrong type for commitment specifier".into())),
         };
 
         if let Some((secret, _payload)) = self.fetch_comm(&p) {
@@ -997,7 +998,7 @@ impl<F: LurkField> Store<F> {
             let secret_num = self.intern_num(secret_element);
             Ok(secret_num)
         } else {
-            Err(LurkError::Store("secret could not be extracted".into()))
+            Err(Error("secret could not be extracted".into()))
         }
     }
 
@@ -2599,12 +2600,12 @@ impl<F: LurkField> Store<F> {
         RawPtr((p, true), Default::default())
     }
 
-    pub fn ptr_eq(&self, a: &Ptr<F>, b: &Ptr<F>) -> Result<bool, LurkError> {
+    pub fn ptr_eq(&self, a: &Ptr<F>, b: &Ptr<F>) -> Result<bool, Error> {
         // In order to compare Ptrs, we *must* resolve the hashes. Otherwise, we risk failing to recognize equality of
         // compound data with opaque data in either element's transitive closure.
         match (self.get_expr_hash(a), self.get_expr_hash(b)) {
             (Some(a_hash), Some(b_hash)) => Ok(a.0 == b.0 && a_hash == b_hash),
-            _ => Err(LurkError::Store(
+            _ => Err(Error(
                 "one or more values missing when comparing Ptrs for equality".into(),
             )),
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1994,7 +1994,6 @@ impl<F: LurkField> Store<F> {
     }
 
     pub fn car_cdr(&self, ptr: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), Error> {
-        // FIXME: Maybe make error.
         match ptr.0 {
             Tag::Nil => Ok((self.get_nil(), self.get_nil())),
             Tag::Cons => match self.fetch(ptr) {
@@ -2016,11 +2015,7 @@ impl<F: LurkField> Store<F> {
                     panic!();
                 }
             }
-            _ => {
-                // FIXME: Don't panic. This can happen at runtime in a valid Lurk program,
-                // so it should result in an explicit error.
-                Err(Error("Can only extract car_cdr from Cons".into()))
-            }
+            _ => Err(Error("Can only extract car_cdr from Cons".into())),
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/lurk-lang/lurk-rs/issues/178

Includes some yak shaving as follows:

* There is no explicit mention of "provable error" in the codebase currently and there probably should be. In addition, in order to properly return (provable) errors from `reduce_with_witness`, it would be necessary to match on the return value from `car_cdr_named` etc to check for error and return a `Return` object (can't use the `?` operator). The additional `match` creates even more nested blocks in a function that is quite frankly very complex already. Creating a `ProvableError` type for this purpose solves both issues - explicitly shows when we're returning a provable error, and makes the code easier to read by allowing `?`.
* Split `reduce_with_witness` into two functions, one with most of the current functionality that can potentially return a `ProvableError`, and a higher level one that converts them into `Return` objects. Call the latter `reduce_with_witness` and pick a new name for the former.
* As part of this effort, clean up the set of errors to be a little clearer as to what they're for, move certain errors that can only originate from a certain module, into that module, etc.
* Now that some of these (currently non-provable) errors are bubbled up instead of causing panic, fix the repl to not bail out anyway.

Remaining work:
- [ ] Change strings for ProvableErrors to not just all be `"Evaluation Error"`. Or if we don't think we'll ever need to pass the string on anywhere, just get rid of that field entirely. If keeping the field, maybe use a struct instead of a tuple.
- [ ] Go through all the places that we've fixed to not panic and return a (non-provable) error instead, and see if it should be provable.