### PR TITLE
More hashing optimizations

### DIFF
--- a/fcomm/tests/proof_tests.rs
+++ b/fcomm/tests/proof_tests.rs
@@ -304,10 +304,8 @@ fn test_create_open_and_verify_complicated_higher_order_functional_commitment1()
     );
 }
 
-// #[test]
-// #[ignore]
-// FIXME: This fails to verify, which seems to be a circuit bug.
-#[allow(dead_code)]
+#[test]
+#[ignore]
 fn test_create_open_and_verify_complicated_higher_order_functional_commitment2() {
     let function_source = "(letrec ((secret-data '((joe 4 3) (bill 10 2 3) (jane 8 7 6 10) (carol 3 5 8))) (filter (lambda (data predicate) (if data (if (predicate (cdr (car data))) (cons (car data) (filter (cdr data) predicate)) (filter (cdr data) predicate))))) (f (lambda (predicate) (car (car (filter secret-data predicate)))))) f)";
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1256,12 +1256,13 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
         lookup_continuation
     );
 
-    let conda = or!(cs, &cond1, &cond2, &sym_is_self_evaluating)?; // cond1, cond2, sym_is_self_evaluating,
+    let conda = or!(cs, &cond1, &sym_is_self_evaluating)?; // cond1, cond2, sym_is_self_evaluating,
     let condb = or!(cs, &cond4, &cond6)?; // cond4, cond6
     let condc = or!(cs, &conda, &cond8)?; // cond1, cond2, cond8, sym_is_self_evaluating
 
-    let condx = or!(cs, &cond5, &cond0, &cond4)?; // cond0, con4, cond5
-    let condy = or!(cs, &cond0, &cond3, &cond6)?; // cond0, cond3, cond6
+    let condw = or!(cs, &cond0, &cond2)?; // cond0, cond2
+    let condx = or!(cs, &cond5, &cond4, &condw)?; // cond0, cond2, cond4, cond5
+    let condy = or!(cs, &cond3, &cond6, &condw)?; // cond0, cond2, cond3, cond6
 
     // cond1, cond2, cond4, cond5 // cond_expr
     let cond_expr = or!(cs, &conda, &condx, &cond7, &cond10)?; // cond0, cond1, cond2, cond4, cond5, sym_is_self_evaluating

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -301,15 +301,21 @@ impl<F: LurkField> Circuit<F> for MultiFrame<'_, F, IO<F>, Witness<F>> {
 
             let (_, (new_expr, new_env, new_cont)) =
                 frames.iter().fold((0, acc), |(i, allocated_io), frame| {
-                    if let Some(xxx) = frame.input {
+                    if let Some(next_input) = frame.input {
+                        // Ensure all intermediate allocated I/O values match the provided executation trace.
                         assert_eq!(
                             allocated_io.0.hash().get_value(),
-                            store.hash_expr(&xxx.expr).map(|x| *x.value()),
+                            store.hash_expr(&next_input.expr).map(|x| *x.value()),
                             "expr mismatch"
                         );
                         assert_eq!(
+                            allocated_io.1.hash().get_value(),
+                            store.hash_expr(&next_input.env).map(|x| *x.value()),
+                            "env mismatch"
+                        );
+                        assert_eq!(
                             allocated_io.2.hash().get_value(),
-                            store.hash_cont(&xxx.cont).map(|x| *x.value()),
+                            store.hash_cont(&next_input.cont).map(|x| *x.value()),
                             "cont mismatch"
                         );
                     };

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1023,6 +1023,9 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
         witness.as_ref().and_then(|w| w.closure_to_extend.as_ref()),
     )?;
 
+    // Without this, fun is unconstrained.
+    implies_equal!(cs, &extended_env_not_dummy, &fun_hash, val2.hash());
+
     let rec_env = binding;
 
     let extended_env = AllocatedPtr::construct_cons_named(
@@ -1034,9 +1037,6 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
         allocated_cons_witness,
         &extended_env_not_dummy,
     )?;
-
-    // Without this, fun is unconstrained.
-    implies_equal!(cs, &extended_env_not_dummy, &fun_hash, val2.hash());
 
     let extended_fun = AllocatedPtr::construct_fun(
         &mut cs.namespace(|| "extended_fun"),

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1165,7 +1165,6 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
     }
 
     let cs = &mut cs.namespace(|| "otherwise_and_binding_is_nil");
-    //let cond2 = and!(cs, &otherwise_and_binding_is_nil, not_dummy)?;
     let cond2 = otherwise_and_binding_is_nil;
     {
         // let cond = and!(cs, &otherwise_and_binding_is_nil, not_dummy)?;
@@ -1176,7 +1175,6 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
     }
     let cs = &mut cs.namespace(|| "v_is_expr1_real");
 
-    //let cond3 = and!(cs, &v_is_expr1_real, not_dummy)?;
     let cond3 = v_is_expr1_real;
     {
         implies_equal_t!(cs, &cond3, output_expr, val);
@@ -2991,12 +2989,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let arg1 = AllocatedPtr::by_index(1, &continuation_components);
 
-        // let arg1_is_num = equal!(cs, arg1.tag(), &g.num_tag)?;
-
         let commit_secret = pick!(cs, &is_op2_hide, arg1.hash(), &g.default_num)?;
-
         let secret = pick!(cs, &is_op1_open_or_secret, &open_secret, &commit_secret)?;
-
         let committed = pick_ptr!(cs, &is_op1_open, &open_expr, result)?;
 
         (

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -502,7 +502,7 @@ impl<'a, F: LurkField> Results<'a, F> {
         result_env: &'a AllocatedPtr<F>,
         result_cont: &'a AllocatedContPtr<F>,
         make_thunk_num: &'a AllocatedNum<F>,
-        newer_cont_not_dummy: &'a AllocatedNum<F>,
+        newer_cont2_not_dummy: &'a AllocatedNum<F>,
     ) {
         let key = key.as_field();
         add_clause(
@@ -527,7 +527,7 @@ impl<'a, F: LurkField> Results<'a, F> {
         add_clause_single(
             &mut self.newer_cont2_not_dummy_clauses,
             key,
-            newer_cont_not_dummy,
+            newer_cont2_not_dummy,
         );
     }
 }

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -402,7 +402,7 @@ pub fn hash_poseidon<CS: ConstraintSystem<F>, F: LurkField, A: Arity<F>>(
 }
 
 impl<F: LurkField> Ptr<F> {
-    pub fn allocate_maybe_fun<CS: ConstraintSystem<F>>(
+    pub fn allocate_maybe_fun_unconstrained<CS: ConstraintSystem<F>>(
         cs: CS,
         store: &Store<F>,
         maybe_fun: Option<&Ptr<F>>,

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -410,8 +410,10 @@ impl<F: LurkField> ContPtr<F> {
         store: &Store<F>,
     ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
         if let Some(cont) = cont {
+            dbg!("allocate_maybe_dummy_components", &cont);
             cont.allocate_components(cs, store)
         } else {
+            dbg!("allocate_maybe_dummy_components dummy");
             ContPtr::allocate_dummy_components(cs, store)
         }
     }

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -9,9 +9,7 @@ use neptune::{
 
 use super::pointer::AsAllocatedHashComponents;
 use crate::field::LurkField;
-use crate::store::{
-    ContPtr, ContTag, Expression, HashScalar, Op1, Op2, Pointer, Ptr, Store, Tag, Thunk,
-};
+use crate::store::{ContTag, Expression, HashScalar, Op1, Op2, Pointer, Ptr, Store, Tag, Thunk};
 use crate::store::{IntoHashComponents, ScalarPtr};
 use crate::store::{ScalarContPtr, ScalarPointer};
 
@@ -401,75 +399,6 @@ pub fn hash_poseidon<CS: ConstraintSystem<F>, F: LurkField, A: Arity<F>>(
     constants: &PoseidonConstants<F, A>,
 ) -> Result<AllocatedNum<F>, SynthesisError> {
     poseidon_hash(cs, preimage, constants)
-}
-
-impl<F: LurkField> ContPtr<F> {
-    pub fn allocate_maybe_dummy_components<CS: ConstraintSystem<F>>(
-        cs: CS,
-        cont: Option<&ContPtr<F>>,
-        store: &Store<F>,
-    ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
-        if let Some(cont) = cont {
-            dbg!("allocate_maybe_dummy_components", &cont);
-            cont.allocate_components(cs, store)
-        } else {
-            dbg!("allocate_maybe_dummy_components dummy");
-            ContPtr::allocate_dummy_components(cs, store)
-        }
-    }
-
-    fn allocate_components<CS: ConstraintSystem<F>>(
-        &self,
-        mut cs: CS,
-        store: &Store<F>,
-    ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
-        let component_frs = store
-            .get_hash_components_cont(self)
-            .expect("missing hash components");
-
-        let components: Vec<_> = component_frs
-            .iter()
-            .enumerate()
-            .map(|(i, fr)| {
-                AllocatedNum::alloc(
-                    &mut cs.namespace(|| format!("alloc component {}", i)),
-                    || Ok(*fr),
-                )
-            })
-            .collect::<Result<_, _>>()?;
-
-        let hash = hash_poseidon(
-            cs.namespace(|| "Continuation"),
-            components.clone(),
-            store.poseidon_constants().c8(),
-        )?;
-
-        Ok((hash, components))
-    }
-
-    fn allocate_dummy_components<CS: ConstraintSystem<F>>(
-        mut cs: CS,
-        store: &Store<F>,
-    ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
-        let result: Vec<_> = (0..8)
-            .map(|i| {
-                AllocatedNum::alloc(
-                    cs.namespace(|| format!("Continuation component {}", i)),
-                    || Ok(F::zero()),
-                )
-            })
-            .collect::<Result<_, _>>()?;
-
-        // We need to create these constraints, but eventually we can avoid doing any calculation.
-        // We just need a precomputed dummy witness.
-        let dummy_hash = hash_poseidon(
-            cs.namespace(|| "Continuation"),
-            result.clone(),
-            store.poseidon_constants().c8(),
-        )?;
-
-        Ok((dummy_hash, result))
-    }
 }
 
 impl<F: LurkField> Ptr<F> {

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -319,7 +319,6 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
                     panic!("requested {:?} but found a dummy allocation", name)
                 }
                 Ok(alloc_name) => {
-                    //dbg!(&self.witness);
                     assert_eq!(
                         name, alloc_name,
                         "requested and allocated names don't match."
@@ -333,10 +332,10 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
         (allocated_hash.preimage, allocated_hash.digest)
     }
 
-    pub fn get_components_unchecked(
+    pub fn get_components_unconstrained(
         &mut self,
         name: ContName,
-    ) -> (Vec<AllocatedNum<F>>, AllocatedNum<F>, bool) {
+    ) -> (Vec<AllocatedNum<F>>, AllocatedNum<F>) {
         let index = name.index();
         let Slot {
             name: allocated_name,
@@ -344,24 +343,14 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
             consumed: _,
         } = self.slots[index].clone();
 
-        // match (name, allocated_name) {
-        //     (ContName::NewerCont2, Ok(allocated)) => {
-        //         if allocated != name {
-        //             dbg!(&name, &allocated_name);
-        //             panic!("xxxxx");
-        //         }
-        //     }
-        //     (_, _) => (),
-        // }
-
-        dbg!(name, allocated_name);
-        let names_match = allocated_name
+        // Debugging
+        let _names_match = allocated_name
             .map(|alloc_name| alloc_name == name)
             .unwrap_or(false);
 
         assert_eq!(8, allocated_hash.preimage.len());
         self.slots[index].consume();
 
-        (allocated_hash.preimage, allocated_hash.digest, names_match)
+        (allocated_hash.preimage, allocated_hash.digest)
     }
 }

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -74,9 +74,8 @@ impl<'a, VanillaWitness, Name: Debug, F: LurkField, PreimageType>
             .iter()
             .enumerate()
             .filter(|(_, x)| !x.is_consumed())
-            .map(|(i, x)| (i, &x.name, x.consumed))
+            .map(|(i, x)| (i, &x.name))
             .collect::<Vec<_>>();
-
         assert_eq!(
             0,
             unconsumed.len(),
@@ -313,8 +312,6 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
             allocated: allocated_hash,
             consumed: _,
         } = self.slots[index].clone();
-        self.slots[index].consume();
-
         if !expect_dummy {
             match allocated_name {
                 Err(_) => {
@@ -322,7 +319,7 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
                     panic!("requested {:?} but found a dummy allocation", name)
                 }
                 Ok(alloc_name) => {
-                    dbg!(&self.witness);
+                    //dbg!(&self.witness);
                     assert_eq!(
                         name, alloc_name,
                         "requested and allocated names don't match."
@@ -331,6 +328,40 @@ impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
             };
         }
         assert_eq!(8, allocated_hash.preimage.len());
+        self.slots[index].consume();
+
         (allocated_hash.preimage, allocated_hash.digest)
+    }
+
+    pub fn get_components_unchecked(
+        &mut self,
+        name: ContName,
+    ) -> (Vec<AllocatedNum<F>>, AllocatedNum<F>, bool) {
+        let index = name.index();
+        let Slot {
+            name: allocated_name,
+            allocated: allocated_hash,
+            consumed: _,
+        } = self.slots[index].clone();
+
+        // match (name, allocated_name) {
+        //     (ContName::NewerCont2, Ok(allocated)) => {
+        //         if allocated != name {
+        //             dbg!(&name, &allocated_name);
+        //             panic!("xxxxx");
+        //         }
+        //     }
+        //     (_, _) => (),
+        // }
+
+        dbg!(name, allocated_name);
+        let names_match = allocated_name
+            .map(|alloc_name| alloc_name == name)
+            .unwrap_or(false);
+
+        assert_eq!(8, allocated_hash.preimage.len());
+        self.slots[index].consume();
+
+        (allocated_hash.preimage, allocated_hash.digest, names_match)
     }
 }

--- a/src/circuit/gadgets/hashes.rs
+++ b/src/circuit/gadgets/hashes.rs
@@ -5,26 +5,37 @@ use neptune::circuit2::poseidon_hash_allocated as poseidon_hash;
 use crate::circuit::gadgets::pointer::{AllocatedPtr, AsAllocatedHashComponents};
 
 use crate::field::LurkField;
-use crate::hash_witness::{ConsName, HashStub, HashWitness, MAX_CONSES_PER_REDUCTION};
+use crate::hash_witness::{ConsName, ConsWitness, ContName, ContWitness, HashName, Stub};
 use crate::store::{HashConst, HashConstants, ScalarPointer, ScalarPtr, Store};
 
-pub struct AllocatedHash<F: LurkField> {
+pub struct AllocatedPtrHash<F: LurkField> {
     preimage: Vec<AllocatedPtr<F>>,
     digest: AllocatedNum<F>,
 }
 
-pub struct AllocatedHashWitness<'a, F: LurkField> {
-    #[allow(dead_code)]
-    pub(crate) hash_witness: &'a HashWitness<F>, // Sometimes used for debugging.
-    slots: Vec<(Result<ConsName, ()>, AllocatedHash<F>)>,
+pub struct AllocatedNumHash<F: LurkField> {
+    preimage: Vec<AllocatedNum<F>>,
+    digest: AllocatedNum<F>,
 }
 
-impl<F: LurkField> AllocatedHash<F> {
+pub struct AllocatedConsWitness<'a, F: LurkField> {
+    #[allow(dead_code)]
+    pub(crate) cons_witness: &'a ConsWitness<F>, // Sometimes used for debugging.
+    slots: Vec<(Result<ConsName, ()>, AllocatedPtrHash<F>)>,
+}
+
+pub struct AllocatedContWitness<'a, F: LurkField> {
+    #[allow(dead_code)]
+    pub(crate) cont_witness: &'a ContWitness<F>, // Sometimes used for debugging.
+    slots: Vec<(Result<ContName, ()>, AllocatedNumHash<F>)>,
+}
+
+impl<F: LurkField> AllocatedPtrHash<F> {
     fn alloc<CS: ConstraintSystem<F>>(
         cs: &mut CS,
         constants: &HashConstants<F>,
         preimage: Vec<AllocatedPtr<F>>,
-    ) -> Result<AllocatedHash<F>, SynthesisError> {
+    ) -> Result<Self, SynthesisError> {
         let constants = constants.constants((2 * preimage.len()).into());
 
         let pr: Vec<AllocatedNum<F>> = preimage
@@ -32,6 +43,21 @@ impl<F: LurkField> AllocatedHash<F> {
             .flat_map(|x| x.as_allocated_hash_components())
             .cloned()
             .collect();
+
+        let digest = constants.hash(cs, pr)?;
+
+        Ok(Self { preimage, digest })
+    }
+}
+impl<F: LurkField> AllocatedNumHash<F> {
+    fn alloc<CS: ConstraintSystem<F>>(
+        cs: &mut CS,
+        constants: &HashConstants<F>,
+        preimage: Vec<AllocatedNum<F>>,
+    ) -> Result<Self, SynthesisError> {
+        let constants = constants.constants(preimage.len().into());
+
+        let pr: Vec<AllocatedNum<F>> = preimage.to_vec();
 
         let digest = constants.hash(cs, pr)?;
 
@@ -54,24 +80,24 @@ impl<'a, F: LurkField> HashConst<'a, F> {
     }
 }
 
-impl<'a, F: LurkField> AllocatedHashWitness<'a, F> {
-    pub fn from_hash_witness<CS: ConstraintSystem<F>>(
+impl<'a, F: LurkField> AllocatedConsWitness<'a, F> {
+    pub fn from_cons_witness<CS: ConstraintSystem<F>>(
         cs0: &mut CS,
         s: &Store<F>,
-        hw: &'a HashWitness<F>,
+        cons_witness: &'a ConsWitness<F>,
     ) -> Result<Self, SynthesisError> {
-        let mut slots = Vec::with_capacity(MAX_CONSES_PER_REDUCTION);
-        for (i, (name, p)) in hw.slots.iter().enumerate() {
+        let mut slots = Vec::with_capacity(cons_witness.slots.len());
+        for (i, (name, p)) in cons_witness.slots.iter().enumerate() {
             let cs = &mut cs0.namespace(|| format!("slot-{}", i));
 
             let (car_ptr, cdr_ptr, cons_hash) = match p {
-                HashStub::Dummy => (
+                Stub::Dummy => (
                     Some(ScalarPtr::from_parts(F::zero(), F::zero())),
                     Some(ScalarPtr::from_parts(F::zero(), F::zero())),
                     None,
                 ),
-                HashStub::Blank => (None, None, None),
-                HashStub::Value(hash) => (
+                Stub::Blank => (None, None, None),
+                Stub::Value(hash) => (
                     s.hash_expr(&hash.car),
                     s.hash_expr(&hash.cdr),
                     s.hash_expr(&hash.cons),
@@ -90,7 +116,7 @@ impl<'a, F: LurkField> AllocatedHashWitness<'a, F> {
                     None => Err(SynthesisError::AssignmentMissing),
                 })?;
 
-            let allocated_hash = AllocatedHash::alloc(
+            let allocated_hash = AllocatedPtrHash::alloc(
                 &mut cs.namespace(|| "cons"),
                 s.poseidon_constants(),
                 vec![allocated_car, allocated_cdr],
@@ -104,7 +130,7 @@ impl<'a, F: LurkField> AllocatedHashWitness<'a, F> {
         }
 
         Ok(Self {
-            hash_witness: hw,
+            cons_witness,
             slots,
         })
     }
@@ -130,5 +156,107 @@ impl<'a, F: LurkField> AllocatedHashWitness<'a, F> {
             &allocated_hash.preimage[1],
             &allocated_hash.digest,
         )
+    }
+}
+
+impl<'a, F: LurkField> AllocatedContWitness<'a, F> {
+    pub fn from_cont_witness<CS: ConstraintSystem<F>>(
+        cs0: &mut CS,
+        s: &Store<F>,
+        cont_witness: &'a ContWitness<F>,
+    ) -> Result<Self, SynthesisError> {
+        let mut slots = Vec::with_capacity(cont_witness.slots.len());
+        for (i, (name, p)) in cont_witness.slots.iter().enumerate() {
+            let cs = &mut cs0.namespace(|| format!("slot-{}", i));
+
+            let (cont_ptr, components) = match p {
+                Stub::Dummy => (
+                    None,
+                    Some([
+                        F::zero(),
+                        F::zero(),
+                        F::zero(),
+                        F::zero(),
+                        F::zero(),
+                        F::zero(),
+                        F::zero(),
+                        F::zero(),
+                    ]),
+                ),
+                Stub::Blank => (None, None),
+                Stub::Value(cont) => (
+                    Some(cont.cont_ptr),
+                    s.get_hash_components_cont(&cont.cont_ptr),
+                ),
+            };
+
+            let allocated_components = if let Some(components) = components {
+                components
+                    .iter()
+                    .enumerate()
+                    .map(|(i, component)| {
+                        AllocatedNum::alloc(
+                            &mut cs.namespace(|| format!("component_{}", i)),
+                            || Ok(*component),
+                        )
+                        .unwrap()
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                (0..8usize)
+                    .map(|i| {
+                        AllocatedNum::alloc(
+                            &mut cs.namespace(|| format!("component_{}", i)),
+                            // This should never be called, because this branch is only taken when stub is blank.
+                            || Err(SynthesisError::AssignmentMissing),
+                        )
+                        .unwrap()
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            let allocated_hash = AllocatedNumHash::alloc(
+                &mut cs.namespace(|| "cont"),
+                s.poseidon_constants(),
+                allocated_components,
+            )?;
+
+            if cont_ptr.is_some() {
+                slots.push((Ok(*name), allocated_hash));
+            } else {
+                slots.push((Err(()), allocated_hash));
+            }
+        }
+
+        Ok(Self {
+            cont_witness,
+            slots,
+        })
+    }
+
+    pub fn get_components(
+        &self,
+        name: ContName,
+        expect_dummy: bool,
+    ) -> (&[AllocatedNum<F>], &AllocatedNum<F>) {
+        let (allocated_name, allocated_hash) = &self.slots[name.index()];
+
+        if !expect_dummy {
+            match allocated_name {
+                Err(_) => {
+                    dbg!(&self.cont_witness);
+                    panic!("requested {:?} but found a dummy allocation", name)
+                }
+                Ok(alloc_name) => {
+                    dbg!(&self.cont_witness);
+                    assert_eq!(
+                        name, *alloc_name,
+                        "requested and allocated names don't match."
+                    )
+                }
+            };
+        }
+        assert_eq!(8, allocated_hash.preimage.len());
+        (&allocated_hash.preimage, &allocated_hash.digest)
     }
 }

--- a/src/circuit/gadgets/macros.rs
+++ b/src/circuit/gadgets/macros.rs
@@ -37,7 +37,7 @@ macro_rules! if_then_else {
 }
 
 // If expression.
-macro_rules! ifx {
+macro_rules! pick {
     ($cs:ident, $a:expr, $b:expr, $c:expr) => {{
         let a = $a;
         let b = $b;
@@ -54,7 +54,7 @@ macro_rules! ifx {
     }};
 }
 
-macro_rules! ifx_t {
+macro_rules! pick_ptr {
     ($cs:ident, $a:expr, $b:expr, $c:expr) => {{
         let a = $a;
         let b = $b;
@@ -73,7 +73,7 @@ macro_rules! ifx_t {
 
 // Allocates a bit (returned as Boolean) which is true if a and b are equal.
 macro_rules! equal {
-    ($cs:ident, $a:expr, $b:expr) => {
+    ($cs:expr, $a:expr, $b:expr) => {
         alloc_equal(
             $cs.namespace(|| format!("{} equal {}", stringify!($a), stringify!($b))),
             $a,
@@ -117,7 +117,7 @@ macro_rules! implies_equal_t {
 
 // Returns a Boolean which is true if all of its arguments are true.
 macro_rules! and {
-    ($cs:ident, $a:expr, $b:expr) => {
+    ($cs:expr, $a:expr, $b:expr) => {
         Boolean::and(
             $cs.namespace(|| format!("{} and {}", stringify!($a), stringify!($b))),
             $a,
@@ -173,14 +173,14 @@ macro_rules! equal_t {
 
 // Returns a Boolean which is true if any of its arguments are true.
 macro_rules! or {
-    ($cs:ident, $a:expr, $b:expr) => {
+    ($cs:expr, $a:expr, $b:expr) => {
         or(
             $cs.namespace(|| format!("{} or {}", stringify!($a), stringify!($b))),
             $a,
             $b,
         )
     };
-    ($cs:ident, $a:expr, $($x:expr),+) => {{
+    ($cs:expr, $a:expr, $($x:expr),+) => {{
         // This namespace isn't necessarily unique, so some debugging/tuning could be required,
         // if multiple `or!`s at the same level have the same first argument.
         //

--- a/src/circuit/gadgets/macros.rs
+++ b/src/circuit/gadgets/macros.rs
@@ -93,14 +93,21 @@ macro_rules! equal_t {
 }
 
 macro_rules! implies_equal {
-    ($cs:ident, $condition:expr, $a: expr, $b: expr) => {
+    ($cs:ident, $condition:expr, $a: expr, $b: expr) => {{
         let equal = equal!($cs, $a, $b)?;
         enforce_implication(
-            $cs.namespace(|| format!("implies_equal {} {}", stringify!($a), stringify!($b))),
+            $cs.namespace(|| {
+                format!(
+                    "implies_equal: {} => {} == {}",
+                    stringify!($condition),
+                    stringify!($a),
+                    stringify!($b)
+                )
+            }),
             $condition,
             &equal,
         )?;
-    };
+    }};
 }
 
 macro_rules! implies_equal_t {
@@ -108,7 +115,14 @@ macro_rules! implies_equal_t {
         let equal = equal_t!($cs, $a, $b)?;
 
         enforce_implication(
-            $cs.namespace(|| format!("implies_equal_t {} {}", stringify!($a), stringify!($b))),
+            $cs.namespace(|| {
+                format!(
+                    "implies_equal_t: {} => {} == {}",
+                    stringify!($condition),
+                    stringify!($a),
+                    stringify!($b)
+                )
+            }),
             $condition,
             &equal,
         )?;
@@ -195,7 +209,7 @@ macro_rules! or {
 // Enforce that x is true.
 macro_rules! is_true {
     ($cs:ident, $x:expr) => {
-        enforce_true($cs.namespace(|| format!("{} is true!", stringify!($x))), $x);
+        enforce_true($cs.namespace(|| format!("{} is true!", stringify!($x))), $x)
     };
 }
 
@@ -223,6 +237,15 @@ macro_rules! allocate_continuation_tag {
         AllocatedNum::alloc(
             $cs.namespace(|| format!("{} continuation tag", stringify!($continuation_tag))),
             || Ok($continuation_tag.cont_tag_fr()),
+        )
+    };
+}
+
+macro_rules! boolean_num {
+    ($cs:expr, $boolean:expr) => {
+        boolean_to_num(
+            $cs.namespace(|| format!("boolean_num({})", stringify!($boolean))),
+            $boolean,
         )
     };
 }

--- a/src/circuit/gadgets/macros.rs
+++ b/src/circuit/gadgets/macros.rs
@@ -129,6 +129,22 @@ macro_rules! implies_equal_t {
     };
 }
 
+macro_rules! implies {
+    ($cs:ident, $condition:expr, $implication:expr) => {{
+        enforce_implication(
+            $cs.namespace(|| {
+                format!(
+                    "implies: {} => {}",
+                    stringify!($condition),
+                    stringify!($implication)
+                )
+            }),
+            $condition,
+            $implication,
+        )?;
+    }};
+}
+
 // Returns a Boolean which is true if all of its arguments are true.
 macro_rules! and {
     ($cs:expr, $a:expr, $b:expr) => {

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -236,7 +236,7 @@ impl<F: LurkField> AllocatedPtr<F> {
         car: &AllocatedPtr<F>,
         cdr: &AllocatedPtr<F>,
         name: ConsName,
-        allocated_cons_witness: &AllocatedConsWitness<F>,
+        allocated_cons_witness: &mut AllocatedConsWitness<F>,
         not_dummy: &Boolean,
     ) -> Result<AllocatedPtr<F>, SynthesisError> {
         let expect_dummy = !(not_dummy.get_value().unwrap_or(false));
@@ -640,7 +640,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
         name: ContName,
         cont_tag: &AllocatedNum<F>,
         components: &[&dyn AsAllocatedHashComponents<F>; 4],
-        allocated_cont_witness: &AllocatedContWitness<F>,
+        allocated_cont_witness: &mut AllocatedContWitness<F>,
         not_dummy: &Boolean,
     ) -> Result<Self, SynthesisError> {
         let expect_dummy = !(not_dummy.get_value().unwrap_or(false));
@@ -681,7 +681,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
 
         let cont = AllocatedContPtr {
             tag: cont_tag.clone(),
-            hash: hash.clone(),
+            hash,
         };
         Ok(cont)
     }

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -8,7 +8,7 @@ use ff::PrimeField;
 
 use crate::{
     field::LurkField,
-    hash_witness::ConsName,
+    hash_witness::{ConsName, ContName},
     store::{
         ContPtr, Continuation, Expression, IntoHashComponents, Ptr, ScalarContPtr, ScalarPointer,
         ScalarPtr, Store, Thunk,
@@ -19,7 +19,7 @@ use crate::{
 use super::{
     constraints::{alloc_equal, enforce_implication, equal, pick},
     data::{allocate_constant, hash_poseidon, GlobalAllocations},
-    hashes::AllocatedHashWitness,
+    hashes::{AllocatedConsWitness, AllocatedContWitness},
 };
 
 /// Allocated version of `Ptr`.
@@ -203,7 +203,7 @@ impl<F: LurkField> AllocatedPtr<F> {
         Ok(Self { tag, hash })
     }
 
-    pub fn construct_cons<CS: ConstraintSystem<F>>(
+    fn construct_cons<CS: ConstraintSystem<F>>(
         mut cs: CS,
         g: &GlobalAllocations<F>,
         store: &Store<F>,
@@ -236,12 +236,12 @@ impl<F: LurkField> AllocatedPtr<F> {
         car: &AllocatedPtr<F>,
         cdr: &AllocatedPtr<F>,
         name: ConsName,
-        allocated_hash_witness: &AllocatedHashWitness<F>,
+        allocated_cons_witness: &AllocatedConsWitness<F>,
         not_dummy: &Boolean,
     ) -> Result<AllocatedPtr<F>, SynthesisError> {
         let expect_dummy = !(not_dummy.get_value().unwrap_or(false));
         let (allocated_car, allocated_cdr, allocated_digest) =
-            allocated_hash_witness.get_cons(name, expect_dummy);
+            allocated_cons_witness.get_cons(name, expect_dummy);
 
         let real_car = car.alloc_equal(&mut cs.namespace(|| "real_car"), allocated_car)?;
         let real_cdr = cdr.alloc_equal(&mut cs.namespace(|| "real_cdr"), allocated_cdr)?;
@@ -610,27 +610,78 @@ impl<F: LurkField> AllocatedContPtr<F> {
         }
     }
 
-    pub fn construct<CS: ConstraintSystem<F>>(
+    // fn construct_unnamed<CS: ConstraintSystem<F>>(
+    //     mut cs: CS,
+    //     store: &Store<F>,
+    //     cont_tag: &AllocatedNum<F>,
+    //     components: &[&dyn AsAllocatedHashComponents<F>; 4],
+    // ) -> Result<Self, SynthesisError> {
+    //     let components = components
+    //         .iter()
+    //         .flat_map(|c| c.as_allocated_hash_components())
+    //         .cloned()
+    //         .collect();
+
+    //     let hash = hash_poseidon(
+    //         cs.namespace(|| "Continuation"),
+    //         components,
+    //         store.poseidon_constants().c8(),
+    //     )?;
+
+    //     let cont = AllocatedContPtr {
+    //         tag: cont_tag.clone(),
+    //         hash,
+    //     };
+    //     Ok(cont)
+    // }
+
+    pub fn construct_named<CS: ConstraintSystem<F>>(
         mut cs: CS,
-        store: &Store<F>,
+        name: ContName,
         cont_tag: &AllocatedNum<F>,
         components: &[&dyn AsAllocatedHashComponents<F>; 4],
+        allocated_cont_witness: &AllocatedContWitness<F>,
+        not_dummy: &Boolean,
     ) -> Result<Self, SynthesisError> {
-        let components = components
+        let expect_dummy = !(not_dummy.get_value().unwrap_or(false));
+
+        let (found_components, hash) = allocated_cont_witness.get_components(name, expect_dummy);
+
+        let supplied_components: Vec<AllocatedNum<F>> = components
             .iter()
             .flat_map(|c| c.as_allocated_hash_components())
             .cloned()
             .collect();
 
-        let hash = hash_poseidon(
-            cs.namespace(|| "Continuation"),
-            components,
-            store.poseidon_constants().c8(),
+        let mut acc = None;
+
+        for (i, (c1, c2)) in found_components.iter().zip(supplied_components).enumerate() {
+            let component_is_real = equal!(
+                &mut cs.namespace(|| format!("component {} matches", i)),
+                c1,
+                &c2
+            )?;
+
+            if let Some(a) = &acc {
+                and!(
+                    &mut cs.namespace(|| format!("accumulate real component conjunction {}", i)),
+                    a,
+                    &component_is_real
+                )?;
+            } else {
+                acc = Some(component_is_real.clone());
+            }
+        }
+
+        enforce_implication(
+            &mut cs.namespace(|| format!("not_dummy implies real cont {:?}", &name)),
+            not_dummy,
+            &acc.expect("acc was never initialized"),
         )?;
 
         let cont = AllocatedContPtr {
             tag: cont_tag.clone(),
-            hash,
+            hash: hash.clone(),
         };
         Ok(cont)
     }

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -171,7 +171,7 @@ impl<F: LurkField> AllocatedPtr<F> {
             .unwrap_or_else(|| "<PTR MISSING>".to_string())
     }
 
-    pub fn allocate_thunk_components<CS: ConstraintSystem<F>>(
+    pub fn allocate_thunk_components_unconstrained<CS: ConstraintSystem<F>>(
         &self,
         cs: CS,
         store: &Store<F>,

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -1,10 +1,7 @@
 use std::fmt::Debug;
 
 use bellperson::{
-    gadgets::{
-        boolean::{AllocatedBit, Boolean},
-        num::AllocatedNum,
-    },
+    gadgets::{boolean::Boolean, num::AllocatedNum},
     ConstraintSystem, SynthesisError,
 };
 use ff::PrimeField;
@@ -696,8 +693,7 @@ impl<F: LurkField> AllocatedContPtr<F> {
         components: &[&dyn AsAllocatedHashComponents<F>; 4],
         allocated_cont_witness: &mut AllocatedContWitness<F>,
     ) -> Result<(Self, AllocatedNum<F>), SynthesisError> {
-        let (found_components, hash, apparently_not_dummy) =
-            allocated_cont_witness.get_components_unchecked(name);
+        let (found_components, hash) = allocated_cont_witness.get_components_unconstrained(name);
 
         let supplied_components: Vec<AllocatedNum<F>> = components
             .iter()

--- a/src/circuit/gadgets/pointer.rs
+++ b/src/circuit/gadgets/pointer.rs
@@ -610,31 +610,6 @@ impl<F: LurkField> AllocatedContPtr<F> {
         }
     }
 
-    // fn construct_unnamed<CS: ConstraintSystem<F>>(
-    //     mut cs: CS,
-    //     store: &Store<F>,
-    //     cont_tag: &AllocatedNum<F>,
-    //     components: &[&dyn AsAllocatedHashComponents<F>; 4],
-    // ) -> Result<Self, SynthesisError> {
-    //     let components = components
-    //         .iter()
-    //         .flat_map(|c| c.as_allocated_hash_components())
-    //         .cloned()
-    //         .collect();
-
-    //     let hash = hash_poseidon(
-    //         cs.namespace(|| "Continuation"),
-    //         components,
-    //         store.poseidon_constants().c8(),
-    //     )?;
-
-    //     let cont = AllocatedContPtr {
-    //         tag: cont_tag.clone(),
-    //         hash,
-    //     };
-    //     Ok(cont)
-    // }
-
     pub fn construct_named<CS: ConstraintSystem<F>>(
         mut cs: CS,
         name: ContName,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -612,7 +612,7 @@ fn reduce_with_witness<F: LurkField>(
                                         }
                                     }
                                 }
-                                _ => return Err(LurkError::Reduce("Bad form.".into())),
+                                _ => Control::Return(expr, env, store.intern_cont_error()), // bad form
                             }
                         }
                     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -498,7 +498,7 @@ fn reduce_with_witness<F: LurkField>(
                                     } else {
                                         // expr does not match the binding's var.
 
-                                        // CIRCUIT: otherwise_and_v_not_expr
+                                        // CIRCUIT: otherwise_and_sym
                                         match cont.tag() {
                                             ContTag::Lookup => {
                                                 // If performing a lookup, continue with remaining env.
@@ -519,7 +519,7 @@ fn reduce_with_witness<F: LurkField>(
                                                     expr,
                                                     smaller_env,
                                                     cont_witness.intern_named_cont(
-                                                        ContName::XXX,
+                                                        ContName::Lookup,
                                                         store,
                                                         Continuation::Lookup {
                                                             saved_env: env,
@@ -693,7 +693,7 @@ fn reduce_with_witness<F: LurkField>(
                             };
                             let cont = if head == store.lurk_sym("let") {
                                 cont_witness.intern_named_cont(
-                                    ContName::LetLike,
+                                    ContName::NewerCont,
                                     store,
                                     Continuation::Let {
                                         var,
@@ -704,7 +704,7 @@ fn reduce_with_witness<F: LurkField>(
                                 )
                             } else {
                                 cont_witness.intern_named_cont(
-                                    ContName::LetLike,
+                                    ContName::NewerCont,
                                     store,
                                     Continuation::LetRec {
                                         var,
@@ -726,7 +726,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Binop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Binop {
                                     operator: Op2::Cons,
@@ -746,7 +746,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Binop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Binop {
                                     operator: Op2::StrCons,
@@ -766,7 +766,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Binop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Binop {
                                     operator: Op2::Hide,
@@ -786,7 +786,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Binop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Binop {
                                     operator: Op2::Begin,
@@ -810,7 +810,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Car,
@@ -832,7 +832,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Cdr,
@@ -850,7 +850,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Commit,
@@ -868,7 +868,6 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                //ContName::NewerCont,
                                 ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
@@ -887,7 +886,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::U64,
@@ -905,7 +904,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Comm,
@@ -923,7 +922,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Char,
@@ -939,7 +938,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Eval,
@@ -952,7 +951,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Binop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Binop {
                                     operator: Op2::Eval,
@@ -972,7 +971,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Open,
@@ -990,7 +989,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Secret,
@@ -1008,7 +1007,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Atom,
@@ -1026,7 +1025,7 @@ fn reduce_with_witness<F: LurkField>(
                             arg1,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Unop {
                                     operator: Op1::Emit,
@@ -1041,7 +1040,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::Sum,
@@ -1057,7 +1056,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::Diff,
@@ -1073,7 +1072,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::Product,
@@ -1089,7 +1088,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::Quotient,
@@ -1105,7 +1104,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::Modulo,
@@ -1121,7 +1120,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Unop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::NumEqual,
@@ -1137,7 +1136,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::Equal,
@@ -1153,7 +1152,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::Less,
@@ -1169,7 +1168,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::Greater,
@@ -1185,7 +1184,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::LessEqual,
@@ -1201,7 +1200,7 @@ fn reduce_with_witness<F: LurkField>(
                         arg1,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::Binop {
                                 operator: Op2::GreaterEqual,
@@ -1218,7 +1217,7 @@ fn reduce_with_witness<F: LurkField>(
                         condition,
                         env,
                         cont_witness.intern_named_cont(
-                            ContName::Binop,
+                            ContName::NewerCont,
                             store,
                             Continuation::If {
                                 unevaled_args: more,
@@ -1241,7 +1240,7 @@ fn reduce_with_witness<F: LurkField>(
                             fun_form,
                             env,
                             cont_witness.intern_named_cont(
-                                ContName::Binop,
+                                ContName::NewerCont,
                                 store,
                                 Continuation::Call0 {
                                     saved_env: env,
@@ -1259,7 +1258,7 @@ fn reduce_with_witness<F: LurkField>(
                                 fun_form,
                                 env,
                                 cont_witness.intern_named_cont(
-                                    ContName::Binop,
+                                    ContName::NewerCont,
                                     store,
                                     Continuation::Call {
                                         unevaled_arg: arg,
@@ -1399,7 +1398,7 @@ fn apply_continuation<F: LurkField>(
                     let next_expr = unevaled_arg;
 
                     let newer_cont = cont_witness.intern_named_cont(
-                        ContName::Binop,
+                        ContName::NewerCont2,
                         store,
                         Continuation::Call2 {
                             function,
@@ -1537,7 +1536,7 @@ fn apply_continuation<F: LurkField>(
                             *result,
                             *env,
                             cont_witness.intern_named_cont(
-                                ContName::Unop,
+                                ContName::NewerCont2,
                                 store,
                                 Continuation::Emit { continuation },
                             ),
@@ -1633,7 +1632,7 @@ fn apply_continuation<F: LurkField>(
                         arg2,
                         saved_env,
                         cont_witness.intern_named_cont(
-                            ContName::XXX,
+                            ContName::NewerCont2,
                             store,
                             Continuation::Binop2 {
                                 operator,
@@ -1921,7 +1920,7 @@ fn make_tail_continuation<F: LurkField>(
         ContTag::Tail => continuation,
         // Otherwise, package it along with supplied env as a new Tail continuation.
         _ => cont_witness.intern_named_cont(
-            ContName::NewerCont,
+            ContName::NewerCont2,
             store,
             Continuation::Tail {
                 saved_env: env,

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -120,12 +120,7 @@ pub enum ContName {
     ApplyContinuation,
     LetLike,
     NewerCont,
-
     NewerCont2,
-
-    WontMatchCircuitName,
-    WontMatchEvalName,
-    Call,
     MakeThunk,
     Lookup,
 }
@@ -139,9 +134,7 @@ impl HashName for ContName {
             Self::NewerCont => 1,
             Self::NewerCont2 => 1,
             Self::LetLike => 1,
-
             Self::MakeThunk => 1,
-            _ => 1, // fixme,
         }
     }
 }

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -119,13 +119,15 @@ pub enum ContName {
     NeverUsed,
     ApplyContinuation,
     LetLike,
-    Binop,
-    Unop,
+    NewerCont,
+
+    NewerCont2,
+
+    WontMatchCircuitName,
+    WontMatchEvalName,
+    Call,
     MakeThunk,
     Lookup,
-    NewerCont,
-    Tail,
-    XXX,
 }
 
 impl HashName for ContName {
@@ -133,9 +135,12 @@ impl HashName for ContName {
         match self {
             Self::NeverUsed => MAX_CONTS_PER_REDUCTION + 1,
             Self::ApplyContinuation => 0,
-            Self::MakeThunk => 1,
             Self::Lookup => 0,
             Self::NewerCont => 1,
+            Self::NewerCont2 => 1,
+            Self::LetLike => 1,
+
+            Self::MakeThunk => 1,
             _ => 1, // fixme,
         }
     }
@@ -306,6 +311,10 @@ impl<
 
     fn all_stubs(&self) -> Vec<Stub<T>> {
         self.slots.iter().map(|x| x.1).collect()
+    }
+
+    pub fn all_names(&self) -> Vec<Name> {
+        self.slots.iter().map(|x| x.0).collect()
     }
 
     pub fn stubs_used(&self) -> Vec<Stub<T>> {

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -1,7 +1,12 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
 use crate::field::LurkField;
-use crate::store::{Ptr, Store};
+use crate::store::{ContPtr, Continuation, Ptr, Store};
 
 pub const MAX_CONSES_PER_REDUCTION: usize = 11;
+pub const MAX_CONTS_PER_REDUCTION: usize = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Stub<T> {
@@ -10,7 +15,27 @@ pub enum Stub<T> {
     Value(T),
 }
 
-pub type HashStub<F> = Stub<Cons<F>>;
+impl<T> Stub<T> {
+    fn is_dummy(&self) -> bool {
+        matches!(self, Self::Dummy)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Cons<F: LurkField> {
+    pub car: Ptr<F>,
+    pub cdr: Ptr<F>,
+    pub cons: Ptr<F>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Cont<F: LurkField> {
+    pub cont_ptr: ContPtr<F>,
+    pub continuation: Continuation<F>,
+}
+
+pub type ConsStub<F> = Stub<Cons<F>>;
+pub type ContStub<F> = Stub<Cont<F>>;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Default)]
 pub enum ConsName {
@@ -47,8 +72,12 @@ pub enum ConsName {
     Expanded,
 }
 
-impl ConsName {
-    pub fn index(&self) -> usize {
+pub trait HashName {
+    fn index(&self) -> usize;
+}
+
+impl HashName for ConsName {
+    fn index(&self) -> usize {
         match self {
             Self::NeverUsed => MAX_CONSES_PER_REDUCTION + 1,
             Self::Expr => 0,
@@ -84,7 +113,35 @@ impl ConsName {
     }
 }
 
-impl<F: LurkField> HashStub<F> {
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Default)]
+pub enum ContName {
+    #[default]
+    NeverUsed,
+    ApplyContinuation,
+    LetLike,
+    Binop,
+    Unop,
+    MakeThunk,
+    Lookup,
+    NewerCont,
+    Tail,
+    XXX,
+}
+
+impl HashName for ContName {
+    fn index(&self) -> usize {
+        match self {
+            Self::NeverUsed => MAX_CONTS_PER_REDUCTION + 1,
+            Self::ApplyContinuation => 0,
+            Self::MakeThunk => 1,
+            Self::Lookup => 0,
+            Self::NewerCont => 1,
+            _ => 1, // fixme,
+        }
+    }
+}
+
+impl<F: LurkField> ConsStub<F> {
     pub fn car_cdr(&mut self, s: &mut Store<F>, cons: &Ptr<F>) -> (Ptr<F>, Ptr<F>) {
         match self {
             Self::Dummy => {
@@ -98,7 +155,7 @@ impl<F: LurkField> HashStub<F> {
 
                 (car, cdr)
             }
-            Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
+            Self::Blank => unreachable!("Blank ConsStub should be used only in blank circuits."),
             Self::Value(h) => h.car_cdr(cons),
         }
     }
@@ -120,7 +177,7 @@ impl<F: LurkField> HashStub<F> {
 
                 Ok((car, cdr))
             }
-            Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
+            Self::Blank => unreachable!("Blank ConsStub should be used only in blank circuits."),
             Self::Value(h) => Ok(h.car_cdr(cons)),
         }
     }
@@ -134,7 +191,7 @@ impl<F: LurkField> HashStub<F> {
 
                 cons
             }
-            Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
+            Self::Blank => unreachable!("Blank ConsStub should be used only in blank circuits."),
             Self::Value(_) => Cons::cons(store, car, cdr),
         }
     }
@@ -147,37 +204,84 @@ impl<F: LurkField> HashStub<F> {
 
                 cons
             }
-            Self::Blank => unreachable!("Blank HashStub should be used only in blank circuits."),
+            Self::Blank => unreachable!("Blank ConsStub should be used only in blank circuits."),
             Self::Value(_) => Cons::strcons(store, car, cdr),
         }
     }
+}
 
-    fn is_dummy(&self) -> bool {
-        matches!(self, Self::Dummy)
+impl<F: LurkField> ContStub<F> {}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HashWitness<Name: HashName, T, const L: usize, F: LurkField> {
+    pub slots: [(Name, Stub<T>); L],
+    _f: PhantomData<F>,
+}
+
+impl<Name: HashName, T, const L: usize, F: LurkField> HashWitness<Name, T, L, F> {
+    pub fn length() -> usize {
+        L
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct HashWitness<F: LurkField> {
-    pub slots: [(ConsName, HashStub<F>); MAX_CONSES_PER_REDUCTION],
+pub type ConsWitness<F> = HashWitness<ConsName, Cons<F>, MAX_CONSES_PER_REDUCTION, F>;
+pub type ContWitness<F> = HashWitness<ContName, Cont<F>, MAX_CONTS_PER_REDUCTION, F>;
+
+impl<F: LurkField> HashWitness<ConsName, Cons<F>, MAX_CONSES_PER_REDUCTION, F> {
+    #[allow(dead_code)]
+    fn assert_specific_invariants(&self, store: &Store<F>) {
+        // Use the commented code below to search for (non-nil) duplicated conses, which could indicate that two
+        // different Cons are being used to reference the identical structural value. In that case, they could be
+        // coalesced, potentially leading to fewer slots being required.
+        //
+        // As of the initial optimization pass, Env and ExtendedClosureEnv appear to be duplicated in this way. However,
+        // it's not clear why that is, and coalescing them does not obviously lead to a potential savings, so we will
+        // leave them distinct for now.
+
+        let mut digests = HashMap::new();
+
+        for (name, p) in self.slots.iter() {
+            match p {
+                Stub::Value(hash) => {
+                    if let Some(existing_name) = digests.insert(hash.cons, name) {
+                        let nil = store.get_nil();
+                        if !store.ptr_eq(&hash.cons, &nil).unwrap() {
+                            use crate::writer::Write;
+                            let cons = hash.cons.fmt_to_string(store);
+                            dbg!(hash.cons, cons, name, existing_name);
+                            panic!("duplicate");
+                        }
+                    };
+                }
+                _ => (),
+            };
+        }
+    }
 }
 
-impl<F: LurkField> HashWitness<F> {
-    pub fn new_from_stub(stub: HashStub<F>) -> Self {
+impl<
+        Name: HashName + Default + Copy + Eq + Debug,
+        T: Copy,
+        const MAX_T_PER_REDUCTION: usize,
+        F: LurkField,
+    > HashWitness<Name, T, MAX_T_PER_REDUCTION, F>
+{
+    pub fn new_from_stub(stub: Stub<T>) -> Self {
         Self {
-            slots: [(ConsName::NeverUsed, stub); MAX_CONSES_PER_REDUCTION],
+            slots: [(Name::default(), stub); MAX_T_PER_REDUCTION],
+            _f: Default::default(),
         }
     }
 
     pub fn new_dummy() -> Self {
-        Self::new_from_stub(HashStub::Dummy)
+        Self::new_from_stub(Stub::Dummy)
     }
 
     pub fn new_blank() -> Self {
-        Self::new_from_stub(HashStub::Blank)
+        Self::new_from_stub(Stub::Blank)
     }
 
-    pub fn get_assigned_slot(&mut self, name: ConsName) -> &mut HashStub<F> {
+    pub fn get_assigned_slot(&mut self, name: Name) -> &mut Stub<T> {
         let i = name.index();
         let (slot_name, p) = self.slots[i];
         if p.is_dummy() {
@@ -194,7 +298,34 @@ impl<F: LurkField> HashWitness<F> {
         }
     }
 
-    pub fn get_named_cons(&self, name: &ConsName) -> HashStub<F> {
+    pub fn assert_invariants(&self, _store: &Store<F>) {
+        // TODO: Figure out how to make this work.
+        // self.assert_specific_invariants(store);
+        assert!(self.stubs_used_count() <= MAX_T_PER_REDUCTION);
+    }
+
+    fn all_stubs(&self) -> Vec<Stub<T>> {
+        self.slots.iter().map(|x| x.1).collect()
+    }
+
+    pub fn stubs_used(&self) -> Vec<Stub<T>> {
+        self.all_stubs()
+            .into_iter()
+            .filter(|c| !c.is_dummy())
+            .collect()
+    }
+
+    pub fn stubs_used_count(&self) -> usize {
+        self.all_stubs().iter().filter(|c| !c.is_dummy()).count()
+    }
+
+    pub fn total_stub(&self) -> usize {
+        self.all_stubs().len()
+    }
+}
+
+impl<F: LurkField> ConsWitness<F> {
+    pub fn get_named_cons(&self, name: &ConsName) -> ConsStub<F> {
         for (slot_name, p) in &self.slots {
             if slot_name == name {
                 return *p;
@@ -254,63 +385,6 @@ impl<F: LurkField> HashWitness<F> {
 
         self.cons_named(name, store, binding, env)
     }
-
-    pub fn assert_invariants(&self, _store: &Store<F>) {
-        // Use the commented code below to search for (non-nil) duplicated conses, which could indicate that two
-        // different Cons are being used to reference the identical structural value. In that case, they could be
-        // coalesced, potentially leading to fewer slots being required.
-        //
-        // As of the initial optimization pass, Env and ExtendedClosureEnv appear to be duplicated in this way. However,
-        // it's not clear why that is, and coalescing them does not obviously lead to a potential savings, so we will
-        // leave them distinct for now.
-
-        // let mut digests = HashMap::new();
-
-        // for (name, p) in self.slots.iter() {
-        //     match p {
-        //         Stub::Value(hash) => {
-        //             if let Some(existing_name) = digests.insert(hash.cons, name) {
-        //                 use crate::writer::Write;
-        //                 let nil = store.get_nil();
-        //                 if !store.ptr_eq(&hash.cons, &nil).unwrap() {
-        //                     let cons = hash.cons.fmt_to_string(store);
-        //                     dbg!(hash.cons, cons, name, existing_name);
-        //                     panic!("duplicate");
-        //                 }
-        //             };
-        //         }
-        //         _ => (),
-        //     };
-        // }
-
-        assert!(self.conses_used_count() <= MAX_CONSES_PER_REDUCTION);
-    }
-
-    fn all_conses(&self) -> Vec<HashStub<F>> {
-        self.slots.iter().map(|x| x.1).collect()
-    }
-
-    pub fn conses_used(&self) -> Vec<HashStub<F>> {
-        self.all_conses()
-            .into_iter()
-            .filter(|c| !c.is_dummy())
-            .collect()
-    }
-
-    pub fn conses_used_count(&self) -> usize {
-        self.all_conses().iter().filter(|c| !c.is_dummy()).count()
-    }
-
-    pub fn total_conses(&self) -> usize {
-        self.all_conses().len()
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Cons<F: LurkField> {
-    pub car: Ptr<F>,
-    pub cdr: Ptr<F>,
-    pub cons: Ptr<F>,
 }
 
 impl<F: LurkField> Cons<F> {
@@ -334,5 +408,69 @@ impl<F: LurkField> Cons<F> {
 
     fn get_car_cdr_mut(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), String> {
         s.car_cdr_mut(cons)
+    }
+}
+
+impl<F: LurkField> ContWitness<F> {
+    pub fn fetch_named_cont(
+        &mut self,
+        name: ContName,
+        store: &mut Store<F>,
+        cont: &ContPtr<F>,
+    ) -> Option<Continuation<F>> {
+        self.get_assigned_slot(name).fetch_cont(store, cont)
+    }
+
+    pub fn intern_named_cont(
+        &mut self,
+        name: ContName,
+        store: &mut Store<F>,
+        continuation: Continuation<F>,
+    ) -> ContPtr<F> {
+        let cont_ptr = continuation.intern_aux(store);
+        let stub = self.get_assigned_slot(name);
+
+        match stub {
+            Stub::Dummy => {
+                *stub = Stub::Value(Cont {
+                    cont_ptr,
+                    continuation,
+                });
+                cont_ptr
+            }
+            Stub::Blank => unreachable!(),
+            Stub::Value(h) => h.cont_ptr,
+        }
+    }
+}
+
+impl<F: LurkField> ContStub<F> {
+    pub fn fetch_cont(
+        &mut self,
+        store: &mut Store<F>,
+        cont: &ContPtr<F>,
+    ) -> Option<Continuation<F>> {
+        match self {
+            Self::Dummy => {
+                let continuation = store.fetch_cont(cont)?;
+                // dbg!("overwriting dummy", continuation, store.hash_cont(&cont));
+                *self = Self::Value(Cont {
+                    cont_ptr: *cont,
+                    continuation,
+                });
+
+                Some(continuation)
+            }
+            Self::Blank => unreachable!("Blank ConsStub should be used only in blank circuits."),
+            Self::Value(h) => Some(h.fetch_cont(cont)),
+        }
+    }
+}
+
+impl<F: LurkField> Cont<F> {
+    fn fetch_cont(&mut self, cont: &ContPtr<F>) -> Continuation<F> {
+        assert_eq!(cont, &self.cont_ptr);
+
+        self.continuation
     }
 }

--- a/src/num.rs
+++ b/src/num.rs
@@ -176,8 +176,9 @@ impl<F: LurkField> Num<F> {
     }
 
     fn is_less_than(&self, other: &Num<F>) -> bool {
+        assert!(self != other);
         match (self.is_negative(), other.is_negative()) {
-            // Both positive or both negative
+            // Both negative or neither negative
             (true, true) | (false, false) => self.is_less_than_aux(*other),
             (true, false) => true,
             (false, true) => false,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2672,4 +2672,14 @@ mod tests {
 
         nova_test_aux(s, expr, None, None, Some(terminal), None, 3);
     }
+
+    #[test]
+    fn outer_prove_reduce_sym_contradiction_regression() {
+        let s = &mut Store::<Fr>::default();
+
+        let expr = "(eval 'a '(nil))";
+        let error = s.get_cont_error();
+
+        nova_test_aux(s, expr, None, None, Some(error), None, 4);
+    }
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2615,8 +2615,7 @@ mod tests {
     // The following functional commitment tests were discovered to fail. They are commented out (as tests) for now so
     // they can be addressed independently in future work.
 
-    // #[test]
-    #[allow(dead_code)]
+    #[test]
     fn outer_prove_functional_commitment() {
         let s = &mut Store::<Fr>::default();
 
@@ -2629,8 +2628,8 @@ mod tests {
         nova_test_aux(s, expr, Some(res), None, Some(terminal), None, 25);
     }
 
-    // #[test]
-    #[allow(dead_code)]
+    #[test]
+    #[ignore]
     fn outer_prove_complicated_functional_commitment() {
         let s = &mut Store::<Fr>::default();
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -370,10 +370,12 @@ mod tests {
 
         let mut cs_blank = MetricCS::<Fr>::new();
 
+        dbg!("------------> synthesizing blank");
         let blank = MultiFrame::<Fr, IO<Fr>, Witness<Fr>>::blank(chunk_frame_count);
         blank
             .synthesize(&mut cs_blank)
             .expect("failed to synthesize blank");
+        dbg!("synthesized blank <------------");
 
         for (i, multiframe) in multiframes.iter().enumerate() {
             let mut cs = TestConstraintSystem::new();
@@ -2060,6 +2062,32 @@ mod tests {
     }
 
     #[test]
+    fn outer_prove_car_cdr_of_cons() {
+        let s = &mut Store::<Fr>::default();
+        let res1 = s.num(1);
+        let res2 = s.num(2);
+        let terminal = s.get_cont_terminal();
+        nova_test_aux(
+            s,
+            r#"(car (cons 1 2))"#,
+            Some(res1),
+            None,
+            Some(terminal),
+            None,
+            5,
+        );
+        nova_test_aux(
+            s,
+            r#"(cdr (cons 1 2))"#,
+            Some(res2),
+            None,
+            Some(terminal),
+            None,
+            5,
+        );
+    }
+
+    #[test]
     fn outer_prove_car_cdr_invalid_tag_error_lambda() {
         let s = &mut Store::<Fr>::default();
         let error = s.get_cont_error();
@@ -2090,6 +2118,14 @@ mod tests {
         let expected = s.num(456);
         let terminal = s.get_cont_terminal();
         nova_test_aux(s, expr, Some(expected), None, Some(terminal), None, 5);
+    }
+
+    #[test]
+    fn outer_prove_hide_wrong_secret_type() {
+        let s = &mut Store::<Fr>::default();
+        let expr = "(hide 'x 456)";
+        let error = s.get_cont_error();
+        nova_test_aux(s, expr, None, None, Some(error), None, 3);
     }
 
     #[test]
@@ -2550,7 +2586,7 @@ mod tests {
     #[test]
     fn outer_prove_test_eval() {
         let s = &mut Store::<Fr>::default();
-        let expr = "(* 3 (eval (cons '+ (cons 1 (cons 2 nil)))))";
+        let expr = "(* 3 (eval  (cons '+ (cons 1 (cons 2 nil)))))";
         let expr2 = "(* 5 (eval '(+ 1 a) '((a . 3))))"; // two-arg eval, optional second arg is env.
         let res = s.num(9);
         let res2 = s.num(20);

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -294,9 +294,8 @@ mod tests {
     };
     use pallas::Scalar as Fr;
 
-    // FIXME: This is failing with values of (at least) 1, 2.
     const DEFAULT_CHUNK_FRAME_COUNT: usize = 5;
-
+    const CHUNK_FRAME_COUNTS_TO_TEST: [usize; 3] = [1, 2, 5];
     fn nova_test_aux(
         s: &mut Store<Fr>,
         expr: &str,
@@ -306,18 +305,20 @@ mod tests {
         expected_emitted: Option<Vec<Ptr<Fr>>>,
         expected_iterations: usize,
     ) {
-        nova_test_full_aux(
-            s,
-            expr,
-            expected_result,
-            expected_env,
-            expected_cont,
-            expected_emitted,
-            expected_iterations,
-            DEFAULT_CHUNK_FRAME_COUNT,
-            false,
-            None,
-        )
+        for chunk_size in CHUNK_FRAME_COUNTS_TO_TEST {
+            nova_test_full_aux(
+                s,
+                expr,
+                expected_result,
+                expected_env,
+                expected_cont,
+                expected_emitted.as_ref(),
+                expected_iterations,
+                chunk_size,
+                false,
+                None,
+            )
+        }
     }
 
     fn nova_test_full_aux(
@@ -326,7 +327,7 @@ mod tests {
         expected_result: Option<Ptr<Fr>>,
         expected_env: Option<Ptr<Fr>>,
         expected_cont: Option<ContPtr<Fr>>,
-        expected_emitted: Option<Vec<Ptr<Fr>>>,
+        expected_emitted: Option<&Vec<Ptr<Fr>>>,
         expected_iterations: usize,
         chunk_frame_count: usize,
         check_nova: bool,
@@ -400,7 +401,7 @@ mod tests {
                 .iter()
                 .flat_map(|frame| frame.output.maybe_emitted_expression(&s))
                 .collect();
-            assert_eq!(expected_emitted, emitted_vec);
+            assert_eq!(expected_emitted, &emitted_vec);
         }
 
         if let Some(expected_result) = expected_result {

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2700,10 +2700,10 @@ mod tests {
     }
 
     #[test]
-    fn outer_prove_test_self_eval_t() {
+    fn outer_prove_test_self_eval_nil() {
         let s = &mut Store::<Fr>::default();
 
-        // nil doesn't have SYM tag, therefore this case is not solved using cond1
+        // nil doesn't have SYM tag
         let expr = "nil";
 
         let terminal = s.get_cont_terminal();
@@ -2714,8 +2714,6 @@ mod tests {
     fn outer_prove_test_env_not_nil_and_binding_nil() {
         let s = &mut Store::<Fr>::default();
 
-        // NOTE: this unit test is kind of useless, it was just used to understand that binding is nil
-        // condition doesn't contribute to cond2, since condition env-is-nil is reached first
         let expr = "(let ((a 1) (b 2)) c)";
 
         let error = s.get_cont_error();
@@ -2724,12 +2722,10 @@ mod tests {
 
     #[test]
     fn outer_prove_test_eval_bad_form() {
-        // FIXME: failing unit test
         let s = &mut Store::<Fr>::default();
         let expr = "(* 5 (eval '(+ 1 a) '((0 . 3))))"; // two-arg eval, optional second arg is env.
-        let terminal = s.get_cont_terminal();
+        let error = s.get_cont_error();
 
-        nova_test_aux(s, expr, None, None, Some(terminal), None, 9);
+        nova_test_aux(s, expr, None, None, Some(error), None, 8);
     }
-
 }

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -370,14 +370,12 @@ mod tests {
 
         let mut cs_blank = MetricCS::<Fr>::new();
 
-        dbg!("------------> synthesizing blank");
         let blank = MultiFrame::<Fr, IO<Fr>, Witness<Fr>>::blank(chunk_frame_count);
         blank
             .synthesize(&mut cs_blank)
             .expect("failed to synthesize blank");
-        dbg!("synthesized blank <------------");
 
-        for (i, multiframe) in multiframes.iter().enumerate() {
+        for (_i, multiframe) in multiframes.iter().enumerate() {
             let mut cs = TestConstraintSystem::new();
             multiframe.clone().synthesize(&mut cs).unwrap();
 
@@ -385,7 +383,7 @@ mod tests {
                 assert!(prev.precedes(&multiframe));
             }
 
-            dbg!(i);
+            // dbg!(i);
             assert!(cs.is_satisfied());
             assert!(cs.verify(&multiframe.public_inputs()));
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2683,4 +2683,53 @@ mod tests {
 
         nova_test_aux(s, expr, None, None, Some(error), None, 4);
     }
+
+    #[test]
+    fn outer_prove_test_self_eval_env_not_nil() {
+        let s = &mut Store::<Fr>::default();
+
+        // NOTE: cond1 shouldn't depend on env-is-not-nil
+        // therefore this unit test is not very useful
+        // the conclusion is that by removing condition env-is-not-nil from cond1,
+        // we solve this soundness problem
+        // this solution makes the circuit a bit smaller
+        let expr = "(let ((a 1)) t)";
+
+        let terminal = s.get_cont_terminal();
+        nova_test_aux(s, expr, None, None, Some(terminal), None, 3);
+    }
+
+    #[test]
+    fn outer_prove_test_self_eval_t() {
+        let s = &mut Store::<Fr>::default();
+
+        // nil doesn't have SYM tag, therefore this case is not solved using cond1
+        let expr = "nil";
+
+        let terminal = s.get_cont_terminal();
+        nova_test_aux(s, expr, None, None, Some(terminal), None, 1);
+    }
+
+    #[test]
+    fn outer_prove_test_env_not_nil_and_binding_nil() {
+        let s = &mut Store::<Fr>::default();
+
+        // NOTE: this unit test is kind of useless, it was just used to understand that binding is nil
+        // condition doesn't contribute to cond2, since condition env-is-nil is reached first
+        let expr = "(let ((a 1) (b 2)) c)";
+
+        let error = s.get_cont_error();
+        nova_test_aux(s, expr, None, None, Some(error), None, 7);
+    }
+
+    #[test]
+    fn outer_prove_test_eval_bad_form() {
+        // FIXME: failing unit test
+        let s = &mut Store::<Fr>::default();
+        let expr = "(* 5 (eval '(+ 1 a) '((0 . 3))))"; // two-arg eval, optional second arg is env.
+        let terminal = s.get_cont_terminal();
+
+        nova_test_aux(s, expr, None, None, Some(terminal), None, 9);
+    }
+
 }


### PR DESCRIPTION
This PR extends the technique introduced in #199 to allocated named continuations. It turns out that only two continuation hashes are required per reduction, so this work reduces the circuit by about another 1,000 constraints.

It has also become clear that the previous approach was also error-prone. The enforced discipline required to pass allocated booleans indicating whether any given hash usage is 'real' or 'dummy' proved valuable. As a result, I ended up discovering a number of soundness problems throughout the circuit. These in turn had sometimes masked correctness issues undetected by tests. That possibility points to a pervasive risk. Future work will address the risk by moving away from an ad-hoc, manual circuit and toward an approach that will be sound by construction.

In the meantime, a happy side effect of these changes is that *without any intentional work to address them*, I discovered that all the known test failures we had deferred addressing (by disabling tests) were fixed by these changes. This includes a long-standing functional commitment test in `fcomm`, several simpler functional commitment examples, and many tests which failed if the number of frames per circuit was changed from the default of 5.

Although there is still further work to be done on all three fronts, the above suggests why I have confidence that this is an improvement. In this case, a better approach to the circuit naturally led to related improvements in the dimensions of performance, correctness, and soundness. One especially useful outcome of this work is that it paves the way for further refactoring and redesign that I believe can get us to *very* high confidence. 