### PR TITLE
Don't exit REPL on runtime error.

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -120,7 +120,9 @@ pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
                         if is_meta {
                             repl.state.handle_meta(&mut s, expr, &package, p)?
                         } else {
-                            repl.state.handle_non_meta(&mut s, expr, false)?
+                            let _ = repl.state.handle_non_meta(&mut s, expr, false);
+
+                            continue;
                         }
                     }
                     Err(parser::Error::NoInput) => {


### PR DESCRIPTION
This PR supersedes the placeholder, #217. Now runtime errors during the E(valuation) part of the REPL don't break the L(oop).

Although this does fix #178 in the literal sense, the underlying problem is related to Lurk-level error-handling, so let's not close it with this.