### PR TITLE
Use nextest in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,9 +119,16 @@ jobs:
           at: "~/"
       - restore_rustup_cache
       - install_gpu_deps
+      - run: >
+          [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
+          curl -LsSf https://get.nexte.st/latest/linux |
+          tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: Linux Tests
-          command: cargo test --release --workspace -- --ignored --skip groth16::tests::outer_prove_recursion --test-threads=1
+          command: cargo nextest run --release --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)' -j1
+      - run:
+          name: Linux Doc Tests
+          command: cargo test --doc --workspace
 
   arm64:
     executor: arm64
@@ -142,10 +149,17 @@ jobs:
       - run: cargo --version
       - run: cargo update
       - run: cargo fetch
+      - run: >
+          [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
+          curl -LsSf https://get.nexte.st/latest/linux-arm |
+          tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: Arm64 Tests
-          command: cargo test --workspace --release
+          command: cargo nextest run --release --workspace
           no_output_timeout: 120m
+      - run:
+          name: Arm64 Doc Tests
+          command: cargo test --doc --workspace
 
   mac:
     executor: darwin
@@ -165,10 +179,17 @@ jobs:
       - run: cargo --version
       - run: cargo update
       - run: cargo fetch
+      - run: >
+          [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
+          curl -LsSf https://get.nexte.st/latest/mac |
+          tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: MacOS Tests
-          command: cargo test --workspace --release
+          command: cargo nextest run --release --workspace
           no_output_timeout: 120m
+      - run:
+          name: MacOS Doc Tests
+          command: cargo test --doc --workspace
 
   clippy:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,6 @@ jobs:
           name: Calculate dependencies
           command: cargo generate-lockfile
       - restore_rustup_cache
-      - run: cargo update
       - run: cargo fetch
       - run: rm -rf .git
       - persist_to_workspace:
@@ -155,7 +154,6 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run: rustup show
       - run: cargo --version
-      - run: cargo update
       - run: cargo fetch
       - run: 
           name: Install nextest
@@ -187,7 +185,6 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run: rustup show
       - run: cargo --version
-      - run: cargo update
       - run: cargo fetch
       - run: 
           name: Install nextest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: Linux Tests
-          command: cargo nextest run --release --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)' -j1
+          command: cargo nextest run --profile ci --release --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)' -j1
       - run:
           name: Linux Doc Tests
           command: cargo test --doc --workspace
@@ -155,7 +155,7 @@ jobs:
           tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: Arm64 Tests
-          command: cargo nextest run --release --workspace
+          command: cargo nextest run --profile ci --release --workspace
           no_output_timeout: 120m
       - run:
           name: Arm64 Doc Tests
@@ -185,7 +185,7 @@ jobs:
           tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: MacOS Tests
-          command: cargo nextest run --release --workspace
+          command: cargo nextest run --profile ci --release --workspace
           no_output_timeout: 120m
       - run:
           name: MacOS Doc Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,15 @@ jobs:
       - run:
           name: Wasm Build
           command: cargo build --target wasm32-unknown-unknown
+      - run: 
+          name: Install nextest
+          command: >
+            [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
+            curl -LsSf https://get.nexte.st/latest/linux |
+            tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: Linux Tests
-          command: cargo test --workspace
+          command: cargo nextest run --profile ci --workspace
           no_output_timeout: 120m
 
   linux_release:
@@ -119,10 +125,12 @@ jobs:
           at: "~/"
       - restore_rustup_cache
       - install_gpu_deps
-      - run: >
-          [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
-          curl -LsSf https://get.nexte.st/latest/linux |
-          tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - run: 
+          name: Install nextest
+          command: >
+            [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
+            curl -LsSf https://get.nexte.st/latest/linux |
+            tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: Linux Tests
           command: cargo nextest run --profile ci --release --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)' -j1
@@ -149,10 +157,12 @@ jobs:
       - run: cargo --version
       - run: cargo update
       - run: cargo fetch
-      - run: >
-          [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
-          curl -LsSf https://get.nexte.st/latest/linux-arm |
-          tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - run: 
+          name: Install nextest
+          command: >
+            [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
+            curl -LsSf https://get.nexte.st/latest/linux-arm |
+            tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: Arm64 Tests
           command: cargo nextest run --profile ci --release --workspace
@@ -179,10 +189,12 @@ jobs:
       - run: cargo --version
       - run: cargo update
       - run: cargo fetch
-      - run: >
-          [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
-          curl -LsSf https://get.nexte.st/latest/mac |
-          tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - run: 
+          name: Install nextest
+          command: >
+            [ -f ${CARGO_HOME:-~/.cargo/bin}/cargo-nextest ] ||
+            curl -LsSf https://get.nexte.st/latest/mac |
+            tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: MacOS Tests
           command: cargo nextest run --profile ci --release --workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
             tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - run:
           name: Linux Tests
-          command: cargo nextest run --profile ci --release --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)' -j1
+          command: cargo nextest run --profile ci --release --workspace --run-ignored all -E 'all() - test(groth16::tests::outer_prove_recursion)'
       - run:
           name: Linux Doc Tests
           command: cargo test --doc --workspace

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Show skipped tests in the CI output.
+status-level = "skip"
+# Do not cancel the test run on the first failure.
+fail-fast = false
+# Mark tests as slow after 20mins, kill them after 50
+slow-timeout = { period = "1200s", terminate-after = 1 }

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -10,6 +10,17 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Arbitrary))]
+/// Type for hieararchical symbol names
+///
+/// # Example
+///
+/// ```
+/// # use lurk::Symbol;
+/// let r = Symbol::root();
+/// let a_b = r.child("a".into()).child("b".into());
+/// assert_eq!(a_b.full_name(), "|a|.|b|");
+/// assert_eq!(a_b.path(), &vec!["", "a", "b"]);
+/// ```
 pub struct Symbol {
     pub path: Vec<String>,
     // It would be better not to have this here, but it simplifies things in the Store, at least for now.


### PR DESCRIPTION
This introduces the use of [nextest](https://nexte.st/) in CI. This is expected to bring performance improvements for some jobs, due to a [better parallelization model](https://nexte.st/book/how-it-works.html) - except for the `linux-release` job, which is completely sequential anyway. (Edit: the linux-release job is made non-sequential in this PR. The linux job is a wasm job)

Since [nextest does not support documentation tests](https://github.com/nextest-rs/nextest/issues/16), this introduces a perfunctory doctest ahead of the CI change, and runs a separate `cargo test --doc` task.

The goal of this CI is to introduce feature parity with the existing, and it does not aim to change behavior (yet).