### PR TITLE
feat: derive Arbitrary implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ memmap = { version = "0.5.8", package = "memmap2" }
 pasta-msm = { version = "0.1.0", package = "lurk-pasta-msm" }
 proptest = "1.1.0"
 proptest-derive = "0.3.0"
+rand = "0.8.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -62,7 +63,6 @@ gpu = ["neptune/opencl"]
 criterion = "0.3.5"
 structopt = { version = "0.3", default-features = false }
 tap = "1.0.1"
-rand = "0.8.4"
 
 [[bench]]
 name = "eval"

--- a/src/scalar_store.rs
+++ b/src/scalar_store.rs
@@ -367,35 +367,30 @@ mod test {
 
     // This doesn't create well-defined ScalarStores, so is only useful for
     // testing ipld
-    impl<Fr: LurkField> Arbitrary for ScalarStore<Fr> {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            (
-                prop::collection::btree_map(
-                    any::<ScalarPtr<Fr>>(),
-                    any::<Option<ScalarExpression<Fr>>>(),
-                    0..100,
-                ),
-                prop::collection::btree_map(
-                    any::<ScalarContPtr<Fr>>(),
-                    any::<Option<ScalarContinuation<Fr>>>(),
-                    0..100,
-                ),
-            )
-                .prop_map(|(scalar_map, scalar_cont_map)| ScalarStore {
-                    scalar_map,
-                    scalar_cont_map,
-                    pending_scalar_ptrs: Vec::new(),
-                })
-                .boxed()
-        }
+    fn ipld_scalar_store_strategy<Fr: LurkField>() -> impl Strategy<Value = ScalarStore<Fr>> {
+        (
+            prop::collection::btree_map(
+                any::<ScalarPtr<Fr>>(),
+                any::<Option<ScalarExpression<Fr>>>(),
+                0..100,
+            ),
+            prop::collection::btree_map(
+                any::<ScalarContPtr<Fr>>(),
+                any::<Option<ScalarContinuation<Fr>>>(),
+                0..100,
+            ),
+        )
+            .prop_map(|(scalar_map, scalar_cont_map)| ScalarStore {
+                scalar_map,
+                scalar_cont_map,
+                pending_scalar_ptrs: Vec::new(),
+            })
+            .boxed()
     }
 
     proptest! {
         #[test]
-        fn prop_scalar_store_ipld(x: ScalarStore<Fr>) {
+        fn prop_scalar_store_ipld(x in ipld_scalar_store_strategy::<Fr>()) {
             let to_ipld = to_ipld(x.clone()).unwrap();
             let from_ipld = from_ipld(to_ipld).unwrap();
             assert_eq!(x, from_ipld);

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -17,6 +17,7 @@ pub struct Symbol {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 pub enum Sym {
     Sym(Symbol),
     Key(Symbol),

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,10 +1,12 @@
-use std::{convert::TryFrom, fmt};
-
+#[cfg(not(target_arch = "wasm32"))]
+use proptest_derive::Arbitrary;
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::{convert::TryFrom, fmt};
 
 use crate::field::LurkField;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]
 pub enum ExprTag {
     Nil = 0b0000_0000_0000_0000,
@@ -82,6 +84,7 @@ impl ExprTag {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]
 pub enum ContTag {
     Outermost = 0b0001_0000_0000_0000,
@@ -174,6 +177,7 @@ impl fmt::Display for ContTag {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Hash, Serialize_repr, Deserialize_repr)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]
 pub enum Op1 {
     Car = 0b0010_0000_0000_0000,
@@ -254,6 +258,7 @@ impl fmt::Display for Op1 {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Hash, Serialize_repr, Deserialize_repr)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 #[repr(u16)]
 pub enum Op2 {
     Sum = 0b0011_0000_0000_0000,
@@ -366,101 +371,6 @@ pub mod tests {
 
     use super::*;
     use proptest::prelude::*;
-
-    impl Arbitrary for ExprTag {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            prop_oneof!(
-                Just(ExprTag::Nil),
-                Just(ExprTag::Cons),
-                Just(ExprTag::Sym),
-                Just(ExprTag::Fun),
-                Just(ExprTag::Num),
-                Just(ExprTag::Thunk),
-                Just(ExprTag::Str),
-                Just(ExprTag::Char),
-                Just(ExprTag::Comm),
-                Just(ExprTag::U64),
-                Just(ExprTag::Key),
-            )
-            .boxed()
-        }
-    }
-
-    impl Arbitrary for ContTag {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            prop_oneof!(
-                Just(ContTag::Outermost),
-                Just(ContTag::Call),
-                Just(ContTag::Call2),
-                Just(ContTag::Tail),
-                Just(ContTag::Error),
-                Just(ContTag::Lookup),
-                Just(ContTag::Unop),
-                Just(ContTag::Binop),
-                Just(ContTag::Binop2),
-                Just(ContTag::If),
-                Just(ContTag::Let),
-                Just(ContTag::LetRec),
-                Just(ContTag::Dummy),
-                Just(ContTag::Terminal),
-                Just(ContTag::Emit),
-            )
-            .boxed()
-        }
-    }
-
-    impl Arbitrary for Op1 {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            prop_oneof!(
-                Just(Op1::Car),
-                Just(Op1::Cdr),
-                Just(Op1::Atom),
-                Just(Op1::Emit),
-                Just(Op1::Secret),
-                Just(Op1::Commit),
-                Just(Op1::Num),
-                Just(Op1::Comm),
-                Just(Op1::Char),
-                Just(Op1::Eval),
-            )
-            .boxed()
-        }
-    }
-
-    impl Arbitrary for Op2 {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            prop_oneof!(
-                Just(Op2::Sum),
-                Just(Op2::Diff),
-                Just(Op2::Product),
-                Just(Op2::Quotient),
-                Just(Op2::Equal),
-                Just(Op2::NumEqual),
-                Just(Op2::Less),
-                Just(Op2::Greater),
-                Just(Op2::LessEqual),
-                Just(Op2::GreaterEqual),
-                Just(Op2::Cons),
-                Just(Op2::StrCons),
-                Just(Op2::Begin),
-                Just(Op2::Hide),
-                Just(Op2::Eval)
-            )
-            .boxed()
-        }
-    }
 
     proptest! {
     #[test]

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_arch = "wasm32"))]
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::Display,
@@ -6,6 +8,7 @@ use std::{
 
 /// Unsigned fixed-width integer type for Lurk.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Serialize, Deserialize)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
 pub enum UInt {
     U64(u64),
 }


### PR DESCRIPTION
This is a follow-up to #229 and hence #240 that leans into the derivability of `Arbitrary`. It derives those implementations of `Arbitrary` that trivially can (i.e. those that do not rely on the `FWrap` newtype, or custom behavior such as that of `ScalarStore`).

The regularity of this derivation ensures that these implementations are more maintainable, as we won't have to update them if one of e.g. the Tag enums change.
