### PR TITLE
Add minimal CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Global Owners
+* @porcuquine
+
+# Doc
+*.md @jpeg07
+
+# Circuit
+/src/circuit/* @emmorais


### PR DESCRIPTION
Closes #234.

This is intended as a minimal starting point, from which we can iterate and potentially add more granular and/or permissive ownership over time.