### PR TITLE
Refactor errors

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2134,7 +2134,6 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         cont,
         &g.error_ptr_cont,
     )?;
-
     results.add_clauses_cons(
         *current_env_hash.value(),
         env,

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -2134,6 +2134,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         cont,
         &g.error_ptr_cont,
     )?;
+
     results.add_clauses_cons(
         *current_env_hash.value(),
         env,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
-use crate::field::LurkField;
 use crate::parser;
-use crate::store::{self, Ptr};
+use crate::store;
 use bellperson::SynthesisError;
 use nova::errors::NovaError;
 use thiserror::Error;
@@ -23,18 +22,4 @@ pub enum RuntimeError {
     Store(#[from] store::Error),
     #[error("Parser error: {0}")]
     Parser(#[from] parser::Error),
-}
-
-#[derive(Error, Debug, Clone)]
-pub enum ReduceError<F: LurkField> {
-    #[error("Runtime error: {0}")]
-    Runtime(#[from] RuntimeError),
-    #[error("Explicit error: {0}")]
-    Explicit(String, Ptr<F>),
-}
-
-impl<F: LurkField> From<store::Error> for ReduceError<F> {
-    fn from(e: store::Error) -> Self {
-        Self::Runtime(e.into())
-    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
-use crate::eval;
 use crate::field;
 use crate::parser;
-use crate::store;
+use crate::store::{self, Ptr};
 use bellperson::SynthesisError;
 use nova::errors::NovaError;
 use thiserror::Error;
@@ -12,13 +11,13 @@ pub enum ProofError {
     Nova(NovaError),
     #[error("Synthesis error: {0}")]
     Synthesis(#[from] SynthesisError),
-    #[error("Lurk error: {0}")]
-    Lurk(#[from] LurkError),
+    #[error("Runtime error: {0}")]
+    RuntimeError(#[from] RuntimeError),
 }
 
 #[derive(Error, Debug, Clone)]
-pub enum LurkError {
-    #[error("Evaluation error: {0}")]
+pub enum RuntimeError {
+    #[error("Reduction error: {0}")]
     Reduce(String),
     #[error("Lookup error: {0}")]
     Store(#[from] store::Error),
@@ -28,8 +27,8 @@ pub enum LurkError {
 
 #[derive(Error, Debug, Clone)]
 pub enum ReduceError<F: field::LurkField> {
-    #[error("Lurk error: {0}")]
-    Lurk(#[from] LurkError),
+    #[error("Runtime error: {0}")]
+    Runtime(#[from] RuntimeError),
     #[error("Explicit error: {0}")]
-    Explicit(#[from] eval::ExplicitError<F>),
+    Explicit(String, Ptr<F>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::field;
+use crate::field::LurkField;
 use crate::parser;
 use crate::store::{self, Ptr};
 use bellperson::SynthesisError;
@@ -26,9 +26,15 @@ pub enum RuntimeError {
 }
 
 #[derive(Error, Debug, Clone)]
-pub enum ReduceError<F: field::LurkField> {
+pub enum ReduceError<F: LurkField> {
     #[error("Runtime error: {0}")]
     Runtime(#[from] RuntimeError),
     #[error("Explicit error: {0}")]
     Explicit(String, Ptr<F>),
+}
+
+impl<F: LurkField> From<store::Error> for ReduceError<F> {
+    fn from(e: store::Error) -> Self {
+        Self::Runtime(e.into())
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,8 @@ pub enum ProofError {
 
 #[derive(Error, Debug, Clone)]
 pub enum RuntimeError {
-    #[error("Reduction error: {0}")]
-    Reduce(String),
+    #[error("Miscellaneous error: {0}")]
+    Misc(String),
     #[error("Lookup error: {0}")]
     Store(#[from] store::Error),
     #[error("Parser error: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use crate::parser;
 use crate::store;
 use bellperson::SynthesisError;
 use nova::errors::NovaError;
@@ -10,16 +9,26 @@ pub enum ProofError {
     Nova(NovaError),
     #[error("Synthesis error: {0}")]
     Synthesis(#[from] SynthesisError),
-    #[error("Runtime error: {0}")]
-    RuntimeError(#[from] RuntimeError),
+    #[error("Reduction error: {0}")]
+    Reduction(#[from] ReductionError),
+}
+
+impl From<NovaError> for ProofError {
+    fn from(e: NovaError) -> Self {
+        Self::Nova(e)
+    }
+}
+
+impl From<store::Error> for ProofError {
+    fn from(e: store::Error) -> Self {
+        Self::Reduction(e.into())
+    }
 }
 
 #[derive(Error, Debug, Clone)]
-pub enum RuntimeError {
+pub enum ReductionError {
     #[error("Miscellaneous error: {0}")]
     Misc(String),
     #[error("Lookup error: {0}")]
     Store(#[from] store::Error),
-    #[error("Parser error: {0}")]
-    Parser(#[from] parser::Error),
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2137,9 +2137,9 @@ fn extend_closure<F: LurkField>(
             }
             _ => unreachable!(),
         },
-        _ => Err(ReduceError::Runtime(RuntimeError::Misc(format!(
-            "extend_closure received non-Fun: {fun:?}"
-        )))),
+        _ => unreachable!(
+            "fun.tag() stopped being Tag::Fun after already having been checked in caller."
+        ),
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,4 +1,4 @@
-use crate::error::RuntimeError;
+use crate::error::ReductionError;
 use crate::field::LurkField;
 use crate::hash_witness::{ConsName, ConsWitness, ContName, ContWitness};
 use crate::num::Num;
@@ -128,7 +128,7 @@ impl<F: LurkField, W: Copy> Frame<IO<F>, W> {
 }
 
 pub trait Evaluable<F: LurkField, W> {
-    fn reduce(&self, store: &mut Store<F>) -> Result<(Self, W), RuntimeError>
+    fn reduce(&self, store: &mut Store<F>) -> Result<(Self, W), ReductionError>
     where
         Self: Sized;
 
@@ -141,7 +141,7 @@ pub trait Evaluable<F: LurkField, W> {
 }
 
 impl<F: LurkField> Evaluable<F, Witness<F>> for IO<F> {
-    fn reduce(&self, store: &mut Store<F>) -> Result<(Self, Witness<F>), RuntimeError> {
+    fn reduce(&self, store: &mut Store<F>) -> Result<(Self, Witness<F>), ReductionError> {
         let (expr, env, cont, witness) = reduce(self.expr, self.env, self.cont, store)?;
         Ok((Self { expr, env, cont }, witness))
     }
@@ -220,7 +220,7 @@ impl<F: LurkField> IO<F> {
 }
 
 impl<F: LurkField, T: Evaluable<F, Witness<F>> + Clone + PartialEq + Copy> Frame<T, Witness<F>> {
-    pub(crate) fn next(&self, store: &mut Store<F>) -> Result<Self, RuntimeError> {
+    pub(crate) fn next(&self, store: &mut Store<F>) -> Result<Self, ReductionError> {
         let input = self.output;
         let (output, witness) = input.reduce(store)?;
 
@@ -237,7 +237,7 @@ impl<F: LurkField, T: Evaluable<F, Witness<F>> + Clone + PartialEq + Copy> Frame
 }
 
 impl<F: LurkField, T: Evaluable<F, Witness<F>> + Clone + PartialEq + Copy> Frame<T, Witness<F>> {
-    fn from_initial_input(input: T, store: &mut Store<F>) -> Result<Self, RuntimeError> {
+    fn from_initial_input(input: T, store: &mut Store<F>) -> Result<Self, ReductionError> {
         input.log(store, 0);
         let (output, witness) = input.reduce(store)?;
         Ok(Self {
@@ -257,7 +257,7 @@ pub struct FrameIt<'a, W: Copy, F: LurkField> {
 }
 
 impl<'a, F: LurkField> FrameIt<'a, Witness<F>, F> {
-    fn new(initial_input: IO<F>, store: &'a mut Store<F>) -> Result<Self, RuntimeError> {
+    fn new(initial_input: IO<F>, store: &'a mut Store<F>) -> Result<Self, ReductionError> {
         let frame = Frame::from_initial_input(initial_input, store)?;
         Ok(Self {
             first: true,
@@ -277,7 +277,7 @@ impl<'a, F: LurkField> FrameIt<'a, Witness<F>, F> {
             Frame<IO<F>, Witness<F>>,
             Vec<Ptr<F>>,
         ),
-        RuntimeError,
+        ReductionError,
     > {
         let mut previous_frame = self.frame.clone();
         let mut emitted: Vec<Ptr<F>> = Vec::new();
@@ -298,10 +298,10 @@ impl<'a, F: LurkField> FrameIt<'a, Witness<F>, F> {
 
 // Wrapper struct to preserve errors that would otherwise be lost during iteration
 #[derive(Debug)]
-struct ResultFrame<'a, F: LurkField>(Result<FrameIt<'a, Witness<F>, F>, RuntimeError>);
+struct ResultFrame<'a, F: LurkField>(Result<FrameIt<'a, Witness<F>, F>, ReductionError>);
 
 impl<'a, F: LurkField> Iterator for ResultFrame<'a, F> {
-    type Item = Result<Frame<IO<F>, Witness<F>>, RuntimeError>;
+    type Item = Result<Frame<IO<F>, Witness<F>>, ReductionError>;
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         let mut frame_it = match &mut self.0 {
             Ok(f) => f,
@@ -363,7 +363,7 @@ fn reduce<F: LurkField>(
     env: Ptr<F>,
     cont: ContPtr<F>,
     store: &mut Store<F>,
-) -> Result<(Ptr<F>, Ptr<F>, ContPtr<F>, Witness<F>), RuntimeError> {
+) -> Result<(Ptr<F>, Ptr<F>, ContPtr<F>, Witness<F>), ReductionError> {
     let (ctrl, witness) = reduce_with_witness(expr, env, cont, store)?;
     let (new_expr, new_env, new_cont) = ctrl.into_results(store);
 
@@ -405,7 +405,7 @@ fn reduce_with_witness_inner<F: LurkField>(
     store: &mut Store<F>,
     cons_witness: &mut ConsWitness<F>,
     cont_witness: &mut ContWitness<F>,
-) -> Result<(Control<F>, Option<Ptr<F>>), RuntimeError> {
+) -> Result<(Control<F>, Option<Ptr<F>>), ReductionError> {
     let mut closure_to_extend = None;
     Ok((
         if cont.tag() == ContTag::Terminal {
@@ -414,7 +414,7 @@ fn reduce_with_witness_inner<F: LurkField>(
             match expr.tag() {
                 Tag::Thunk => match store
                     .fetch(&expr)
-                    .ok_or_else(|| RuntimeError::Store(store::Error("Fetch failed".into())))?
+                    .ok_or_else(|| store::Error("Fetch failed".into()))?
                 {
                     Expression::Thunk(thunk) => {
                         Control::ApplyContinuation(thunk.value, env, thunk.continuation)
@@ -789,9 +789,8 @@ fn reduce_with_witness_inner<F: LurkField>(
                             )
                         }
                     } else if head == store.lurk_sym("car") {
-                        let (arg1, end) = cons_witness
-                            .car_cdr_mut_named(ConsName::ExprCdr, store, &rest)
-                            .map_err(|e| RuntimeError::Store(e))?;
+                        let (arg1, end) =
+                            cons_witness.car_cdr_mut_named(ConsName::ExprCdr, store, &rest)?;
                         if !end.is_nil() {
                             Control::Error(expr, env)
                         } else {
@@ -809,9 +808,8 @@ fn reduce_with_witness_inner<F: LurkField>(
                             )
                         }
                     } else if head == store.lurk_sym("cdr") {
-                        let (arg1, end) = cons_witness
-                            .car_cdr_mut_named(ConsName::ExprCdr, store, &rest)
-                            .map_err(|e| RuntimeError::Store(e))?;
+                        let (arg1, end) =
+                            cons_witness.car_cdr_mut_named(ConsName::ExprCdr, store, &rest)?;
                         if !end.is_nil() {
                             Control::Error(expr, env)
                         } else {
@@ -1317,7 +1315,7 @@ pub fn reduce_with_witness<F: LurkField>(
     env: Ptr<F>,
     cont: ContPtr<F>,
     store: &mut Store<F>,
-) -> Result<(Control<F>, Witness<F>), RuntimeError> {
+) -> Result<(Control<F>, Witness<F>), ReductionError> {
     let cons_witness = &mut ConsWitness::<F>::new_dummy();
     let cont_witness = &mut ContWitness::<F>::new_dummy();
 
@@ -1351,7 +1349,7 @@ fn apply_continuation<F: LurkField>(
     control: Control<F>,
     store: &mut Store<F>,
     witness: &mut Witness<F>,
-) -> Result<Control<F>, RuntimeError> {
+) -> Result<Control<F>, ReductionError> {
     if !control.is_apply_continuation() {
         return Ok(control);
     }
@@ -1599,12 +1597,7 @@ fn apply_continuation<F: LurkField>(
                             let scalar_ptr = store
                                 .get_expr_hash(&result)
                                 .ok_or_else(|| store::Error("expr hash missing".into()))?;
-                            store.get_char(
-                                char::from_u32(scalar_ptr.value().to_u32().ok_or_else(|| {
-                                    RuntimeError::Misc("Ptr is invalid u32".into())
-                                })?)
-                                .ok_or_else(|| RuntimeError::Misc("u32 is invalid char".into()))?,
-                            )
+                            store.get_char_from_u32(scalar_ptr.value().to_u32_unchecked())
                         }
                         _ => return Ok(Control::Error(result, env)),
                     },
@@ -1886,7 +1879,7 @@ fn make_thunk<F: LurkField>(
     control: Control<F>,
     store: &mut Store<F>,
     witness: &mut Witness<F>,
-) -> Result<Control<F>, RuntimeError> {
+) -> Result<Control<F>, ReductionError> {
     if !control.is_make_thunk() {
         return Ok(control);
     }
@@ -1976,7 +1969,7 @@ where
         }
     }
 
-    pub fn eval(&mut self) -> Result<(IO<F>, usize, Vec<Ptr<F>>), RuntimeError> {
+    pub fn eval(&mut self) -> Result<(IO<F>, usize, Vec<Ptr<F>>), ReductionError> {
         let initial_input = self.initial();
         let frame_iterator = FrameIt::new(initial_input, self.store)?;
 
@@ -2003,14 +1996,14 @@ where
         }
     }
 
-    pub fn iter(&mut self) -> Result<Take<FrameIt<'_, Witness<F>, F>>, RuntimeError> {
+    pub fn iter(&mut self) -> Result<Take<FrameIt<'_, Witness<F>, F>>, ReductionError> {
         let initial_input = self.initial();
 
         Ok(FrameIt::new(initial_input, self.store)?.take(self.limit))
     }
 
     // Wraps frames in Result type in order to fail gracefully
-    pub fn get_frames(&mut self) -> Result<Vec<Frame<IO<F>, Witness<F>>>, RuntimeError> {
+    pub fn get_frames(&mut self) -> Result<Vec<Frame<IO<F>, Witness<F>>>, ReductionError> {
         let frame = FrameIt::new(self.initial(), self.store)?;
         let result_frame = ResultFrame(Ok(frame)).take(self.limit);
         let ret: Result<Vec<_>, _> = result_frame.collect();
@@ -2023,7 +2016,7 @@ where
         store: &'a mut Store<F>,
         limit: usize,
         needs_frame_padding: Fp,
-    ) -> Result<Vec<Frame<IO<F>, Witness<F>>>, RuntimeError> {
+    ) -> Result<Vec<Frame<IO<F>, Witness<F>>>, ReductionError> {
         let mut evaluator = Self::new(expr, env, store, limit);
 
         let mut frames = evaluator.get_frames()?;
@@ -2064,7 +2057,7 @@ fn extend_rec<F: LurkField>(
     val: Ptr<F>,
     store: &mut Store<F>,
     cons_witness: &mut ConsWitness<F>,
-) -> Result<Ptr<F>, RuntimeError> {
+) -> Result<Ptr<F>, ReductionError> {
     let (binding_or_env, rest) = cons_witness.car_cdr_named(ConsName::Env, store, &env)?;
     let (var_or_binding, _val_or_more_bindings) =
         cons_witness.car_cdr_named(ConsName::EnvCar, store, &binding_or_env)?;
@@ -2095,7 +2088,7 @@ fn extend_closure<F: LurkField>(
     rec_env: &Ptr<F>,
     store: &mut Store<F>,
     cons_witness: &mut ConsWitness<F>,
-) -> Result<Ptr<F>, RuntimeError> {
+) -> Result<Ptr<F>, ReductionError> {
     match fun.tag() {
         Tag::Fun => match store
             .fetch(fun)
@@ -2153,7 +2146,7 @@ fn lookup<F: LurkField>(
 
 // Convenience functions, mostly for use in tests.
 
-pub fn eval_to_ptr<F: LurkField>(s: &mut Store<F>, src: &str) -> Result<Ptr<F>, RuntimeError> {
+pub fn eval_to_ptr<F: LurkField>(s: &mut Store<F>, src: &str) -> Result<Ptr<F>, ReductionError> {
     let expr = s.read(src).unwrap();
     let limit = 1000000;
     Ok(Evaluator::new(expr, empty_sym_env(s), s, limit)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -597,7 +597,7 @@ fn reduce_with_witness_control<F: LurkField>(
                                             }
                                         }
                                     }
-                                    _ => Control::Return(expr, env, store.intern_cont_error()), // CIRCUIT: with_other_binding
+                                    _ => Err(ExplicitError("Evaluation error".into(), expr))?, // CIRCUIT: with_other_binding
                                 }
                             }
                         }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1626,11 +1626,9 @@ fn apply_continuation<F: LurkField>(
                                 .ok_or_else(|| store::Error("expr hash missing".into()))?;
                             store.get_char(
                                 char::from_u32(scalar_ptr.value().to_u32().ok_or_else(|| {
-                                    RuntimeError::Reduce("Ptr is invalid u32".into())
+                                    RuntimeError::Misc("Ptr is invalid u32".into())
                                 })?)
-                                .ok_or_else(|| {
-                                    RuntimeError::Reduce("u32 is invalid char".into())
-                                })?,
+                                .ok_or_else(|| RuntimeError::Misc("u32 is invalid char".into()))?,
                             )
                         }
                         _ => return Ok(Control::Return(*result, *env, store.intern_cont_error())),
@@ -2122,11 +2120,11 @@ fn extend_closure<F: LurkField>(
     rec_env: &Ptr<F>,
     store: &mut Store<F>,
     cons_witness: &mut ConsWitness<F>,
-) -> Result<Ptr<F>, RuntimeError> {
+) -> Result<Ptr<F>, ReduceError<F>> {
     match fun.tag() {
         Tag::Fun => match store
             .fetch(fun)
-            .ok_or_else(|| store::Error("Fetch failed".into()))?
+            .ok_or_else(|| ReduceError::Runtime(store::Error("Fetch failed".into()).into()))?
         {
             Expression::Fun(arg, body, closed_env) => {
                 let extended = cons_witness.cons_named(
@@ -2139,9 +2137,9 @@ fn extend_closure<F: LurkField>(
             }
             _ => unreachable!(),
         },
-        _ => Err(RuntimeError::Reduce(format!(
+        _ => Err(ReduceError::Runtime(RuntimeError::Misc(format!(
             "extend_closure received non-Fun: {fun:?}"
-        ))),
+        )))),
     }
 }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -24,6 +24,12 @@ pub trait LurkField: PrimeField + PrimeFieldBits {
         def.as_mut().copy_from_slice(bs);
         Self::from_repr(def).into()
     }
+    // Return a u32 corresponding to the first 4 little-endian bytes of this field element, discarding the remaining bytes.
+    fn to_u32_unchecked(&self) -> u32 {
+        let mut byte_array = [0u8; 4];
+        byte_array.copy_from_slice(&self.to_repr().as_ref()[0..4]);
+        u32::from_le_bytes(byte_array)
+    }
     fn to_u32(&self) -> Option<u32> {
         for x in &self.to_repr().as_ref()[4..] {
             if *x != 0 {

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use crate::error;
 use crate::field::LurkField;
 use crate::store;
 use crate::store::{ContPtr, Continuation, Ptr, Store};
@@ -146,7 +145,7 @@ impl<F: LurkField> ConsStub<F> {
         &mut self,
         s: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), error::ReductionError> {
+    ) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         match self {
             Self::Dummy => {
                 let (car, cdr) = Cons::get_car_cdr(s, cons)?;
@@ -338,7 +337,7 @@ impl<F: LurkField> ConsWitness<F> {
         name: ConsName,
         store: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), error::ReductionError> {
+    ) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         self.get_assigned_slot(name).car_cdr(store, cons)
     }
 

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -146,7 +146,7 @@ impl<F: LurkField> ConsStub<F> {
         &mut self,
         s: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), error::RuntimeError> {
+    ) -> Result<(Ptr<F>, Ptr<F>), error::ReductionError> {
         match self {
             Self::Dummy => {
                 let (car, cdr) = Cons::get_car_cdr(s, cons)?;
@@ -338,7 +338,7 @@ impl<F: LurkField> ConsWitness<F> {
         name: ConsName,
         store: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), error::RuntimeError> {
+    ) -> Result<(Ptr<F>, Ptr<F>), error::ReductionError> {
         self.get_assigned_slot(name).car_cdr(store, cons)
     }
 

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -146,7 +146,7 @@ impl<F: LurkField> ConsStub<F> {
         &mut self,
         s: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), error::LurkError> {
+    ) -> Result<(Ptr<F>, Ptr<F>), error::RuntimeError> {
         match self {
             Self::Dummy => {
                 let (car, cdr) = Cons::get_car_cdr(s, cons)?;
@@ -338,7 +338,7 @@ impl<F: LurkField> ConsWitness<F> {
         name: ConsName,
         store: &mut Store<F>,
         cons: &Ptr<F>,
-    ) -> Result<(Ptr<F>, Ptr<F>), error::LurkError> {
+    ) -> Result<(Ptr<F>, Ptr<F>), error::RuntimeError> {
         self.get_assigned_slot(name).car_cdr(store, cons)
     }
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -21,7 +21,7 @@ use crate::circuit::{
     },
     CircuitFrame, MultiFrame,
 };
-use crate::error::{LurkError, ProofError};
+use crate::error::{RuntimeError, ProofError};
 use crate::eval::{Evaluator, Frame, Witness, IO};
 use crate::field::LurkField;
 use crate::proof::{Prover, PublicParameters};
@@ -102,13 +102,13 @@ impl<F: LurkField> NovaProver<F> {
         limit: usize,
     ) -> Result<(Proof, Vec<S1>, Vec<S1>, usize), ProofError> {
         let frames = self.get_evaluation_frames(expr, env, store, limit)?;
-        let z0 = frames[0].input.to_vector(store).map_err(LurkError::Store)?;
+        let z0 = frames[0].input.to_vector(store).map_err(RuntimeError::Store)?;
         let zi = frames
             .last()
             .unwrap()
             .output
             .to_vector(store)
-            .map_err(LurkError::Store)?;
+            .map_err(RuntimeError::Store)?;
         let circuits = MultiFrame::from_frames(self.chunk_frame_count(), &frames, store);
         let num_steps = circuits.len();
         let proof =
@@ -219,7 +219,7 @@ impl<'a> Proof<'a> {
                     .input
                     .unwrap()
                     .to_vector(store)
-                    .map_err(LurkError::Store)?;
+                    .map_err(RuntimeError::Store)?;
                 let mut zi_allocated = Vec::with_capacity(zi.len());
 
                 for (i, x) in zi.iter().enumerate() {

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -21,7 +21,7 @@ use crate::circuit::{
     },
     CircuitFrame, MultiFrame,
 };
-use crate::error::{RuntimeError, ProofError};
+use crate::error::ProofError;
 use crate::eval::{Evaluator, Frame, Witness, IO};
 use crate::field::LurkField;
 use crate::proof::{Prover, PublicParameters};
@@ -102,13 +102,8 @@ impl<F: LurkField> NovaProver<F> {
         limit: usize,
     ) -> Result<(Proof, Vec<S1>, Vec<S1>, usize), ProofError> {
         let frames = self.get_evaluation_frames(expr, env, store, limit)?;
-        let z0 = frames[0].input.to_vector(store).map_err(RuntimeError::Store)?;
-        let zi = frames
-            .last()
-            .unwrap()
-            .output
-            .to_vector(store)
-            .map_err(RuntimeError::Store)?;
+        let z0 = frames[0].input.to_vector(store)?;
+        let zi = frames.last().unwrap().output.to_vector(store)?;
         let circuits = MultiFrame::from_frames(self.chunk_frame_count(), &frames, store);
         let num_steps = circuits.len();
         let proof =
@@ -218,20 +213,16 @@ impl<'a> Proof<'a> {
                 let zi = circuit_primary.frames.as_ref().unwrap()[0]
                     .input
                     .unwrap()
-                    .to_vector(store)
-                    .map_err(RuntimeError::Store)?;
+                    .to_vector(store)?;
                 let mut zi_allocated = Vec::with_capacity(zi.len());
 
                 for (i, x) in zi.iter().enumerate() {
                     let allocated =
-                        AllocatedNum::alloc(cs.namespace(|| format!("z{i}_1")), || Ok(*x))
-                            .map_err(ProofError::Synthesis)?;
+                        AllocatedNum::alloc(cs.namespace(|| format!("z{i}_1")), || Ok(*x))?;
                     zi_allocated.push(allocated);
                 }
 
-                circuit_primary
-                    .synthesize(&mut cs, zi_allocated.as_slice())
-                    .map_err(ProofError::Synthesis)?;
+                circuit_primary.synthesize(&mut cs, zi_allocated.as_slice())?;
 
                 assert!(cs.is_satisfied());
             }
@@ -245,7 +236,7 @@ impl<'a> Proof<'a> {
                 z0_secondary.clone(),
             );
             assert!(res.is_ok());
-            recursive_snark = Some(res.map_err(ProofError::Nova)?);
+            recursive_snark = Some(res?);
         }
 
         Ok(Self::Recursive(Box::new(recursive_snark.unwrap())))
@@ -253,10 +244,17 @@ impl<'a> Proof<'a> {
 
     pub fn compress(self, pp: &'a PublicParams) -> Result<Self, ProofError> {
         match &self {
-            Self::Recursive(recursive_snark) => Ok(Self::Compressed(Box::new(
-                CompressedSNARK::<_, _, _, _, SS1, SS2>::prove(pp, recursive_snark)
-                    .map_err(ProofError::Nova)?,
-            ))),
+            Self::Recursive(recursive_snark) => Ok(Self::Compressed(Box::new(CompressedSNARK::<
+                _,
+                _,
+                _,
+                _,
+                SS1,
+                SS2,
+            >::prove(
+                pp,
+                recursive_snark,
+            )?))),
             Self::Compressed(_) => Ok(self),
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -11,7 +11,7 @@ use once_cell::sync::OnceCell;
 
 use libipld::Cid;
 
-use crate::error::RuntimeError;
+use crate::error::ReductionError;
 use crate::field::{FWrap, LurkField};
 use crate::package::{Package, LURK_EXTERNAL_SYMBOL_NAMES};
 use crate::parser::{convert_sym_case, names_keyword};
@@ -1175,11 +1175,11 @@ impl<F: LurkField> Store<F> {
         self.intern_sym_with_case_conversion(name, &package)
     }
 
-    pub fn car(&self, expr: &Ptr<F>) -> Result<Ptr<F>, RuntimeError> {
+    pub fn car(&self, expr: &Ptr<F>) -> Result<Ptr<F>, ReductionError> {
         Ok(self.car_cdr(expr)?.0)
     }
 
-    pub fn cdr(&self, expr: &Ptr<F>) -> Result<Ptr<F>, RuntimeError> {
+    pub fn cdr(&self, expr: &Ptr<F>) -> Result<Ptr<F>, ReductionError> {
         Ok(self.car_cdr(expr)?.1)
     }
 
@@ -1621,7 +1621,11 @@ impl<F: LurkField> Store<F> {
     }
 
     pub fn get_char(&self, c: char) -> Ptr<F> {
-        Ptr(Tag::Char, RawPtr::new(u32::from(c) as usize))
+        self.get_char_from_u32(u32::from(c))
+    }
+
+    pub fn get_char_from_u32(&self, code: u32) -> Ptr<F> {
+        Ptr(Tag::Char, RawPtr::new(code as usize))
     }
 
     pub fn get_u64(&self, n: u64) -> Ptr<F> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -11,7 +11,6 @@ use once_cell::sync::OnceCell;
 
 use libipld::Cid;
 
-use crate::error::ReductionError;
 use crate::field::{FWrap, LurkField};
 use crate::package::{Package, LURK_EXTERNAL_SYMBOL_NAMES};
 use crate::parser::{convert_sym_case, names_keyword};
@@ -1175,11 +1174,11 @@ impl<F: LurkField> Store<F> {
         self.intern_sym_with_case_conversion(name, &package)
     }
 
-    pub fn car(&self, expr: &Ptr<F>) -> Result<Ptr<F>, ReductionError> {
+    pub fn car(&self, expr: &Ptr<F>) -> Result<Ptr<F>, Error> {
         Ok(self.car_cdr(expr)?.0)
     }
 
-    pub fn cdr(&self, expr: &Ptr<F>) -> Result<Ptr<F>, ReductionError> {
+    pub fn cdr(&self, expr: &Ptr<F>) -> Result<Ptr<F>, Error> {
         Ok(self.car_cdr(expr)?.1)
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -11,7 +11,7 @@ use once_cell::sync::OnceCell;
 
 use libipld::Cid;
 
-use crate::error::LurkError;
+use crate::error::RuntimeError;
 use crate::field::{FWrap, LurkField};
 use crate::package::{Package, LURK_EXTERNAL_SYMBOL_NAMES};
 use crate::parser::{convert_sym_case, names_keyword};
@@ -1175,11 +1175,11 @@ impl<F: LurkField> Store<F> {
         self.intern_sym_with_case_conversion(name, &package)
     }
 
-    pub fn car(&self, expr: &Ptr<F>) -> Result<Ptr<F>, LurkError> {
+    pub fn car(&self, expr: &Ptr<F>) -> Result<Ptr<F>, RuntimeError> {
         Ok(self.car_cdr(expr)?.0)
     }
 
-    pub fn cdr(&self, expr: &Ptr<F>) -> Result<Ptr<F>, LurkError> {
+    pub fn cdr(&self, expr: &Ptr<F>) -> Result<Ptr<F>, RuntimeError> {
         Ok(self.car_cdr(expr)?.1)
     }
 


### PR DESCRIPTION
Closes #230.

This PR refactors and significantly simplifies the error types. As part of that effort, the `Explicit` error variant becomes `Control::Error` — which makes very clear (as desired) that this is part of the Lurk language's control flow rather than an implementation, runtime, store, etc. error encountered during reduction.