### PR TITLE
Ensure type coercions are constrained.

### DIFF
--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2285,7 +2285,13 @@ mod tests {
     fn outer_prove_num_invalid_tag() {
         let s = &mut Store::<Fr>::default();
         let expr = "(num (quote x))";
+        let expr1 = "(num \"asdf\")";
+        let expr2 = "(num '(1))";
         let error = s.get_cont_error();
+        nova_test_aux(s, expr, None, None, Some(error), None, 2);
+        nova_test_aux(s, expr1, None, None, Some(error), None, 2);
+        nova_test_aux(s, expr2, None, None, Some(error), None, 4);
+
         nova_test_aux(s, expr, None, None, Some(error), None, 2);
     }
 
@@ -2293,16 +2299,24 @@ mod tests {
     fn outer_prove_comm_invalid_tag() {
         let s = &mut Store::<Fr>::default();
         let expr = "(comm (quote x))";
+        let expr1 = "(comm \"asdf\")";
+        let expr2 = "(comm '(1))";
         let error = s.get_cont_error();
         nova_test_aux(s, expr, None, None, Some(error), None, 2);
+        nova_test_aux(s, expr1, None, None, Some(error), None, 2);
+        nova_test_aux(s, expr2, None, None, Some(error), None, 4);
     }
 
     #[test]
     fn outer_prove_char_invalid_tag() {
         let s = &mut Store::<Fr>::default();
         let expr = "(char (quote x))";
+        let expr1 = "(char \"asdf\")";
+        let expr2 = "(char '(1))";
         let error = s.get_cont_error();
         nova_test_aux(s, expr, None, None, Some(error), None, 2);
+        nova_test_aux(s, expr1, None, None, Some(error), None, 2);
+        nova_test_aux(s, expr2, None, None, Some(error), None, 4);
     }
 
     #[test]


### PR DESCRIPTION
The type coercion circuit functions were performing unconstrained allocations. Now they just construct a new AllocatedPtr, reusing the value of the input and a globally allocated tag.

I also added more tests of invalid input for the coercion operators.

Importantly, the coercion helpers are not responsible for checking the validity of the input type. Also, when coercing to a char, we don't currently check that it is in range. See FIXME comment. We should either return an explicit error or truncate to u32 range. This needs a new issue.