### PR TITLE
refactor: convert quickcheck -> proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -168,6 +168,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -457,9 +472,9 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -668,7 +683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -798,16 +813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,8 +870,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5109f6bc9cd57feda665da326f3f6c57e0498c8fe9f7d12d7b8abc96719ca91b"
 dependencies = [
  "execute-command-tokens",
- "quote",
- "syn",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -874,6 +879,15 @@ name = "execute-command-tokens"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba569491c70ec8471e34aa7e9c0b9e82bb5d2464c0398442d17d3c4af814e5a"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fcomm"
@@ -935,9 +949,9 @@ dependencies = [
  "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1133,7 +1147,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -1159,6 +1173,15 @@ dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
  "rayon",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1296,8 +1319,8 @@ dependencies = [
  "pasta_curves",
  "peekmore",
  "pretty_env_logger",
- "quickcheck",
- "quickcheck_macros",
+ "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "rand_xorshift",
  "rayon",
@@ -1307,6 +1330,7 @@ dependencies = [
  "serde_repr",
  "string-interner",
  "structopt",
+ "tap",
  "thiserror",
 ]
 
@@ -1382,9 +1406,9 @@ version = "0.1.0"
 dependencies = [
  "blstrs",
  "lurk",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1479,9 +1503,9 @@ checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -1788,7 +1812,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "log",
 ]
 
@@ -1809,9 +1833,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -1821,9 +1845,18 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -1836,31 +1869,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quickcheck"
-version = "1.0.3"
+name = "quick-error"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "env_logger 0.8.4",
- "log",
- "rand 0.8.5",
-]
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
-name = "quickcheck_macros"
-version = "1.0.0"
+name = "quote"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 0.4.30",
 ]
 
 [[package]]
@@ -1869,7 +1926,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.50",
 ]
 
 [[package]]
@@ -2094,6 +2151,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "rustyline"
 version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,8 +2192,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688599bdab9f42105d0ae1494335a9ffafdeb7d36325e6b10fd4abc5829d6284"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2201,9 +2270,9 @@ version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2223,9 +2292,9 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2345,9 +2414,9 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2358,12 +2427,23 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
  "unicode-ident",
 ]
 
@@ -2373,10 +2453,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -2402,6 +2482,20 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -2449,9 +2543,9 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2488,9 +2582,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2516,6 +2610,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -2592,9 +2692,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -2604,7 +2704,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote",
+ "quote 1.0.23",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2614,9 +2714,9 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2770,8 +2870,8 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ multihash = { version = "0.16.1", default-features = false, features = ["alloc",
 num-bigint = "0.4.3"
 num-integer = "0.1.45"
 num-traits = "0.2.15"
+proptest = "1.0.0"
+proptest-derive = "0.3.0"
 
 [features]
 default = []
@@ -53,8 +55,7 @@ gpu = ["neptune/opencl"]
 [dev-dependencies]
 criterion = "0.3.5"
 structopt = { version = "0.3", default-features = false }
-quickcheck = "1.0.3"
-quickcheck_macros = "1.0.0"
+tap = "1.0.1"
 
 [[bench]]
 name = "eval"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,6 @@ extern crate core;
 #[macro_use]
 extern crate alloc;
 
-#[cfg(test)]
-extern crate quickcheck;
-#[cfg(test)]
-#[macro_use(quickcheck)]
-extern crate quickcheck_macros;
-
 pub mod circuit;
 pub mod eval;
 pub mod field;
@@ -34,31 +28,3 @@ pub use uint::UInt;
 pub const TEST_SEED: [u8; 16] = [
     0x62, 0x59, 0x5d, 0xbe, 0x3d, 0x76, 0x3d, 0x8d, 0xdb, 0x17, 0x32, 0x37, 0x06, 0x54, 0xe5, 0xbc,
 ];
-
-#[cfg(test)]
-pub mod test {
-    use quickcheck::Gen;
-    use rand::Rng;
-
-    // This is a useful testing utility for generating Arbitrary instances of
-    // enums, by providing generators for each variant, plus a frequency weight
-    // for how often to choose that variant. It's included in lib::test to make
-    // it easier to import in the test modules of specific submodules.
-    pub fn frequency<T, F: Fn(&mut Gen) -> T>(g: &mut Gen, gens: Vec<(i64, F)>) -> T {
-        if gens.iter().any(|(v, _)| *v < 0) {
-            panic!("Negative weight");
-        }
-        let sum: i64 = gens.iter().map(|x| x.0).sum();
-        let mut rng = rand::thread_rng();
-        let mut weight: i64 = rng.gen_range(1..=sum);
-        // let mut weight: i64 = g.rng.gen_range(1, sum);
-        for gen in gens {
-            if weight - gen.0 <= 0 {
-                return gen.1(g);
-            } else {
-                weight -= gen.0;
-            }
-        }
-        panic!("Calculation error for weight = {}", weight);
-    }
-}

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -299,228 +299,231 @@ mod test {
     use crate::{Sym, Symbol};
     use blstrs::Scalar as Fr;
 
-    use quickcheck::{Arbitrary, Gen};
-
-    use crate::test::frequency;
+    use proptest::prelude::*;
+    use tap::TapFallible;
 
     use libipld::serde::from_ipld;
     use libipld::serde::to_ipld;
 
-    impl Arbitrary for ScalarThunk<Fr> {
-        fn arbitrary(g: &mut Gen) -> Self {
-            ScalarThunk {
-                value: Arbitrary::arbitrary(g),
-                continuation: Arbitrary::arbitrary(g),
-            }
+    impl<Fr: LurkField> Arbitrary for ScalarThunk<Fr> {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            (any::<ScalarPtr<Fr>>(), any::<ScalarContPtr<Fr>>())
+                .prop_map(|(value, continuation)| Self {
+                    value,
+                    continuation,
+                })
+                .boxed()
         }
     }
 
-    impl Arbitrary for Symbol {
-        fn arbitrary(g: &mut Gen) -> Self {
-            Symbol {
-                path: Arbitrary::arbitrary(g),
-                opaque: Arbitrary::arbitrary(g),
-            }
+    proptest! {
+        fn prop_scalar_thunk_ipld(x in any::<ScalarThunk<Fr>>())  {
+            let to_ipld = to_ipld(x).unwrap();
+            let y = from_ipld(to_ipld).unwrap();
+            assert_eq!(x, y);
         }
     }
 
-    #[quickcheck]
-    fn prop_scalar_thunk_ipld(x: ScalarThunk<Fr>) -> bool {
-        if let Ok(ipld) = to_ipld(x) {
-            if let Ok(y) = from_ipld(ipld) {
-                x == y
-            } else {
-                false
-            }
-        } else {
-            false
+    impl<Fr: LurkField> Arbitrary for ScalarExpression<Fr> {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            prop_oneof!(
+                Just(Self::Nil),
+                any::<(ScalarPtr<Fr>, ScalarPtr<Fr>)>().prop_map(|(x, y)| Self::Cons(x, y)),
+                any::<Symbol>().prop_map(|x| Self::Sym(Sym::Sym(x))),
+                any::<String>().prop_map(|x| Self::Str(x)),
+                any::<FWrap<Fr>>().prop_map(|x| Self::Num(x.0)),
+                any::<(ScalarPtr<Fr>, ScalarPtr<Fr>, ScalarPtr<Fr>)>().prop_map(
+                    |(arg, body, closed_env)| {
+                        Self::Fun {
+                            arg,
+                            body,
+                            closed_env,
+                        }
+                    }
+                ),
+                any::<ScalarThunk<Fr>>().prop_map(|x| Self::Thunk(x)),
+            )
+            .boxed()
         }
     }
 
-    impl Arbitrary for ScalarExpression<Fr> {
-        fn arbitrary(g: &mut Gen) -> Self {
-            let input: Vec<(i64, Box<dyn Fn(&mut Gen) -> ScalarExpression<Fr>>)> = vec![
-                (100, Box::new(|_| Self::Nil)),
-                (
-                    100,
-                    Box::new(|g| Self::Cons(ScalarPtr::arbitrary(g), ScalarPtr::arbitrary(g))),
+    impl<Fr: LurkField> Arbitrary for ScalarContinuation<Fr> {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            prop_oneof!(
+                Just(Self::Outermost),
+                any::<(ScalarPtr<Fr>, ScalarPtr<Fr>, ScalarContPtr<Fr>)>().prop_map(
+                    |(unevaled_arg, saved_env, continuation)| {
+                        Self::Call {
+                            unevaled_arg,
+                            saved_env,
+                            continuation,
+                        }
+                    }
                 ),
-                (100, Box::new(|g| Self::Sym(Sym::Sym(Symbol::arbitrary(g))))),
-                (100, Box::new(|g| Self::Str(String::arbitrary(g)))),
-                (
-                    100,
-                    Box::new(|g| {
-                        let f = FWrap::arbitrary(g);
-                        Self::Num(f.0)
-                    }),
+                any::<(ScalarPtr<Fr>, ScalarPtr<Fr>, ScalarContPtr<Fr>)>().prop_map(
+                    |(function, saved_env, continuation)| {
+                        Self::Call2 {
+                            function,
+                            saved_env,
+                            continuation,
+                        }
+                    }
                 ),
-                (
-                    100,
-                    Box::new(|g| Self::Fun {
-                        arg: ScalarPtr::arbitrary(g),
-                        body: ScalarPtr::arbitrary(g),
-                        closed_env: ScalarPtr::arbitrary(g),
-                    }),
+                any::<(ScalarPtr<Fr>, ScalarContPtr<Fr>)>().prop_map(
+                    |(saved_env, continuation)| {
+                        Self::Tail {
+                            saved_env,
+                            continuation,
+                        }
+                    }
                 ),
-                (100, Box::new(|g| Self::Thunk(ScalarThunk::arbitrary(g)))),
-            ];
-            frequency(g, input)
+                Just(Self::Error),
+                any::<(ScalarPtr<Fr>, ScalarContPtr<Fr>)>().prop_map(
+                    |(saved_env, continuation)| {
+                        Self::Lookup {
+                            saved_env,
+                            continuation,
+                        }
+                    }
+                ),
+                any::<(Op1, ScalarContPtr<Fr>)>().prop_map(|(operator, continuation)| {
+                    Self::Unop {
+                        operator,
+                        continuation,
+                    }
+                }),
+                any::<(Op2, ScalarPtr<Fr>, ScalarPtr<Fr>, ScalarContPtr<Fr>)>().prop_map(
+                    |(operator, saved_env, unevaled_args, continuation)| {
+                        Self::Binop {
+                            operator,
+                            saved_env,
+                            unevaled_args,
+                            continuation,
+                        }
+                    }
+                ),
+                any::<(Op2, ScalarPtr<Fr>, ScalarContPtr<Fr>)>().prop_map(
+                    |(operator, evaled_arg, continuation)| {
+                        Self::Binop2 {
+                            operator,
+                            evaled_arg,
+                            continuation,
+                        }
+                    }
+                ),
+                any::<(ScalarPtr<Fr>, ScalarContPtr<Fr>)>().prop_map(
+                    |(unevaled_args, continuation)| {
+                        Self::If {
+                            unevaled_args,
+                            continuation,
+                        }
+                    }
+                ),
+                any::<(
+                    ScalarPtr<Fr>,
+                    ScalarPtr<Fr>,
+                    ScalarPtr<Fr>,
+                    ScalarContPtr<Fr>
+                )>()
+                .prop_map(|(var, body, saved_env, continuation)| {
+                    Self::Let {
+                        var,
+                        body,
+                        saved_env,
+                        continuation,
+                    }
+                }),
+                any::<(
+                    ScalarPtr<Fr>,
+                    ScalarPtr<Fr>,
+                    ScalarPtr<Fr>,
+                    ScalarContPtr<Fr>
+                )>()
+                .prop_map(|(var, body, saved_env, continuation)| {
+                    Self::LetRec {
+                        var,
+                        body,
+                        saved_env,
+                        continuation,
+                    }
+                }),
+                Just(Self::Dummy),
+                Just(Self::Terminal)
+            )
+            .boxed()
         }
     }
 
-    impl Arbitrary for ScalarContinuation<Fr> {
-        fn arbitrary(g: &mut Gen) -> Self {
-            let input: Vec<(i64, Box<dyn Fn(&mut Gen) -> ScalarContinuation<Fr>>)> = vec![
-                (100, Box::new(|_| Self::Outermost)),
-                (
-                    100,
-                    Box::new(|g| Self::Call {
-                        unevaled_arg: ScalarPtr::arbitrary(g),
-                        saved_env: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::Call2 {
-                        function: ScalarPtr::arbitrary(g),
-                        saved_env: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::Tail {
-                        saved_env: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (100, Box::new(|_| Self::Error)),
-                (
-                    100,
-                    Box::new(|g| Self::Lookup {
-                        saved_env: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::Unop {
-                        operator: Op1::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::Binop {
-                        operator: Op2::arbitrary(g),
-                        saved_env: ScalarPtr::arbitrary(g),
-                        unevaled_args: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::Binop2 {
-                        operator: Op2::arbitrary(g),
-                        evaled_arg: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::If {
-                        unevaled_args: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::Let {
-                        var: ScalarPtr::arbitrary(g),
-                        body: ScalarPtr::arbitrary(g),
-                        saved_env: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (
-                    100,
-                    Box::new(|g| Self::LetRec {
-                        var: ScalarPtr::arbitrary(g),
-                        saved_env: ScalarPtr::arbitrary(g),
-                        body: ScalarPtr::arbitrary(g),
-                        continuation: ScalarContPtr::arbitrary(g),
-                    }),
-                ),
-                (100, Box::new(|_| Self::Dummy)),
-                (100, Box::new(|_| Self::Terminal)),
-            ];
-            frequency(g, input)
-        }
-    }
-
-    #[quickcheck]
-    fn prop_scalar_expression_ipld(x: ScalarExpression<Fr>) -> bool {
-        match to_ipld(x.clone()) {
-            Ok(ipld) => match from_ipld(ipld.clone()) {
-                Ok(y) => {
-                    println!("x: {x:?}");
-                    println!("y: {y:?}");
-                    x == y
-                }
-                Err(e) => {
-                    println!("ser x: {x:?}");
-                    println!("de ipld: {ipld:?}");
-                    println!("err e: {e:?}");
-                    false
-                }
-            },
-            Err(e) => {
+    proptest! {
+        fn prop_scalar_expression_ipld(x: ScalarExpression<Fr>) {
+            let to_ipld = to_ipld(x.clone()).tap_err(|e| {
                 println!("ser x: {x:?}");
                 println!("err e: {e:?}");
-                false
-            }
-        }
-    }
+            }).unwrap();
 
-    #[quickcheck]
-    fn prop_scalar_continuation_ipld(x: ScalarExpression<Fr>) -> bool {
-        if let Ok(ipld) = to_ipld(x.clone()) {
-            if let Ok(y) = from_ipld(ipld) {
-                x == y
-            } else {
-                false
-            }
-        } else {
-            false
+            let y = from_ipld(to_ipld.clone()).tap_err(|e| {
+                println!("ser x: {x:?}");
+                println!("de ipld: {to_ipld:?}");
+                println!("err e: {e:?}");
+            }).unwrap();
+
+            println!("x: {x:?}");
+            println!("y: {y:?}");
+
+            assert_eq!(x, y);
+
         }
+
+        fn prop_scalar_continuation_ipld(x: ScalarExpression<Fr>) {
+            let to_ipld = to_ipld(x.clone()).unwrap();
+            let from_ipld = from_ipld(to_ipld).unwrap();
+            assert_eq!(x, from_ipld);
+        }
+
     }
 
     // This doesn't create well-defined ScalarStores, so is only useful for
     // testing ipld
-    impl Arbitrary for ScalarStore<Fr> {
-        fn arbitrary(g: &mut Gen) -> Self {
-            let map: Vec<(ScalarPtr<Fr>, Option<ScalarExpression<Fr>>)> = Arbitrary::arbitrary(g);
-            let cont_map: Vec<(ScalarContPtr<Fr>, Option<ScalarContinuation<Fr>>)> =
-                Arbitrary::arbitrary(g);
-            ScalarStore {
-                scalar_map: map.into_iter().collect(),
-                scalar_cont_map: cont_map.into_iter().collect(),
-                pending_scalar_ptrs: Vec::new(),
-            }
+    impl<Fr: LurkField> Arbitrary for ScalarStore<Fr> {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            (
+                prop::collection::btree_map(
+                    any::<ScalarPtr<Fr>>(),
+                    any::<Option<ScalarExpression<Fr>>>(),
+                    0..100,
+                ),
+                prop::collection::btree_map(
+                    any::<ScalarContPtr<Fr>>(),
+                    any::<Option<ScalarContinuation<Fr>>>(),
+                    0..100,
+                ),
+            )
+                .prop_map(|(scalar_map, scalar_cont_map)| ScalarStore {
+                    scalar_map,
+                    scalar_cont_map,
+                    pending_scalar_ptrs: Vec::new(),
+                })
+                .boxed()
         }
     }
 
-    #[quickcheck]
-    fn prop_scalar_store_ipld(x: ScalarStore<Fr>) -> bool {
-        if let Ok(ipld) = to_ipld(x.clone()) {
-            if let Ok(y) = from_ipld(ipld) {
-                x == y
-            } else {
-                false
-            }
-        } else {
-            false
+    proptest! {
+        fn prop_scalar_store_ipld(x: ScalarStore<Fr>) {
+            let to_ipld = to_ipld(x.clone()).unwrap();
+            let from_ipld = from_ipld(to_ipld).unwrap();
+            assert_eq!(x, from_ipld);
         }
     }
 

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -3,10 +3,11 @@ use crate::parser::{
 };
 
 use peekmore::PeekMore;
+use proptest_derive::Arbitrary;
 /// Module for symbol type, Sym.
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Arbitrary)]
 pub struct Symbol {
     pub path: Vec<String>,
     // It would be better not to have this here, but it simplifies things in the Store, at least for now.


### PR DESCRIPTION
This is meant to start the discussion on a conversion from [quickcheck](https://github.com/BurntSushi/quickcheck) to [proptest](https://github.com/proptest-rs/proptest).

A few notes:
1. I deleted the `frequency` function, and replaced it with [`prop_oneof`](https://docs.rs/proptest/latest/proptest/macro.prop_oneof.html). It may seem like the weighing of each alternative disappeared, but that is not the case: the `prop_oneof!` macro supports weights, it just has a more simple form in case all those weighs are identical.
1. I'm under-using the derivation of `Arbitrary` through [proptest-derive](https://altsysrq.github.io/proptest-book/proptest-derive/index.html). This is voluntary at this stage, for two reasons:
    - backwards-compatibility: the explicit composition of instances of `Arbitrary` for large enums may have missed certain variants (e.g. the strategy for `Tag` does not generate `Char`, `Comm`, `U64` or `Key`), whereas a derived instance would not miss anything. That could create test failures I didn't want to deal with as part of this PR (I'll get to it eventually of course).
    - deriving `Arbitrary` requires having access to the instance definitions of all the (transitively) composing fields. This essentially requires moving the `Arbitrary` impls from test modules to the main code (which can also [help usability of the library](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits)). I wanted to make sure no one feels strongly against this.
    
Note: this means that a ton of `impl Arbitrary for Foo` could disappear in a future PR, as soon as they are basically doing instance composition with no variability (e.g. exploring enums with empty variants like `FooTag`).

Perf impact is minimal:
https://gist.github.com/huitseeker/d8a203e2bc56ea6043cb67a0e8386312