### PR TITLE
Implement coercion to u32 (and to char)

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4478,7 +4478,7 @@ fn to_comm<F: LurkField>(x: &AllocatedPtr<F>, g: &GlobalAllocations<F>) -> Alloc
     AllocatedPtr::from_parts(&g.comm_tag, x.hash())
 }
 
-fn get_named_components<'a, F: LurkField, CS: ConstraintSystem<F>>(
+fn get_named_components<F: LurkField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     cont_ptr: &AllocatedContPtr<F>,
     name: ContName,

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5092,7 +5092,7 @@ pub(crate) fn print_cs<F: LurkField, C: Comparable<F>>(this: &C) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::circuit::circuit_frame::constraints::{sub, popcount, equal};
+    use crate::circuit::circuit_frame::constraints::{equal, popcount, sub};
     use crate::eval::{empty_sym_env, Evaluable, IO};
     use crate::proof::Provable;
     use crate::proof::{groth16::Groth16Prover, Prover};
@@ -5723,7 +5723,8 @@ mod tests {
                 &mut cs.namespace(|| format!("popcount {x}")),
                 &bits,
                 alloc_popcount.hash(),
-            ).unwrap();
+            )
+            .unwrap();
         }
 
         assert!(cs.is_satisfied());

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4631,6 +4631,7 @@ pub fn comparison_helper<F: LurkField, CS: ConstraintSystem<F>>(
 }
 
 // Enforce 0 <= num < 2ˆn.
+#[allow(dead_code)]
 pub fn enforce_at_most_n_bits<F: LurkField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     g: &GlobalAllocations<F>,
@@ -4746,11 +4747,8 @@ pub fn to_u64<F: LurkField, CS: ConstraintSystem<F>>(
     maybe_u64: &AllocatedNum<F>,
 ) -> Result<AllocatedNum<F>, SynthesisError> {
 
-    let v = match maybe_u64.get_value() {
-        Some(v) => v,
-        None => F::zero(),
-    };
-    let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
+    let field_elem = maybe_u64.get_value().unwrap_or_else(|| F::zero()); //
+    let field_bn = BigUint::from_bytes_le(field_elem.to_repr().as_ref());
     let field_elem_bits = maybe_u64.to_bits_le(&mut cs.namespace(|| "field element bit decomp"))?;
 
     let r64_num = to_unsigned_integer_helper(

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5739,22 +5739,26 @@ mod tests {
             Ok(Fr::from_u64(42).unwrap())
         })
         .unwrap();
-        let power2_32_num = AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 32)"), || {
-            Ok(Fr::pow_vartime(&Fr::from_u64(2).unwrap(), [32]))
+        let a_plus_power2_32_num = AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 32)"), || {
+            Ok(Fr::pow_vartime(&Fr::from_u64(2).unwrap(), [32]) + Fr::from_u64(42).unwrap())
         })
         .unwrap();
-        let add_pow_32 = add(
-            &mut cs.namespace(|| "add pow(2, 32)"),
-            &a_num,
-            &power2_32_num,
+        let bits = a_plus_power2_32_num
+            .to_bits_le(&mut cs.namespace(|| "bits"))
+            .unwrap();
+        let v = a_plus_power2_32_num
+            .get_value()
+            .unwrap_or_else(|| Fr::zero());
+        let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
+        let res = to_unsigned_integer_helper(
+            &mut cs,
+            &g,
+            &a_plus_power2_32_num,
+            field_bn,
+            &bits,
+            UnsignedInt::U32,
         )
         .unwrap();
-        let bits = add_pow_32.to_bits_le(&mut cs.namespace(|| "bits")).unwrap();
-        let v = add_pow_32.get_value().unwrap_or_else(|| Fr::zero());
-        let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
-        let res =
-            to_unsigned_integer_helper(&mut cs, &g, &add_pow_32, field_bn, &bits, UnsignedInt::U32)
-                .unwrap();
 
         equal(&mut cs, || "is equal", &res, &a_num);
         assert!(cs.is_satisfied());
@@ -5769,22 +5773,26 @@ mod tests {
             Ok(Fr::from_u64(42).unwrap())
         })
         .unwrap();
-        let power2_64_num = AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 64)"), || {
-            Ok(Fr::pow_vartime(&Fr::from_u64(2).unwrap(), [64]))
+        let a_plus_power2_32_num = AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 32)"), || {
+            Ok(Fr::pow_vartime(&Fr::from_u64(2).unwrap(), [32]) + Fr::from_u64(42).unwrap())
         })
         .unwrap();
-        let add_pow_64 = add(
-            &mut cs.namespace(|| "add pow(2, 64)"),
-            &a_num,
-            &power2_64_num,
+        let bits = a_plus_power2_32_num
+            .to_bits_le(&mut cs.namespace(|| "bits"))
+            .unwrap();
+        let v = a_plus_power2_32_num
+            .get_value()
+            .unwrap_or_else(|| Fr::zero());
+        let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
+        let res = to_unsigned_integer_helper(
+            &mut cs,
+            &g,
+            &a_plus_power2_32_num,
+            field_bn,
+            &bits,
+            UnsignedInt::U32,
         )
         .unwrap();
-        let bits = add_pow_64.to_bits_le(&mut cs.namespace(|| "bits")).unwrap();
-        let v = add_pow_64.get_value().unwrap_or_else(|| Fr::zero());
-        let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
-        let res =
-            to_unsigned_integer_helper(&mut cs, &g, &add_pow_64, field_bn, &bits, UnsignedInt::U64)
-                .unwrap();
 
         equal(&mut cs, || "is equal", &res, &a_num);
         assert!(cs.is_satisfied());

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4690,10 +4690,6 @@ pub fn to_unsigned_integer_helper<F: LurkField, CS: ConstraintSystem<F>>(
     // field element = pow(2, size).q + r
     let sum = add(&mut cs.namespace(|| "sum remainder"), &product, &r_num)?;
     equal(&mut cs, || "check unsigned decomposition", &sum, field_elem);
-    //enforce_true(
-    //    &mut cs.namespace(|| "enforce decomposition of unsigned integer"),
-    //    &unsigned_decomp,
-    //)?;
     let r_bits = &field_elem_bits[0..size.num_bits() as usize];
     enforce_pack(
         &mut cs.namespace(|| "enforce unsigned pack"),

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4639,7 +4639,7 @@ pub fn enforce_at_most_n_bits<F: LurkField, CS: ConstraintSystem<F>>(
     n: usize,
 ) -> Result<(), SynthesisError> {
     let v = num_bits[n..255].to_vec();
-    popcount(&mut cs.namespace(|| "add all MSBs"), &v, &g.false_num);
+    popcount(&mut cs.namespace(|| "add all MSBs"), &v, &g.false_num)?;
     Ok(())
 }
 
@@ -5781,7 +5781,7 @@ mod tests {
                 &mut cs.namespace(|| format!("popcount {x}")),
                 &bits,
                 alloc_popcount.hash(),
-            );
+            ).unwrap();
         }
 
         assert!(cs.is_satisfied());

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4718,7 +4718,8 @@ pub fn to_unsigned_integers<F: LurkField, CS: ConstraintSystem<F>>(
     };
     let field_bn = BigUint::from_bytes_le(field_elem.to_repr().as_ref());
     // Since bit decomposition is expensive, we compute it only once here
-    let field_elem_bits = maybe_unsigned.to_bits_le(&mut cs.namespace(|| "field element bit decomp"))?;
+    let field_elem_bits =
+        maybe_unsigned.to_bits_le(&mut cs.namespace(|| "field element bit decomp"))?;
 
     let r32_num = to_unsigned_integer_helper(
         &mut cs.namespace(|| "enforce u32"),
@@ -4746,7 +4747,6 @@ pub fn to_u64<F: LurkField, CS: ConstraintSystem<F>>(
     g: &GlobalAllocations<F>,
     maybe_u64: &AllocatedNum<F>,
 ) -> Result<AllocatedNum<F>, SynthesisError> {
-
     let field_elem = maybe_u64.get_value().unwrap_or_else(|| F::zero()); //
     let field_bn = BigUint::from_bytes_le(field_elem.to_repr().as_ref());
     let field_elem_bits = maybe_u64.to_bits_le(&mut cs.namespace(|| "field element bit decomp"))?;

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -21,7 +21,7 @@ use super::gadgets::constraints::{
     self, alloc_equal, alloc_is_zero, enforce_implication, or, pick, sub,
 };
 use crate::circuit::circuit_frame::constraints::{
-    add, allocate_is_negative, boolean_to_num, enforce_pack, enforce_true, mul, popcount,
+    add, allocate_is_negative, boolean_to_num, enforce_pack, equal, mul, popcount,
 };
 use crate::circuit::gadgets::hashes::{AllocatedConsWitness, AllocatedContWitness};
 use crate::circuit::ToInputs;
@@ -4689,15 +4689,16 @@ pub fn to_unsigned_integer_helper<F: LurkField, CS: ConstraintSystem<F>>(
 
     // field element = pow(2, size).q + r
     let sum = add(&mut cs.namespace(|| "sum remainder"), &product, &r_num)?;
-    let unsigned_decomp = alloc_equal(
-        &mut cs.namespace(|| "check unsigned decomposition"),
+    equal(
+        &mut cs,
+        || "check unsigned decomposition",
         &sum,
         field_elem,
-    )?;
-    enforce_true(
-        &mut cs.namespace(|| "enforce decomposition of unsigned integer"),
-        &unsigned_decomp,
-    )?;
+    );
+    //enforce_true(
+    //    &mut cs.namespace(|| "enforce decomposition of unsigned integer"),
+    //    &unsigned_decomp,
+    //)?;
     let r_bits = &field_elem_bits[0..size.num_bits() as usize];
     enforce_pack(
         &mut cs.namespace(|| "enforce unsigned pack"),
@@ -5110,7 +5111,7 @@ pub(crate) fn print_cs<F: LurkField, C: Comparable<F>>(this: &C) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::circuit::circuit_frame::constraints::sub;
+    use crate::circuit::circuit_frame::constraints::{enforce_true, sub};
     use crate::eval::{empty_sym_env, Evaluable, IO};
     use crate::proof::Provable;
     use crate::proof::{groth16::Groth16Prover, Prover};
@@ -5179,9 +5180,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(12512, cs.num_constraints());
+            assert_eq!(12500, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(12140, cs.aux().len());
+            assert_eq!(12131, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4659,26 +4659,20 @@ pub fn to_unsigned_integer_helper<F: LurkField, CS: ConstraintSystem<F>>(
     let (q_bn, r_bn) = field_bn.div_rem(&power_of_two_bn);
     let q_num = allocate_unconstrained_bignum(&mut cs.namespace(|| "q"), q_bn)?;
     let r_num = allocate_unconstrained_bignum(&mut cs.namespace(|| "r"), r_bn)?;
+    let pow2_size = match size {
+        UnsignedInt::U32 => &g.power2_32_num,
+        UnsignedInt::U64 => &g.power2_64_num,
+    };
 
     // field element = pow(2, size).q + r
-    match size {
-        UnsignedInt::U32 => linear(
-            &mut cs,
-            || "product(q,pow(2,32)) + r",
-            &q_num,
-            &g.power2_32_num,
-            &r_num,
-            field_elem,
-        ),
-        UnsignedInt::U64 => linear(
-            &mut cs,
-            || "product(q,pow(2,64)) + r",
-            &q_num,
-            &g.power2_64_num,
-            &r_num,
-            field_elem,
-        ),
-    };
+    linear(
+        &mut cs,
+        || "product(q,pow(2,size)) + r",
+        &q_num,
+        pow2_size,
+        &r_num,
+        field_elem,
+    );
 
     let r_bits = &field_elem_bits[0..size.num_bits() as usize];
     enforce_pack(

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5092,7 +5092,7 @@ pub(crate) fn print_cs<F: LurkField, C: Comparable<F>>(this: &C) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::circuit::circuit_frame::constraints::{equal, popcount, sub};
+    use crate::circuit::circuit_frame::constraints::{popcount, sub};
     use crate::eval::{empty_sym_env, Evaluable, IO};
     use crate::proof::Provable;
     use crate::proof::{groth16::Groth16Prover, Prover};
@@ -5741,7 +5741,7 @@ mod tests {
         let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
 
         let a_plus_power2_32_num =
-            AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 32) + 32"), || Ok(v)).unwrap();
+            AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 32) + 2"), || Ok(v)).unwrap();
 
         let bits = a_plus_power2_32_num
             .to_bits_le(&mut cs.namespace(|| "bits"))
@@ -5766,32 +5766,29 @@ mod tests {
         let mut cs = TestConstraintSystem::<Fr>::new();
         let s = &mut Store::<Fr>::default();
         let g = GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s).unwrap();
-        let a_num = AllocatedNum::alloc(&mut cs.namespace(|| "a num"), || {
-            Ok(Fr::from_u64(42).unwrap())
-        })
-        .unwrap();
-        let a_plus_power2_32_num = AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 32)"), || {
-            Ok(Fr::pow_vartime(&Fr::from_u64(2).unwrap(), [32]) + Fr::from_u64(42).unwrap())
-        })
-        .unwrap();
-        let bits = a_plus_power2_32_num
+
+        let a = Fr::from_u64(2).unwrap();
+        let v = a + Fr::pow_vartime(&Fr::from_u64(2).unwrap(), [64]);
+        let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
+
+        let a_plus_power2_64_num =
+            AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 64) + 2"), || Ok(v)).unwrap();
+
+        let bits = a_plus_power2_64_num
             .to_bits_le(&mut cs.namespace(|| "bits"))
             .unwrap();
-        let v = a_plus_power2_32_num
-            .get_value()
-            .unwrap_or_else(|| Fr::zero());
-        let field_bn = BigUint::from_bytes_le(v.to_repr().as_ref());
+
         let res = to_unsigned_integer_helper(
             &mut cs,
             &g,
-            &a_plus_power2_32_num,
+            &a_plus_power2_64_num,
             field_bn,
             &bits,
-            UnsignedInt::U32,
+            UnsignedInt::U64,
         )
         .unwrap();
 
-        equal(&mut cs, || "is equal", &res, &a_num);
+        assert_eq!(a, res.get_value().unwrap());
         assert!(cs.is_satisfied());
     }
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -5739,10 +5739,14 @@ mod tests {
             Ok(Fr::from_u64(42).unwrap())
         })
         .unwrap();
+        let power2_32_num = AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 32)"), || {
+            Ok(Fr::pow_vartime(&Fr::from_u64(2).unwrap(), [32]))
+        })
+        .unwrap();
         let add_pow_32 = add(
             &mut cs.namespace(|| "add pow(2, 32)"),
             &a_num,
-            &g.power2_32_num,
+            &power2_32_num,
         )
         .unwrap();
         let bits = add_pow_32.to_bits_le(&mut cs.namespace(|| "bits")).unwrap();
@@ -5765,10 +5769,14 @@ mod tests {
             Ok(Fr::from_u64(42).unwrap())
         })
         .unwrap();
+        let power2_64_num = AllocatedNum::alloc(&mut cs.namespace(|| "pow(2, 64)"), || {
+            Ok(Fr::pow_vartime(&Fr::from_u64(2).unwrap(), [64]))
+        })
+        .unwrap();
         let add_pow_64 = add(
             &mut cs.namespace(|| "add pow(2, 64)"),
             &a_num,
-            &g.power2_64_num,
+            &power2_64_num,
         )
         .unwrap();
         let bits = add_pow_64.to_bits_le(&mut cs.namespace(|| "bits")).unwrap();

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4696,7 +4696,7 @@ pub fn to_unsigned_integer_helper<F: LurkField, CS: ConstraintSystem<F>>(
     enforce_pack(
         &mut cs.namespace(|| "enforce unsigned pack"),
         r_bits,
-        &r_num.clone(),
+        &r_num,
     )?;
 
     Ok(r_num)

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4689,12 +4689,7 @@ pub fn to_unsigned_integer_helper<F: LurkField, CS: ConstraintSystem<F>>(
 
     // field element = pow(2, size).q + r
     let sum = add(&mut cs.namespace(|| "sum remainder"), &product, &r_num)?;
-    equal(
-        &mut cs,
-        || "check unsigned decomposition",
-        &sum,
-        field_elem,
-    );
+    equal(&mut cs, || "check unsigned decomposition", &sum, field_elem);
     //enforce_true(
     //    &mut cs.namespace(|| "enforce decomposition of unsigned integer"),
     //    &unsigned_decomp,

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -186,16 +186,18 @@ pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
     Ok(res)
 }
 
-/// Adds a constraint to CS, enforcing a product relationship between the allocated numbers a, b, and product.
+/// Adds a constraint to CS, enforcing a linear relationship between the
+/// allocated numbers a, b, c and num.  Namely, the linear equation
+/// a * b + c = num is enforced.
 ///
-/// a * b = product - c
+/// a * b = num - c
 pub fn linear<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     annotation: A,
     a: &AllocatedNum<F>,
     b: &AllocatedNum<F>,
     c: &AllocatedNum<F>,
-    l: &AllocatedNum<F>,
+    num: &AllocatedNum<F>,
 ) where
     A: FnOnce() -> AR,
     AR: Into<String>,
@@ -205,7 +207,7 @@ pub fn linear<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
         annotation,
         |lc| lc + a.get_variable(),
         |lc| lc + b.get_variable(),
-        |lc| lc + l.get_variable() - c.get_variable(),
+        |lc| lc + num.get_variable() - c.get_variable(),
     );
 }
 

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -77,6 +77,7 @@ pub fn add<F: PrimeField, CS: ConstraintSystem<F>>(
 /// is equal to `sum`.
 ///
 /// summation(v) = sum
+#[allow(dead_code)]
 pub fn popcount<F: PrimeField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     v: &Vec<Boolean>,

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -188,6 +188,29 @@ pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
 
 /// Adds a constraint to CS, enforcing a product relationship between the allocated numbers a, b, and product.
 ///
+/// a * b = product - c
+pub fn linear<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+    cs: &mut CS,
+    annotation: A,
+    a: &AllocatedNum<F>,
+    b: &AllocatedNum<F>,
+    c: &AllocatedNum<F>,
+    l: &AllocatedNum<F>,
+) where
+    A: FnOnce() -> AR,
+    AR: Into<String>,
+{
+    // a * b = product
+    cs.enforce(
+        annotation,
+        |lc| lc + a.get_variable(),
+        |lc| lc + b.get_variable(),
+        |lc| lc + l.get_variable() - c.get_variable(),
+    );
+}
+
+/// Adds a constraint to CS, enforcing a product relationship between the allocated numbers a, b, and product.
+///
 /// a * b = product
 pub fn product<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -117,6 +117,7 @@ pub struct GlobalAllocations<F: LurkField> {
     pub true_num: AllocatedNum<F>,
     pub false_num: AllocatedNum<F>,
     pub default_num: AllocatedNum<F>,
+    pub power2_32_num: AllocatedNum<F>,
     pub power2_64_num: AllocatedNum<F>,
 }
 
@@ -307,6 +308,9 @@ impl<F: LurkField> GlobalAllocations<F> {
         let false_num = allocate_constant(&mut cs.namespace(|| "false"), F::zero())?;
         let default_num = allocate_constant(&mut cs.namespace(|| "default"), F::zero())?;
 
+        let power2_32_ff = F::pow_vartime(&F::from_u64(2).unwrap(), [32]);
+        let power2_32_num = allocate_constant(&mut cs.namespace(|| "pow(2,32)"), power2_32_ff)?;
+
         let power2_64_ff = F::pow_vartime(&F::from_u64(2).unwrap(), [64]);
         let power2_64_num = allocate_constant(&mut cs.namespace(|| "pow(2,64)"), power2_64_ff)?;
 
@@ -406,6 +410,7 @@ impl<F: LurkField> GlobalAllocations<F> {
             true_num,
             false_num,
             default_num,
+            power2_32_num,
             power2_64_num,
         })
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3500,6 +3500,15 @@ mod test {
     }
 
     #[test]
+    fn char_coercion() {
+        let s = &mut Store::<Fr>::default();
+        let expr = r#"(char (- 0 4294967200))"#;
+        let expected_a = s.read(r#"#\a"#).unwrap();
+        let terminal = s.get_cont_terminal();
+        test_aux(s, expr, Some(expected_a), None, Some(terminal), None, 5);
+    }
+
+    #[test]
     fn commit_num() {
         let s = &mut Store::<Fr>::default();
         let expr = "(num (commit 123))";

--- a/src/field.rs
+++ b/src/field.rs
@@ -40,12 +40,6 @@ pub trait LurkField: PrimeField + PrimeFieldBits {
         byte_array.copy_from_slice(&self.to_repr().as_ref()[0..4]);
         Some(u32::from_le_bytes(byte_array))
     }
-    // Return a u32 corresponding to the first 4 little-endian bytes of this field element, discarding the remaining bytes.
-    fn to_u32_unchecked(&self) -> u32 {
-        let mut byte_array = [0u8; 4];
-        byte_array.copy_from_slice(&self.to_repr().as_ref()[0..4]);
-        u32::from_le_bytes(byte_array)
-    }
     fn from_u32(x: u32) -> Option<Self> {
         let mut bytes = vec![0; 32];
         bytes[0..4].as_mut().copy_from_slice(&x.to_le_bytes());

--- a/src/field.rs
+++ b/src/field.rs
@@ -40,6 +40,17 @@ pub trait LurkField: PrimeField + PrimeFieldBits {
         byte_array.copy_from_slice(&self.to_repr().as_ref()[0..4]);
         Some(u32::from_le_bytes(byte_array))
     }
+    // Return a u32 corresponding to the first 4 little-endian bytes of this field element, discarding the remaining bytes.
+    fn to_u32_unchecked(&self) -> u32 {
+        let mut byte_array = [0u8; 4];
+        byte_array.copy_from_slice(&self.to_repr().as_ref()[0..4]);
+        u32::from_le_bytes(byte_array)
+    }
+    fn from_u32(x: u32) -> Option<Self> {
+        let mut bytes = vec![0; 32];
+        bytes[0..4].as_mut().copy_from_slice(&x.to_le_bytes());
+        Self::from_bytes(&bytes)
+    }
     fn to_u64(&self) -> Option<u64> {
         for x in &self.to_repr().as_ref()[8..] {
             if *x != 0 {

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2271,9 +2271,12 @@ mod tests {
     fn outer_prove_char_coercion() {
         let s = &mut Store::<Fr>::default();
         let expr = r#"(char (- 0 4294967200))"#;
+        let expr2 = r#"(char (- 0 4294967199))"#;
         let expected_a = s.read(r#"#\a"#).unwrap();
+        let expected_b = s.read(r#"#\b"#).unwrap();
         let terminal = s.get_cont_terminal();
         nova_test_aux(s, expr, Some(expected_a), None, Some(terminal), None, 5);
+        nova_test_aux(s, expr2, Some(expected_b), None, Some(terminal), None, 5);
     }
 
     #[test]

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -2268,6 +2268,15 @@ mod tests {
     }
 
     #[test]
+    fn outer_prove_char_coercion() {
+        let s = &mut Store::<Fr>::default();
+        let expr = r#"(char (- 0 4294967200))"#;
+        let expected_a = s.read(r#"#\a"#).unwrap();
+        let terminal = s.get_cont_terminal();
+        nova_test_aux(s, expr, Some(expected_a), None, Some(terminal), None, 5);
+    }
+
+    #[test]
     fn outer_prove_commit_num() {
         let s = &mut Store::<Fr>::default();
         let expr = "(num (commit 123))";


### PR DESCRIPTION
Similarly to u64, we implemented coercion to u32, which allows us to have coercion to char. 

We do it by taking the last 4 bytes of the field element. Therefore, we have that for `N = 2^32 + x`, then`(eq (char N) (char x)) => T`. In other words, char coercion is equal to the remainder of division by 2ˆ32. 

