### PR TITLE
Prefer constants to allocations where possible.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrayref"
@@ -69,7 +69,7 @@ version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9834fcc22e0874394a010230586367d4a3e9f11b560f469262678547e1d2575e"
 dependencies = [
- "bstr 1.1.0",
+ "bstr",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -113,7 +113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1a8623f815c0b1fd89efd9b5f4afbb937f91f51c1ebe3f6dda399c69fa938f3"
 dependencies = [
  "bincode",
- "blake2s_simd 1.0.0",
+ "blake2s_simd 1.0.1",
  "blstrs",
  "byteorder",
  "crossbeam-channel",
@@ -187,13 +187,13 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq 0.2.4",
 ]
 
 [[package]]
@@ -209,13 +209,13 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
+checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq 0.2.4",
 ]
 
 [[package]]
@@ -293,21 +293,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
-name = "bstr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
 dependencies = [
  "memchr",
  "once_cell",
@@ -347,9 +335,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -434,11 +422,11 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -538,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -548,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -559,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -572,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -591,13 +579,12 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
 dependencies = [
- "bstr 0.2.17",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -647,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -732,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "env_logger"
@@ -808,7 +795,7 @@ checksum = "5109f6bc9cd57feda665da326f3f6c57e0498c8fe9f7d12d7b8abc96719ca91b"
 dependencies = [
  "execute-command-tokens",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -819,9 +806,9 @@ checksum = "8ba569491c70ec8471e34aa7e9c0b9e82bb5d2464c0398442d17d3c4af814e5a"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -854,13 +841,13 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.8"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb21c69b9fea5e15dbc1049e4b77145dd0ba1c84019c488102de0dc4ea4b0a27"
+checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -887,9 +874,9 @@ dependencies = [
  "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1039,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1115,12 +1102,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1152,21 +1139,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1354,9 +1335,9 @@ version = "0.1.0"
 dependencies = [
  "blstrs",
  "lurk",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1367,18 +1348,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -1422,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
  "blake2b_simd",
- "blake2s_simd 1.0.0",
+ "blake2s_simd 1.0.1",
  "blake3",
  "core2",
  "digest 0.10.6",
@@ -1442,9 +1423,9 @@ checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "synstructure",
 ]
 
@@ -1574,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -1617,22 +1598,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "peekmore"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca84ba11ed2de09f9a946e35be5efe5382bdd0621780b46ea8e24a7797b5be88"
+checksum = "af0fea59e10380d6cc719d1534d20a0c28134b28e5e81cf942c4c26d23227987"
 
 [[package]]
 name = "plotters"
@@ -1725,9 +1706,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1737,7 +1718,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "version_check",
 ]
@@ -1753,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -1819,7 +1800,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
 ]
 
 [[package]]
@@ -1916,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2006,16 +1987,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2043,7 +2024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688599bdab9f42105d0ae1494335a9ffafdeb7d36325e6b10fd4abc5829d6284"
 dependencies = [
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2097,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -2120,18 +2101,18 @@ version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -2142,9 +2123,9 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2199,9 +2180,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
 dependencies = [
  "lock_api",
 ]
@@ -2264,16 +2245,16 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2288,11 +2269,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "unicode-ident",
 ]
@@ -2303,9 +2284,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
 
@@ -2336,16 +2317,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2393,9 +2373,9 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2419,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -2432,9 +2412,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2457,9 +2437,9 @@ checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -2525,9 +2505,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2535,24 +2515,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote 1.0.23",
  "wasm-bindgen-macro-support",
@@ -2560,28 +2540,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2589,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",
@@ -2634,6 +2614,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2741,8 +2745,8 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.109",
  "synstructure",
 ]

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -4667,7 +4667,6 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
     // This is all clunky because we can't currently return AllocatedBit from case expressions.
     let newer_cont2_not_dummy_result_num = case_results[7].clone();
-    // let newer_cont2_not_dummy_ = equal!(cs, &newer_cont2_not_dummy_result_num, &g.true_num)?;
     let newer_cont2_not_dummy_ = equal_const!(cs, &newer_cont2_not_dummy_result_num, F::one())?;
     let newer_cont2_not_dummy = and!(cs, &newer_cont2_not_dummy_, not_dummy)?;
 

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1470,6 +1470,9 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let head_is_a_cons = head.is_cons(&mut cs.namespace(|| "head_is_a_cons"))?;
     let head_is_fun = head.is_fun(&mut cs.namespace(|| "head_is_fun"))?;
 
+    // Possible optimizations:
+    // - The variadic `or!` (and `and!`) can be optimized to a small, constant number of constraints.
+
     // SOUNDNESS: All head symbols corresponding to a binop *must* be included here.
     let head_is_binop0 = or!(
         cs,

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1274,7 +1274,7 @@ pub struct Pointers<F: LurkField> {
     product: ScalarPtr<F>,
     quotient: ScalarPtr<F>,
     modulo: ScalarPtr<F>,
-    numequal: ScalarPtr<F>,
+    num_equal: ScalarPtr<F>,
     equal: ScalarPtr<F>,
     less: ScalarPtr<F>,
     less_equal: ScalarPtr<F>,
@@ -1320,7 +1320,7 @@ impl<F: LurkField> Pointers<F> {
         let product = hash_sym("*");
         let quotient = hash_sym("/");
         let modulo = hash_sym("%");
-        let numequal = hash_sym("=");
+        let num_equal = hash_sym("=");
         let equal = hash_sym("eq");
         let less = hash_sym("<");
         let less_equal = hash_sym("<=");
@@ -1357,7 +1357,7 @@ impl<F: LurkField> Pointers<F> {
             product,
             quotient,
             modulo,
-            numequal,
+            num_equal,
             equal,
             less,
             less_equal,
@@ -1444,7 +1444,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     def_head_val!(head_is_times, p.product);
     def_head_val!(head_is_div, p.quotient);
     def_head_val!(head_is_mod, p.modulo);
-    def_head_val!(head_is_equal, p.equal);
+    def_head_val!(head_is_num_equal, p.num_equal);
     def_head_val!(head_is_eq, p.equal);
     def_head_val!(head_is_less, p.less);
     def_head_val!(head_is_less_equal, p.less_equal);
@@ -1469,7 +1469,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &head_is_times,
         &head_is_div,
         &head_is_mod,
-        &head_is_equal,
+        &head_is_num_equal,
         &head_is_eq,
         &head_is_less,
         &head_is_less_equal,
@@ -2215,7 +2215,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let numequal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_numequal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *p.numequal.value(),
+        *p.num_equal.value(),
         &g.binop_cont_tag,
         numequal_continuation_components,
     );
@@ -2661,7 +2661,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
     // head == =, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*p.numequal.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.num_equal.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == EQ, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -3960,7 +3960,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             b,
             &diff,
             op2.tag(),
-            &store.get_constants(),
+            store.get_constants(),
         )?;
 
         let field_arithmetic_result = AllocatedPtr::pick(

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -18,7 +18,8 @@ use crate::{
 };
 
 use super::gadgets::constraints::{
-    self, alloc_equal, alloc_is_zero, div, enforce_implication, or, pick, sub,
+    self, alloc_equal, alloc_equal_const, alloc_is_zero, div, enforce_implication, or, pick,
+    pick_const, sub,
 };
 use crate::circuit::circuit_frame::constraints::{
     add, allocate_is_negative, boolean_to_num, enforce_pack, linear, mul,
@@ -28,7 +29,7 @@ use crate::circuit::ToInputs;
 use crate::eval::{Frame, Witness, IO};
 use crate::hash_witness::HashWitness;
 use crate::proof::Provable;
-use crate::store::{Ptr, Store, Thunk};
+use crate::store::{Ptr, ScalarPtr, Store, Thunk};
 use crate::tag::{ContTag, ExprTag, Op1, Op2};
 use num_bigint::BigUint;
 use num_integer::Integer;
@@ -203,6 +204,7 @@ impl<F: LurkField> CircuitFrame<'_, F, IO<F>, Witness<F>> {
         i: usize,
         inputs: AllocatedIO<F>,
         g: &GlobalAllocations<F>,
+        p: &Pointers<F>,
     ) -> Result<AllocatedIO<F>, SynthesisError> {
         let (input_expr, input_env, input_cont) = inputs;
 
@@ -238,6 +240,7 @@ impl<F: LurkField> CircuitFrame<'_, F, IO<F>, Witness<F>> {
                 &mut allocated_cont_witness,
                 store,
                 g,
+                &p,
             )
         };
 
@@ -304,6 +307,9 @@ impl<F: LurkField> Circuit<F> for MultiFrame<'_, F, IO<F>, Witness<F>> {
 
             let acc = (input_expr, input_env, input_cont);
 
+            let p = Pointers::new(store);
+
+            // TODO: Make this a trait method, and it in nova.rs.
             let (_, (new_expr, new_env, new_cont)) =
                 frames.iter().fold((0, acc), |(i, allocated_io), frame| {
                     if let Some(next_input) = frame.input {
@@ -339,7 +345,10 @@ impl<F: LurkField> Circuit<F> for MultiFrame<'_, F, IO<F>, Witness<F>> {
                             "cont mismatch"
                         );
                     };
-                    (i + 1, frame.synthesize(cs, i, allocated_io, &g).unwrap())
+                    (
+                        i + 1,
+                        frame.synthesize(cs, i, allocated_io, &g, &p).unwrap(),
+                    )
                 });
 
             // dbg!(
@@ -651,6 +660,7 @@ fn reduce_expression<F: LurkField, CS: ConstraintSystem<F>>(
     allocated_cont_witness: &mut AllocatedContWitness<F>,
     store: &Store<F>,
     g: &GlobalAllocations<F>,
+    p: &Pointers<F>,
 ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
     // dbg!("reduce_expression");
     // dbg!(&expr.fetch_and_write_str(store));
@@ -670,23 +680,17 @@ fn reduce_expression<F: LurkField, CS: ConstraintSystem<F>>(
         results.add_clauses_expr(ExprTag::U64, expr, env, cont, &g.true_num);
     };
 
-    let cont_is_terminal = alloc_equal(
+    let cont_is_terminal = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_terminal"),
-        cont.tag(),
-        g.terminal_ptr.tag(),
+        ContTag::Terminal.as_field(),
     )?;
-    let cont_is_error = alloc_equal(
+    let cont_is_error = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_error"),
-        cont.tag(),
-        g.error_ptr.tag(),
+        ContTag::Error.as_field(),
     )?;
 
     // Enforce (expr.tag == thunk_tag) implies (expr_thunk_hash == expr.hash).
-    let expr_is_thunk = alloc_equal(
-        &mut cs.namespace(|| "expr.tag == thunk_tag"),
-        expr.tag(),
-        &g.thunk_tag,
-    )?;
+    let expr_is_thunk = expr.is_thunk(&mut cs.namespace(|| "expr_is_thunk"))?;
 
     // If expr is a thunk, this will allocate its components and hash, etc.
     // If not, these will be dummies.
@@ -710,11 +714,7 @@ fn reduce_expression<F: LurkField, CS: ConstraintSystem<F>>(
     }
 
     // --
-    let reduce_sym_not_dummy = alloc_equal(
-        &mut cs.namespace(|| "reduce_sym_not_dummy"),
-        expr.tag(),
-        &g.sym_tag,
-    )?;
+    let reduce_sym_not_dummy = expr.is_sym(&mut cs.namespace(|| "reduce_sym_not_dummy"))?;
     let cont_is_terminal_or_error = or!(cs, &cont_is_terminal, &cont_is_error)?;
     let cont_is_not_terminal_or_error = cont_is_terminal_or_error.not();
     let reduce_sym_not_dummy = and!(cs, &reduce_sym_not_dummy, &cont_is_not_terminal_or_error)?;
@@ -742,11 +742,7 @@ fn reduce_expression<F: LurkField, CS: ConstraintSystem<F>>(
     // --
 
     // --
-    let expr_is_cons = alloc_equal(
-        &mut cs.namespace(|| "reduce_cons_not_dummy0"),
-        expr.tag(),
-        &g.cons_tag,
-    )?;
+    let expr_is_cons = expr.is_cons(&mut cs.namespace(|| "reduce_cons_not_dummy0"))?;
 
     let reduce_cons_not_dummy = and!(cs, &expr_is_cons, &cont_is_not_terminal_or_error)?;
 
@@ -761,6 +757,7 @@ fn reduce_expression<F: LurkField, CS: ConstraintSystem<F>>(
         allocated_cont_witness,
         store,
         g,
+        &p,
     )?;
 
     results.add_clauses_expr(
@@ -835,6 +832,7 @@ fn reduce_expression<F: LurkField, CS: ConstraintSystem<F>>(
         allocated_cont_witness,
         store,
         g,
+        p,
     )?;
 
     let apply_continuation_make_thunk: AllocatedNum<F> = apply_continuation_results.3;
@@ -1005,7 +1003,7 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
 
     let binding_is_nil = binding.is_nil(&mut cs.namespace(|| "binding is nil"), g)?;
     let binding_not_nil = binding_is_nil.not();
-    let binding_is_cons = equal!(cs, binding.tag(), &g.cons_tag)?;
+    let binding_is_cons = binding.is_cons(&mut cs.namespace(|| "binding_is_cons"))?;
 
     let env_car_not_dummy = and!(cs, &main, &binding_is_cons)?;
     let (var_or_rec_binding, val_or_more_rec_env) = car_cdr_named(
@@ -1018,8 +1016,10 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
         store,
     )?;
 
-    let var_or_rec_binding_is_sym = equal!(cs, var_or_rec_binding.tag(), &g.sym_tag)?;
-    let var_or_rec_binding_is_cons = equal!(cs, var_or_rec_binding.tag(), &g.cons_tag)?;
+    let var_or_rec_binding_is_sym =
+        var_or_rec_binding.is_sym(&mut cs.namespace(|| "var_or_rec_binding_is_sym"))?;
+    let var_or_rec_binding_is_cons =
+        var_or_rec_binding.is_cons(&mut cs.namespace(|| "var_or_rec_binding_is_cons"))?;
     let var_or_rec_binding_is_sym_or_cons =
         or!(cs, &var_or_rec_binding_is_sym, &var_or_rec_binding_is_cons)?;
 
@@ -1043,7 +1043,7 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
         store,
     )?;
 
-    let val2_is_fun = equal!(cs, val2.tag(), &g.fun_tag)?;
+    let val2_is_fun = val2.is_fun(&mut cs.namespace(|| "val2_is_fun"))?;
     let v2_is_expr = v2.alloc_equal(&mut cs.namespace(|| "v2_is_expr"), expr)?;
     let v2_is_expr_real = and!(cs, &v2_is_expr, envcaar_not_dummy)?;
 
@@ -1109,7 +1109,10 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
 
     let env_to_use = pick_ptr!(cs, &smaller_rec_env_is_nil, &smaller_env, &rec_extended_env)?;
 
-    let cont_is_lookup = equal!(cs, cont.tag(), &g.lookup_cont_tag)?;
+    let cont_is_lookup = cont.alloc_tag_equal(
+        &mut cs.namespace(|| "cons_is_lookup"),
+        ContTag::Lookup.as_field(),
+    )?;
 
     let needed_env_missing = and!(cs, &sym_otherwise, &env_is_nil)?;
     let needed_binding_missing = and!(cs, &main, &binding_is_nil)?;
@@ -1250,6 +1253,129 @@ fn reduce_sym<F: LurkField, CS: ConstraintSystem<F>>(
     Ok((output_expr, output_env, output_cont, apply_cont_num))
 }
 
+pub struct Pointers<F: LurkField> {
+    t: ScalarPtr<F>,
+    nil: ScalarPtr<F>,
+    lambda: ScalarPtr<F>,
+    quote: ScalarPtr<F>,
+    let_: ScalarPtr<F>,
+    letrec: ScalarPtr<F>,
+    cons: ScalarPtr<F>,
+    strcons: ScalarPtr<F>,
+    begin: ScalarPtr<F>,
+    car: ScalarPtr<F>,
+    cdr: ScalarPtr<F>,
+    atom: ScalarPtr<F>,
+    emit: ScalarPtr<F>,
+    sum: ScalarPtr<F>,
+    diff: ScalarPtr<F>,
+    product: ScalarPtr<F>,
+    quotient: ScalarPtr<F>,
+    modulo: ScalarPtr<F>,
+    numequal: ScalarPtr<F>,
+    equal: ScalarPtr<F>,
+    less: ScalarPtr<F>,
+    less_equal: ScalarPtr<F>,
+    greater: ScalarPtr<F>,
+    greater_equal: ScalarPtr<F>,
+    current_env: ScalarPtr<F>,
+    if_: ScalarPtr<F>,
+    hide: ScalarPtr<F>,
+    commit: ScalarPtr<F>,
+    num: ScalarPtr<F>,
+    u64_: ScalarPtr<F>,
+    comm: ScalarPtr<F>,
+    char_: ScalarPtr<F>,
+    eval: ScalarPtr<F>,
+    open: ScalarPtr<F>,
+    secret: ScalarPtr<F>,
+}
+
+impl<F: LurkField> Pointers<F> {
+    pub fn new(store: &Store<F>) -> Self {
+        let hash_sym = |name: &str| {
+            store
+                .get_lurk_sym(name, true)
+                .and_then(|s| store.hash_sym(s, HashScalar::Get))
+                .unwrap()
+        };
+
+        let t = hash_sym("t");
+        let nil = store.hash_nil(HashScalar::Get).unwrap();
+        let lambda = hash_sym("lambda");
+        let quote = hash_sym("quote");
+        let let_ = hash_sym("let");
+        let letrec = hash_sym("letrec");
+        let cons = hash_sym("cons");
+        let strcons = hash_sym("strcons");
+        let begin = hash_sym("begin");
+        let car = hash_sym("car");
+        let cdr = hash_sym("cdr");
+        let atom = hash_sym("atom");
+        let emit = hash_sym("emit");
+        let sum = hash_sym("+");
+        let diff = hash_sym("-");
+        let product = hash_sym("*");
+        let quotient = hash_sym("/");
+        let modulo = hash_sym("%");
+        let numequal = hash_sym("=");
+        let equal = hash_sym("eq");
+        let less = hash_sym("<");
+        let less_equal = hash_sym("<=");
+        let greater = hash_sym(">");
+        let greater_equal = hash_sym(">=");
+        let current_env = hash_sym("current-env");
+        let if_ = hash_sym("if");
+        let hide = hash_sym("hide");
+        let commit = hash_sym("commit");
+        let num = hash_sym("num");
+        let u64_ = hash_sym("u64");
+        let comm = hash_sym("comm");
+        let char_ = hash_sym("char");
+        let eval = hash_sym("eval");
+        let open = hash_sym("open");
+        let secret = hash_sym("secret");
+
+        Self {
+            t,
+            nil,
+            lambda,
+            quote,
+            let_,
+            letrec,
+            cons,
+            strcons,
+            begin,
+            car,
+            cdr,
+            atom,
+            emit,
+            sum,
+            diff,
+            product,
+            quotient,
+            modulo,
+            numequal,
+            equal,
+            less,
+            less_equal,
+            greater,
+            greater_equal,
+            current_env,
+            if_,
+            hide,
+            commit,
+            num,
+            u64_,
+            comm,
+            char_,
+            eval,
+            open,
+            secret,
+        }
+    }
+}
+
 fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     expr: &AllocatedPtr<F>,
@@ -1261,6 +1387,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     allocated_cont_witness: &mut AllocatedContWitness<F>,
     store: &Store<F>,
     g: &GlobalAllocations<F>,
+    p: &Pointers<F>,
 ) -> Result<
     (
         AllocatedPtr<F>,
@@ -1272,49 +1399,6 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 > {
     let mut hash_default_results = HashInputResults::<'_, F>::default();
 
-    let hash_sym = |name: &str| {
-        store
-            .get_lurk_sym(name, true)
-            .and_then(|s| store.hash_sym(s, HashScalar::Get))
-            .unwrap()
-    };
-
-    let lambda_hash = hash_sym("lambda");
-    let quote_hash = hash_sym("quote");
-    let let_sym = hash_sym("let");
-    let let_hash = let_sym.value();
-    let letrec = hash_sym("letrec");
-    let letrec_hash = letrec.value();
-    let cons_hash = hash_sym("cons");
-    let strcons_hash = hash_sym("strcons");
-    let begin_hash = hash_sym("begin");
-    let car_hash = hash_sym("car");
-    let cdr_hash = hash_sym("cdr");
-    let atom_hash = hash_sym("atom");
-    let emit_hash = hash_sym("emit");
-    let sum_hash = hash_sym("+");
-    let diff_hash = hash_sym("-");
-    let product_hash = hash_sym("*");
-    let quotient_hash = hash_sym("/");
-    let modulo_hash = hash_sym("%");
-    let numequal_hash = hash_sym("=");
-    let equal_hash = hash_sym("eq");
-    let less_hash = hash_sym("<");
-    let less_equal_hash = hash_sym("<=");
-    let greater_hash = hash_sym(">");
-    let greater_equal_hash = hash_sym(">=");
-    let current_env_hash = hash_sym("current-env");
-    let if_hash = hash_sym("if");
-    let hide_hash = hash_sym("hide");
-    let commit_hash = hash_sym("commit");
-    let num_hash = hash_sym("num");
-    let u64_hash = hash_sym("u64");
-    let comm_hash = hash_sym("comm");
-    let char_hash = hash_sym("char");
-    let eval_hash = hash_sym("eval");
-    let open_hash = hash_sym("open");
-    let secret_hash = hash_sym("secret");
-
     let (head, rest) = car_cdr_named(
         &mut cs.namespace(|| "reduce_cons expr"),
         g,
@@ -1325,65 +1409,51 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         store,
     )?;
 
-    macro_rules! def_head_sym {
-        ($var:ident, $field:ident) => {
-            let $var = alloc_equal(
-                &mut cs.namespace(|| stringify!($var)),
-                head.hash(),
-                &g.$field.hash(),
-            )?;
+    macro_rules! def_head_val {
+        ($var:ident, $name:expr) => {
+            let $var =
+                head.alloc_hash_equal(&mut cs.namespace(|| stringify!($var)), *$name.value())?;
         };
     }
 
-    // TODO: This currently incurs a lot of extra constraints:
-    // - global constant allocation for each symbol
-    // - the boolean equality allocation for each symbol checked against head
-    // - one constraint for each member of the or!
-    //
-    // Possible optimizations:
-    // - The variadic or! (and and!) can be optimized to a single constraint.
-    // - We can optimize the alloc_equals to use the constant sym.
-    // - We only need to check the tag once, so can just check value/hash equality.
-    //
     // SOUNDNESS: All symbols with their own case clause must be represented in this list
-    def_head_sym!(head_is_lambda0, lambda_sym);
-    def_head_sym!(head_is_let, let_sym);
-    def_head_sym!(head_is_letrec, letrec_sym);
-    def_head_sym!(head_is_eval, eval_sym);
-    def_head_sym!(head_is_quote0, quote_sym);
+    def_head_val!(head_is_lambda0, p.lambda);
+    def_head_val!(head_is_let, p.let_);
+    def_head_val!(head_is_letrec, p.letrec);
+    def_head_val!(head_is_eval, p.eval);
+    def_head_val!(head_is_quote0, p.quote);
+    def_head_val!(head_is_cons, p.cons);
+    def_head_val!(head_is_strcons, p.strcons);
+    def_head_val!(head_is_hide, p.hide);
+    def_head_val!(head_is_commit, p.commit);
+    def_head_val!(head_is_open, p.open);
+    def_head_val!(head_is_secret, p.secret);
+    def_head_val!(head_is_num, p.num);
+    def_head_val!(head_is_u64, p.u64_);
+    def_head_val!(head_is_comm, p.comm);
+    def_head_val!(head_is_char, p.char_);
+    def_head_val!(head_is_begin, p.begin);
+    def_head_val!(head_is_car, p.car);
+    def_head_val!(head_is_cdr, p.cdr);
+    def_head_val!(head_is_atom, p.atom);
+    def_head_val!(head_is_emit, p.emit);
+    def_head_val!(head_is_plus, p.sum);
+    def_head_val!(head_is_minus, p.diff);
+    def_head_val!(head_is_times, p.product);
+    def_head_val!(head_is_div, p.quotient);
+    def_head_val!(head_is_mod, p.modulo);
+    def_head_val!(head_is_equal, p.equal);
+    def_head_val!(head_is_eq, p.equal);
+    def_head_val!(head_is_less, p.less);
+    def_head_val!(head_is_less_equal, p.less_equal);
+    def_head_val!(head_is_greater, p.greater);
+    def_head_val!(head_is_greater_equal, p.greater_equal);
+    def_head_val!(head_is_if0, p.if_);
+    def_head_val!(head_is_current_env0, p.current_env);
 
-    def_head_sym!(head_is_cons, cons_sym);
-    def_head_sym!(head_is_strcons, strcons_sym);
-    def_head_sym!(head_is_hide, hide_sym);
-    def_head_sym!(head_is_commit, commit_sym);
-    def_head_sym!(head_is_open, open_sym);
-    def_head_sym!(head_is_secret, secret_sym);
-    def_head_sym!(head_is_num, num_sym);
-    def_head_sym!(head_is_u64, u64_sym);
-    def_head_sym!(head_is_comm, comm_sym);
-    def_head_sym!(head_is_char, char_sym);
-    def_head_sym!(head_is_begin, begin_sym);
-    def_head_sym!(head_is_car, car_sym);
-    def_head_sym!(head_is_cdr, cdr_sym);
-    def_head_sym!(head_is_atom, atom_sym);
-    def_head_sym!(head_is_emit, emit_sym);
-    def_head_sym!(head_is_plus, plus_sym);
-    def_head_sym!(head_is_minus, minus_sym);
-    def_head_sym!(head_is_times, times_sym);
-    def_head_sym!(head_is_div, div_sym);
-    def_head_sym!(head_is_mod, mod_sym);
-    def_head_sym!(head_is_equal, equal_sym);
-    def_head_sym!(head_is_eq, eq_sym);
-    def_head_sym!(head_is_less, less_sym);
-    def_head_sym!(head_is_less_equal, less_equal_sym);
-    def_head_sym!(head_is_greater, greater_sym);
-    def_head_sym!(head_is_greater_equal, greater_equal_sym);
-    def_head_sym!(head_is_if0, if_sym);
-    def_head_sym!(head_is_current_env0, current_env_sym);
-
-    let head_is_a_sym = equal!(cs, head.tag(), &g.sym_tag)?;
-    let head_is_fun = equal!(cs, head.tag(), &g.fun_tag)?;
-    let head_is_a_cons = equal!(cs, head.tag(), &g.cons_tag)?; // Head is a cons, as opposed to being the symbol, CONS.
+    let head_is_a_sym = head.is_sym(&mut cs.namespace(|| "head_is_a_sym"))?;
+    let head_is_a_cons = head.is_cons(&mut cs.namespace(|| "head_is_a_cons"))?;
+    let head_is_fun = head.is_fun(&mut cs.namespace(|| "head_is_fun"))?;
 
     // SOUNDNESS: All head symbols corresponding to a binop *must* be included here.
     let head_is_binop0 = or!(
@@ -1453,11 +1523,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let head_potentially_fun = and!(cs, &head_potentially_fun_type, &head_is_any.not())?;
 
     let rest_is_nil = rest.is_nil(&mut cs.namespace(|| "rest_is_nil"), g)?;
-    let rest_is_cons = alloc_equal(
-        &mut cs.namespace(|| "rest_is_cons"),
-        rest.tag(),
-        &g.cons_tag,
-    )?;
+    let rest_is_cons = rest.is_cons(&mut cs.namespace(|| "rest_is_cons"))?;
 
     let expr_cdr_not_dummy = and!(
         cs,
@@ -1495,12 +1561,8 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &head_is_eval.not()
     )?;
 
-    let arg1_is_cons = alloc_equal(
-        &mut cs.namespace(|| "arg1_is_cons"),
-        arg1.tag(),
-        &g.cons_tag,
-    )?;
-    let arg1_is_str = alloc_equal(&mut cs.namespace(|| "arg1_is_str"), arg1.tag(), &g.str_tag)?;
+    let arg1_is_cons = arg1.is_cons(&mut cs.namespace(|| "arg1_is_cons"))?;
+    let arg1_is_str = arg1.is_str(&mut cs.namespace(|| "arg1_is_str"))?;
 
     let arg1_is_nil = arg1.is_nil(&mut cs.namespace(|| "arg1_is_nil"), g)?;
     let expr_cadr_not_dummy0 = or!(cs, &arg1_is_cons, &arg1_is_nil, &arg1_is_str)?;
@@ -1540,7 +1602,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
             &car_args,
         )?;
 
-        let arg_is_sym = arg.is_sym(&mut cs.namespace(|| "arg_is_sym"), g)?;
+        let arg_is_sym = arg.is_sym(&mut cs.namespace(|| "arg_is_sym"))?;
         let lambda_not_dummy = and!(cs, &head_is_lambda, not_dummy, &more_is_nil.not())?;
         let inner_not_dummy = and!(cs, &lambda_not_dummy, &cdr_args_is_nil.not())?;
 
@@ -1607,7 +1669,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     };
 
     results.add_clauses_cons(
-        *lambda_hash.value(),
+        *p.lambda.value(),
         &lambda_expr,
         lambda_env,
         &lambda_cont,
@@ -1633,13 +1695,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         (arg1_or_expr, the_cont)
     };
 
-    results.add_clauses_cons(
-        *quote_hash.value(),
-        &arg1_or_expr,
-        env,
-        &the_cont,
-        &g.true_num,
-    );
+    results.add_clauses_cons(*p.quote.value(), &arg1_or_expr, env, &the_cont, &g.true_num);
 
     ////////////////////////////////////////////////////////////////////////////////
 
@@ -1660,15 +1716,8 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         store,
     )?;
     let bindings_is_nil = bindings.is_nil(&mut cs.namespace(|| "bindings_is_nil"), g)?;
-
-    let bindings_is_cons = alloc_equal(
-        &mut cs.namespace(|| "bindings_is_cons"),
-        bindings.tag(),
-        &g.cons_tag,
-    )?;
-
+    let bindings_is_cons = bindings.is_cons(&mut cs.namespace(|| "bindings_is_cons"))?;
     let body_is_nil = body.is_nil(&mut cs.namespace(|| "body_is_nil"), g)?;
-
     let rest_body_is_nil = rest_body.is_nil(&mut cs.namespace(|| "rest_body_is_nil"), g)?;
 
     /*
@@ -1709,7 +1758,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         )?;
 
         let var_let_letrec_is_sym =
-            var_let_letrec.is_sym(&mut cs.namespace(|| "var_let_letrec_is_sym"), g)?;
+            var_let_letrec.is_sym(&mut cs.namespace(|| "var_let_letrec_is_sym"))?;
         let var_let_letrec_is_nil =
             var_let_letrec.is_nil(&mut cs.namespace(|| "var_let_letrec_is_nil"), g)?;
         let var_let_letrec_is_list = or!(cs, &var_let_letrec_is_sym, &var_let_letrec_is_nil)?;
@@ -1824,17 +1873,17 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         // Otherwise, more than one argument was provided (FIXME: error-checking to ensure exactly two were provided?):
         // [binop_cont_tag, g.op2_eval_tag, env.tag(), env.hash(), more.tag(), more.hash(), cont.tag(), cont.hash()]
 
-        let the_op = pick(
+        let the_op = pick_const(
             &mut cs.namespace(|| "eval op"),
             &end_is_nil,
-            &g.unop_cont_tag,
-            &g.binop_cont_tag,
+            ContTag::Unop.as_field(),
+            ContTag::Binop.as_field(),
         )?;
-        let op1_or_op2 = pick(
+        let op1_or_op2 = pick_const(
             &mut cs.namespace(|| "op1 or op2"),
             &end_is_nil,
-            &g.op1_eval_tag,
-            &g.op2_eval_tag,
+            Op1::Eval.as_field(),
+            Op2::Eval.as_field(),
         )?;
         let cont_or_env_tag = pick(
             &mut cs.namespace(|| "env or cont tag"),
@@ -1892,7 +1941,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&default_or_cont_tag, &default_or_cont_hash],
     ];
     hash_default_results.add_hash_input_clauses(
-        *eval_hash.value(),
+        *p.eval.value(),
         &the_op,
         eval_continuation_components,
     );
@@ -1902,14 +1951,14 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let let_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&var_let_letrec, &expanded_let, env, cont];
     hash_default_results.add_hash_input_clauses(
-        *let_sym.value(),
+        *p.let_.value(),
         &g.let_cont_tag,
         let_continuation_components,
     );
     let letrec_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&var_let_letrec, &expanded_letrec, env, cont];
     hash_default_results.add_hash_input_clauses(
-        *letrec.value(),
+        *p.letrec.value(),
         &g.letrec_cont_tag,
         letrec_continuation_components,
     );
@@ -1919,7 +1968,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let cons_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_cons_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *cons_hash.value(),
+        *p.cons.value(),
         &g.binop_cont_tag,
         cons_continuation_components,
     );
@@ -1929,7 +1978,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let strcons_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_strcons_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *strcons_hash.value(),
+        *p.strcons.value(),
         &g.binop_cont_tag,
         strcons_continuation_components,
     );
@@ -1939,7 +1988,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let hide_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_hide_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *hide_hash.value(),
+        *p.hide.value(),
         &g.binop_cont_tag,
         hide_continuation_components,
     );
@@ -1953,7 +2002,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *commit_hash.value(),
+        *p.commit.value(),
         &g.unop_cont_tag,
         commit_continuation_components,
     );
@@ -1967,7 +2016,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *open_hash.value(),
+        *p.open.value(),
         &g.unop_cont_tag,
         open_continuation_components,
     );
@@ -1981,7 +2030,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *secret_hash.value(),
+        *p.secret.value(),
         &g.unop_cont_tag,
         secret_continuation_components,
     );
@@ -1995,7 +2044,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *num_hash.value(),
+        *p.num.value(),
         &g.unop_cont_tag,
         num_continuation_components,
     );
@@ -2009,7 +2058,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *u64_hash.value(),
+        *p.u64_.value(),
         &g.unop_cont_tag,
         u64_continuation_components,
     );
@@ -2023,7 +2072,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *comm_hash.value(),
+        *p.comm.value(),
         &g.unop_cont_tag,
         comm_continuation_components,
     );
@@ -2037,7 +2086,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *char_hash.value(),
+        *p.char_.value(),
         &g.unop_cont_tag,
         char_continuation_components,
     );
@@ -2047,7 +2096,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let begin_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_begin_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *begin_hash.value(),
+        *p.begin.value(),
         &g.binop_cont_tag,
         begin_continuation_components,
     );
@@ -2061,7 +2110,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *car_hash.value(),
+        *p.car.value(),
         &g.unop_cont_tag,
         car_continuation_components,
     );
@@ -2075,7 +2124,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *cdr_hash.value(),
+        *p.cdr.value(),
         &g.unop_cont_tag,
         cdr_continuation_components,
     );
@@ -2089,7 +2138,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *atom_hash.value(),
+        *p.atom.value(),
         &g.unop_cont_tag,
         atom_continuation_components,
     );
@@ -2103,7 +2152,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *emit_hash.value(),
+        *p.emit.value(),
         &g.unop_cont_tag,
         emit_continuation_components,
     );
@@ -2113,7 +2162,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let sum_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_sum_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *sum_hash.value(),
+        *p.sum.value(),
         &g.binop_cont_tag,
         sum_continuation_components,
     );
@@ -2123,7 +2172,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let diff_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_diff_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *diff_hash.value(),
+        *p.diff.value(),
         &g.binop_cont_tag,
         diff_continuation_components,
     );
@@ -2133,7 +2182,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let product_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_product_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *product_hash.value(),
+        *p.product.value(),
         &g.binop_cont_tag,
         product_continuation_components,
     );
@@ -2143,7 +2192,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let quotient_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_quotient_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *quotient_hash.value(),
+        *p.quotient.value(),
         &g.binop_cont_tag,
         quotient_continuation_components,
     );
@@ -2153,7 +2202,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let modulo_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_modulo_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *modulo_hash.value(),
+        *p.modulo.value(),
         &g.binop_cont_tag,
         modulo_continuation_components,
     );
@@ -2164,7 +2213,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let numequal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_numequal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *numequal_hash.value(),
+        *p.numequal.value(),
         &g.binop_cont_tag,
         numequal_continuation_components,
     );
@@ -2174,7 +2223,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let equal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_equal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *equal_hash.value(),
+        *p.equal.value(),
         &g.binop_cont_tag,
         equal_continuation_components,
     );
@@ -2184,7 +2233,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let less_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_less_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *less_hash.value(),
+        *p.less.value(),
         &g.binop_cont_tag,
         less_continuation_components,
     );
@@ -2194,7 +2243,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let less_equal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_less_equal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *less_equal_hash.value(),
+        *p.less_equal.value(),
         &g.binop_cont_tag,
         less_equal_continuation_components,
     );
@@ -2204,7 +2253,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let greater_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_greater_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *greater_hash.value(),
+        *p.greater.value(),
         &g.binop_cont_tag,
         greater_continuation_components,
     );
@@ -2218,7 +2267,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         cont,
     ];
     hash_default_results.add_hash_input_clauses(
-        *greater_equal_hash.value(),
+        *p.greater_equal.value(),
         &g.binop_cont_tag,
         greater_equal_continuation_components,
     );
@@ -2232,7 +2281,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *if_hash.value(),
+        *p.if_.value(),
         &g.if_cont_tag,
         if_continuation_components,
     );
@@ -2245,7 +2294,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &g.error_ptr_cont,
     )?;
     results.add_clauses_cons(
-        *current_env_hash.value(),
+        *p.current_env.value(),
         env,
         env,
         &the_cont_if_rest_is_nil,
@@ -2402,8 +2451,20 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
             &output_cont_letrec,
         )?
     };
-    results.add_clauses_cons(*let_hash, &the_expr, env, &the_cont_letrec, &g.false_num);
-    results.add_clauses_cons(*letrec_hash, &the_expr, env, &the_cont_letrec, &g.false_num);
+    results.add_clauses_cons(
+        *p.let_.value(),
+        &the_expr,
+        env,
+        &the_cont_letrec,
+        &g.false_num,
+    );
+    results.add_clauses_cons(
+        *p.letrec.value(),
+        &the_expr,
+        env,
+        &the_cont_letrec,
+        &g.false_num,
+    );
 
     // head == CONS, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
@@ -2415,7 +2476,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &newer_cont,
     )?;
     results.add_clauses_cons(
-        *cons_hash.value(),
+        *p.cons.value(),
         &arg1,
         env,
         &the_cont_cons_or_strcons,
@@ -2425,7 +2486,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == STRCONS, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *strcons_hash.value(),
+        *p.strcons.value(),
         &arg1,
         env,
         &the_cont_cons_or_strcons,
@@ -2440,7 +2501,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         cont,
         &newer_cont,
     )?;
-    results.add_clauses_cons(*begin_hash.value(), &arg1, env, &cont_begin, &g.false_num);
+    results.add_clauses_cons(*p.begin.value(), &arg1, env, &cont_begin, &g.false_num);
 
     // head == CAR, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
@@ -2452,7 +2513,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     )?;
 
     results.add_clauses_cons(
-        *car_hash.value(),
+        *p.car.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2462,7 +2523,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == CDR, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *cdr_hash.value(),
+        *p.cdr.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2477,12 +2538,12 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &g.error_ptr_cont,
         &newer_cont,
     )?;
-    results.add_clauses_cons(*hide_hash.value(), &arg1, env, &the_cont_hide, &g.false_num);
+    results.add_clauses_cons(*p.hide.value(), &arg1, env, &the_cont_hide, &g.false_num);
 
     // head == COMMIT, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *commit_hash.value(),
+        *p.commit.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2494,7 +2555,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let the_cont_open_or_secret = &newer_cont_if_end_is_nil;
 
     results.add_clauses_cons(
-        *open_hash.value(),
+        *p.open.value(),
         &arg1_or_expr,
         env,
         the_cont_open_or_secret,
@@ -2505,7 +2566,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     /////////////////////////////////////////////////////////////////////////////
 
     results.add_clauses_cons(
-        *secret_hash.value(),
+        *p.secret.value(),
         &arg1_or_expr,
         env,
         the_cont_open_or_secret,
@@ -2515,7 +2576,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == NUM, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *num_hash.value(),
+        *p.num.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2525,7 +2586,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == U64, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *u64_hash.value(),
+        *p.u64_.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2535,7 +2596,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == COMM, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *comm_hash.value(),
+        *p.comm.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2545,7 +2606,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == CHAR, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *char_hash.value(),
+        *p.char_.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2554,12 +2615,12 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
     // head == EVAL, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*eval_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.eval.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == ATOM, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *atom_hash.value(),
+        *p.atom.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2569,7 +2630,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == EMIT, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *emit_hash.value(),
+        *p.emit.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2578,66 +2639,48 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
     // head == +, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*sum_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.sum.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == -, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*diff_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.diff.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == *, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*product_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.product.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == /, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(
-        *quotient_hash.value(),
-        &arg1,
-        env,
-        &newer_cont,
-        &g.false_num,
-    );
+    results.add_clauses_cons(*p.quotient.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == %, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*modulo_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.modulo.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == =, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(
-        *numequal_hash.value(),
-        &arg1,
-        env,
-        &newer_cont,
-        &g.false_num,
-    );
+    results.add_clauses_cons(*p.numequal.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == EQ, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*equal_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.equal.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == <, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*less_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.less.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == <=, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(
-        *less_equal_hash.value(),
-        &arg1,
-        env,
-        &newer_cont,
-        &g.false_num,
-    );
+    results.add_clauses_cons(*p.less_equal.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == >, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*greater_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.greater.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == >=, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *greater_equal_hash.value(),
+        *p.greater_equal.value(),
         &arg1,
         env,
         &newer_cont,
@@ -2646,7 +2689,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
     // head == IF, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*if_hash.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(*p.if_.value(), &arg1, env, &newer_cont, &g.false_num);
 
     let is_zero_arg_call = rest_is_nil;
 
@@ -2810,10 +2853,9 @@ fn make_thunk<F: LurkField, CS: ConstraintSystem<F>>(
 ) -> Result<(AllocatedPtr<F>, AllocatedPtr<F>, AllocatedContPtr<F>), SynthesisError> {
     let mut results = Results::default();
 
-    let cont_is_tail = alloc_equal(
+    let cont_is_tail = cont.alloc_tag_equal(
         &mut cs.namespace(|| "cont_is_tail"),
-        cont.tag(),
-        &g.tail_cont_tag,
+        ContTag::Tail.as_field(),
     )?;
 
     let make_thunk_cont_not_dummy = and!(cs, &cont_is_tail, not_dummy)?;
@@ -2896,6 +2938,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     allocated_cont_witness: &mut AllocatedContWitness<F>,
     store: &Store<F>,
     g: &GlobalAllocations<F>,
+    p: &Pointers<F>,
 ) -> Result<
     (
         AllocatedPtr<F>,
@@ -2933,10 +2976,23 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         &g.false_num,
     );
 
-    let cont_is_terminal = equal!(cs, cont.tag(), g.terminal_ptr.tag())?;
-    let cont_is_dummy = equal!(cs, cont.tag(), g.dummy_ptr.tag())?;
-    let cont_is_error = equal!(cs, cont.tag(), g.error_ptr.tag())?;
-    let cont_is_outermost = equal!(cs, cont.tag(), g.outermost_ptr.tag())?;
+    let cont_is_terminal = cont.alloc_tag_equal(
+        &mut cs.namespace(|| "cont_is_terminal"),
+        ContTag::Terminal.as_field(),
+    )?;
+    let cont_is_dummy = cont.alloc_tag_equal(
+        &mut cs.namespace(|| "cont_is_dummy"),
+        ContTag::Dummy.as_field(),
+    )?;
+    let cont_is_error = cont.alloc_tag_equal(
+        &mut cs.namespace(|| "cont_is_error"),
+        ContTag::Error.as_field(),
+    )?;
+    let cont_is_outermost = cont.alloc_tag_equal(
+        &mut cs.namespace(|| "cont_is_outermost"),
+        ContTag::Outermost.as_field(),
+    )?;
+
     let cont_is_trivial = or!(
         cs,
         &cont_is_terminal,
@@ -3066,18 +3122,23 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
     // Commitment values used in Unop but also outside, so can't be in Unop scope.
     let (commitment, commitment_secret, committed_expr) = {
+        let cs = &mut cs.namespace(|| "common");
         let operator = AllocatedPtr::by_index(0, &continuation_components);
 
-        let is_op2_hide = equal!(cs, &g.op2_hide_tag, operator.tag())?;
-
-        let is_op1_open = equal!(cs, &g.op1_open_tag, operator.tag())?;
-        let is_op1_secret = equal!(cs, &g.op1_secret_tag, operator.tag())?;
+        let is_op2_hide =
+            operator.alloc_tag_equal(&mut cs.namespace(|| "is_op2_hide"), Op2::Hide.as_field())?;
+        let is_op1_open =
+            operator.alloc_tag_equal(&mut cs.namespace(|| "is_op1_open"), Op1::Open.as_field())?;
+        let is_op1_secret = operator.alloc_tag_equal(
+            &mut cs.namespace(|| "is_op1_secret"),
+            Op1::Secret.as_field(),
+        )?;
         let is_op1_open_or_secret = or!(cs, &is_op1_open, &is_op1_secret)?;
 
         // IF this is open, we need to know what we are opening.
         let digest = result.hash();
 
-        let (open_secret_scalar, open_ptr) = match store.get_maybe_opaque(
+        let (open_secret_scalar, open_expr_ptr) = match store.get_maybe_opaque(
             ExprTag::Comm,
             digest.get_value().unwrap_or_else(|| F::zero()),
         ) {
@@ -3089,7 +3150,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         };
 
         let open_expr = AllocatedPtr::alloc(&mut cs.namespace(|| "open_expr"), || {
-            Ok(store.hash_expr(&open_ptr).unwrap())
+            Ok(store.hash_expr(&open_expr_ptr).unwrap())
         })?;
 
         let open_secret = AllocatedNum::alloc(&mut cs.namespace(|| "open_secret"), || {
@@ -3101,36 +3162,30 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let commit_secret = pick!(cs, &is_op2_hide, arg1.hash(), &g.default_num)?;
         let secret = pick!(cs, &is_op1_open_or_secret, &open_secret, &commit_secret)?;
         let committed = pick_ptr!(cs, &is_op1_open, &open_expr, result)?;
-
-        (
-            hide(&mut cs.namespace(|| "Hide"), g, &secret, &committed, store)?,
-            secret,
-            committed,
-        )
+        let hide = hide(&mut cs.namespace(|| "Hide"), g, &secret, &committed, store)?;
+        (hide, secret, committed)
     };
 
     // Continuation::Unop preimage
     /////////////////////////////////////////////////////////////////////////////
     let (unop_val, unop_continuation) = {
+        let cs = &mut cs.namespace(|| "Unop preimage");
         let op1 = AllocatedPtr::by_index(0, &continuation_components);
         let unop_continuation = AllocatedContPtr::by_index(1, &continuation_components);
 
-        let cont_is_unop = equal!(cs, cont.tag(), &g.unop_cont_tag)?;
+        let cont_is_unop = cont.alloc_tag_equal(
+            &mut cs.namespace(|| "cont_is_unop"),
+            ContTag::Unop.as_field(),
+        )?;
 
-        let unop_op_is_car = equal!(cs, op1.tag(), &g.op1_car_tag)?;
-        let unop_op_is_cdr = equal!(cs, op1.tag(), &g.op1_cdr_tag)?;
+        let unop_op_is_car =
+            op1.alloc_tag_equal(&mut cs.namespace(|| "unop_op_is_car"), Op1::Car.as_field())?;
+        let unop_op_is_cdr =
+            op1.alloc_tag_equal(&mut cs.namespace(|| "unop_op_is_cdr"), Op1::Cdr.as_field())?;
         let unop_op_is_car_or_cdr = or!(cs, &unop_op_is_car, &unop_op_is_cdr)?;
 
-        let result_is_cons = alloc_equal(
-            &mut cs.namespace(|| "result_is_cons"),
-            result.tag(),
-            &g.cons_tag,
-        )?;
-        let result_is_str = alloc_equal(
-            &mut cs.namespace(|| "result_is_str"),
-            result.tag(),
-            &g.str_tag,
-        )?;
+        let result_is_cons = result.is_cons(&mut cs.namespace(|| "result_is_cons"))?;
+        let result_is_str = result.is_str(&mut cs.namespace(|| "result_is_str"))?;
 
         let result_is_empty_str = result.alloc_equal(
             &mut cs.namespace(|| "result_is_empty_str"),
@@ -3159,8 +3214,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let res_car = pick_ptr!(cs, &result_is_empty_str, &g.nil_ptr, &allocated_car)?;
         let res_cdr = pick_ptr!(cs, &result_is_empty_str, &g.empty_str_ptr, &allocated_cdr)?;
 
-        let atom_ptr = AllocatedPtr::pick(
-            &mut cs.namespace(|| "atom val"),
+        let is_atom_ptr = AllocatedPtr::pick(
+            &mut cs.namespace(|| "is_atom_ptr"),
             &result_is_cons,
             &g.nil_ptr,
             &g.t_ptr,
@@ -3187,7 +3242,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                     },
                     CaseClause {
                         key: Op1::Atom.as_field(),
-                        value: atom_ptr.tag(),
+                        value: is_atom_ptr.tag(),
                     },
                     CaseClause {
                         key: Op1::Emit.as_field(),
@@ -3237,7 +3292,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                     },
                     CaseClause {
                         key: Op1::Atom.as_field(),
-                        value: atom_ptr.hash(),
+                        value: is_atom_ptr.hash(),
                     },
                     CaseClause {
                         key: Op1::Emit.as_field(),
@@ -3364,7 +3419,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     )?;
 
     // Reused in Call0, Call, and Call2.
-    let result_is_fun = equal!(cs, function.tag(), &g.fun_tag)?;
+    let result_is_fun = function.is_fun(&mut cs.namespace(|| "result_is_fun"))?;
 
     // Continuation::Call0
     /////////////////////////////////////////////////////////////////////////////
@@ -3372,7 +3427,10 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let mut cs = cs.namespace(|| "Call0");
         let continuation = AllocatedContPtr::by_index(1, &continuation_components);
 
-        let cont_is_call0 = equal!(cs, cont.tag(), &g.call0_cont_tag)?;
+        let cont_is_call0 = cont.alloc_tag_equal(
+            &mut cs.namespace(|| "cont_is_call0"),
+            ContTag::Call0.as_field(),
+        )?;
         let call0_not_dummy = and!(cs, &cont_is_call0, &result_is_fun, not_dummy)?;
 
         // NOTE: this allocation is unconstrained. See necessary constraint immediately below.
@@ -3388,11 +3446,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let args_is_dummy =
             arg_t.alloc_equal(&mut cs.namespace(|| "args_is_dummy"), &g.dummy_arg_ptr)?;
 
-        let body_t_is_cons = alloc_equal(
-            &mut cs.namespace(|| "body_t_is_cons"),
-            body_t.tag(),
-            &g.cons_tag,
-        )?;
+        let body_t_is_cons = body_t.is_cons(&mut cs.namespace(|| "body_t_is_cons"))?;
         let body_t_is_nil = body_t.is_nil(&mut cs.namespace(|| "body_t_is_nil"), g)?;
 
         let body_is_list = or!(cs, &body_t_is_cons, &body_t_is_nil)?;
@@ -3410,10 +3464,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let end_is_nil = end.is_nil(&mut cs.namespace(|| "end_is_nil"), g)?;
 
-        let continuation_is_tail = alloc_equal(
+        let continuation_is_tail = continuation.alloc_tag_equal(
             &mut cs.namespace(|| "continuation is tail"),
-            continuation.tag(),
-            &g.tail_cont_tag,
+            ContTag::Tail.as_field(),
         )?;
 
         let tail_cont = AllocatedContPtr::pick(
@@ -3538,7 +3591,10 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let continuation = AllocatedContPtr::by_index(2, &continuation_components);
 
         {
-            let cont_is_call2_precomp = equal!(cs, cont.tag(), &g.call2_cont_tag)?;
+            let cont_is_call2_precomp = cont.alloc_tag_equal(
+                &mut cs.namespace(|| "cont_is_call2_precomp"),
+                ContTag::Call2.as_field(),
+            )?;
             let cont_is_call2_and_not_dummy = and!(cs, &cont_is_call2_precomp, not_dummy)?;
 
             // NOTE: this allocation is unconstrained. See necessary constraint immediately below.
@@ -3574,9 +3630,6 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             let end_is_nil = end.is_nil(&mut cs.namespace(|| "end_is_nil"), g)?;
             let body_is_well_formed = and!(cs, &body_form_is_nil.not(), &end_is_nil)?;
 
-            let args_is_dummy =
-                arg_t.alloc_equal(&mut cs.namespace(|| "args_is_dummy"), &g.dummy_arg_ptr)?;
-
             let extend_not_dummy = and!(
                 cs,
                 &cont_is_call2_and_not_dummy,
@@ -3595,10 +3648,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
                 &extend_not_dummy,
             )?;
 
-            let continuation_is_tail = alloc_equal(
+            let continuation_is_tail = continuation.alloc_tag_equal(
                 &mut cs.namespace(|| "continuation is tail"),
-                continuation.tag(),
-                &g.tail_cont_tag,
+                ContTag::Tail.as_field(),
             )?;
 
             let tail_cont = AllocatedContPtr::pick(
@@ -3647,10 +3699,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let saved_env = AllocatedPtr::by_index(1, &continuation_components);
         let unevaled_args = AllocatedPtr::by_index(2, &continuation_components);
 
-        let cont_is_binop = alloc_equal(
+        let cont_is_binop = cont.alloc_tag_equal(
             &mut cs.namespace(|| "cont_is_binop"),
-            cont.tag(),
-            &g.binop_cont_tag,
+            ContTag::Binop.as_field(),
         )?;
 
         let binop_not_dummy = Boolean::and(
@@ -3669,11 +3720,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             store,
         )?;
 
-        let op_is_begin = alloc_equal(
-            cs.namespace(|| "op_is_begin"),
-            operator.tag(),
-            &g.op2_begin_tag,
-        )?;
+        let op_is_begin =
+            operator.alloc_tag_equal(&mut cs.namespace(|| "op_is_begin"), Op2::Begin.as_field())?;
 
         let rest_is_nil = allocated_rest.is_nil(&mut cs.namespace(|| "rest_is_nil"), g)?;
         let rest_not_nil = rest_is_nil.not();
@@ -3753,21 +3801,22 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     // Continuation::Binop2
     /////////////////////////////////////////////////////////////////////////////
     let (the_expr, the_env, the_cont, make_thunk_num) = {
+        let mut cs = cs.namespace(|| "Binop2");
         let op2 = AllocatedPtr::by_index(0, &continuation_components);
         let arg1 = AllocatedPtr::by_index(1, &continuation_components);
         let continuation = AllocatedContPtr::by_index(2, &continuation_components);
 
         let arg2 = result;
 
-        let arg1_is_num = alloc_equal(&mut cs.namespace(|| "arg1_is_num"), arg1.tag(), &g.num_tag)?;
-        let arg2_is_num = alloc_equal(&mut cs.namespace(|| "arg2_is_num"), arg2.tag(), &g.num_tag)?;
+        let arg1_is_num = arg1.is_num(&mut cs.namespace(|| "arg1_is_num"))?;
+        let arg2_is_num = arg2.is_num(&mut cs.namespace(|| "arg2_is_num"))?;
         let both_args_are_nums = Boolean::and(
             &mut cs.namespace(|| "both_args_are_nums"),
             &arg1_is_num,
             &arg2_is_num,
         )?;
-        let arg1_is_u64 = alloc_equal(&mut cs.namespace(|| "arg1_is_u64"), arg1.tag(), &g.u64_tag)?;
-        let arg2_is_u64 = alloc_equal(&mut cs.namespace(|| "arg2_is_u64"), arg2.tag(), &g.u64_tag)?;
+        let arg1_is_u64 = arg1.is_u64(&mut cs.namespace(|| "arg1_is_u64"))?;
+        let arg2_is_u64 = arg2.is_u64(&mut cs.namespace(|| "arg2_is_u64"))?;
         let both_args_are_u64s = Boolean::and(
             &mut cs.namespace(|| "both_args_are_u64s"),
             &arg1_is_u64,
@@ -3811,42 +3860,28 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let (a, b) = (arg1_final.hash(), arg2_final.hash()); // For Nums, the 'hash' is an immediate value.
 
-        let tags_equal = alloc_equal(
-            &mut cs.namespace(|| "tags equal"),
-            arg1_final.tag(),
-            arg2_final.tag(),
-        )?;
-        let vals_equal = alloc_equal(
-            &mut cs.namespace(|| "vals equal"),
-            arg1_final.hash(),
-            arg2_final.hash(),
-        )?;
-        let args_equal =
-            Boolean::and(&mut cs.namespace(|| "args equal"), &tags_equal, &vals_equal)?;
+        let args_equal = arg1_final.alloc_equal(&mut cs.namespace(|| "args_equal"), &arg2_final)?;
 
-        let args_equal_ptr = AllocatedPtr::pick(
+        let args_equal_ptr = AllocatedPtr::pick_const(
             &mut cs.namespace(|| "args_equal_ptr"),
             &args_equal,
-            &g.t_ptr,
-            &g.nil_ptr,
+            &p.t,
+            &p.nil,
         )?;
 
-        let not_dummy = alloc_equal(
+        let not_dummy = cont.alloc_tag_equal(
             &mut cs.namespace(|| "Binop2 not dummy"),
-            cont.tag(),
-            &g.binop2_cont_tag,
+            ContTag::Binop2.as_field(),
         )?;
 
         let sum = add(&mut cs.namespace(|| "sum"), a, b)?;
         let diff = sub(&mut cs.namespace(|| "difference"), a, b)?;
         let product = mul(&mut cs.namespace(|| "product"), a, b)?;
 
-        let op2_is_div = alloc_equal(
-            cs.namespace(|| "op2_is_div"),
-            op2.tag(),
-            &g.op2_quotient_tag,
-        )?;
-        let op2_is_mod = alloc_equal(cs.namespace(|| "op2_is_mod"), op2.tag(), &g.op2_modulo_tag)?;
+        let op2_is_div =
+            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_div"), Op2::Quotient.as_field())?;
+        let op2_is_mod =
+            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_mod"), Op2::Modulo.as_field())?;
 
         let op2_is_div_or_mod = or(
             &mut cs.namespace(|| "op2 is div or mod"),
@@ -3865,16 +3900,11 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let quotient = div(&mut cs.namespace(|| "quotient"), a, &divisor)?;
 
-        let is_cons = alloc_equal(
-            &mut cs.namespace(|| "Op2 is Cons"),
-            op2.tag(),
-            &g.op2_cons_tag,
-        )?;
-
-        let is_strcons = alloc_equal(
+        let is_cons =
+            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Cons"), Op2::Cons.as_field())?;
+        let is_strcons = op2.alloc_tag_equal(
             &mut cs.namespace(|| "Op2 is StrCons"),
-            op2.tag(),
-            &g.op2_strcons_tag,
+            Op2::StrCons.as_field(),
         )?;
 
         let is_cons_or_strcons = or(
@@ -3883,12 +3913,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &is_strcons,
         )?;
 
-        let arg1_is_char = alloc_equal(
-            &mut cs.namespace(|| "arg1_is_char"),
-            arg1.tag(),
-            &g.char_tag,
-        )?;
-        let arg2_is_str = alloc_equal(&mut cs.namespace(|| "arg2_is_str"), arg2.tag(), &g.str_tag)?;
+        let arg1_is_char = arg1.is_char(&mut cs.namespace(|| "arg1_is_char"))?;
+        let arg2_is_str = arg2.is_str(&mut cs.namespace(|| "arg2_is_str"))?;
         let args_are_char_str = Boolean::and(
             &mut cs.namespace(|| "args_are_char_str"),
             &arg1_is_char,
@@ -3964,16 +3990,12 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             g,
         )?;
 
-        let is_equal = alloc_equal(
-            &mut cs.namespace(|| "Op2 is Equal"),
-            op2.tag(),
-            &g.op2_equal_tag,
-        )?;
+        let is_equal =
+            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Equal"), Op2::Equal.as_field())?;
 
-        let is_num_equal = alloc_equal(
+        let is_num_equal = op2.alloc_tag_equal(
             &mut cs.namespace(|| "Op2 is NumEqual"),
-            op2.tag(),
-            &g.op2_numequal_tag,
+            Op2::NumEqual.as_field(),
         )?;
 
         let is_equal_or_num_equal = or(
@@ -3982,17 +4004,11 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &is_num_equal,
         )?;
 
-        let op2_is_hide = alloc_equal(
-            &mut cs.namespace(|| "Op2 is Hide"),
-            op2.tag(),
-            &g.op2_hide_tag,
-        )?;
+        let op2_is_hide =
+            op2.alloc_tag_equal(&mut cs.namespace(|| "Op2 is Hide"), Op2::Hide.as_field())?;
 
-        let commitment_tag_is_comm = alloc_equal(
-            &mut cs.namespace(|| "commitment tag is comm"),
-            commitment.tag(),
-            &g.comm_tag,
-        )?;
+        let commitment_tag_is_comm =
+            commitment.is_comm(&mut cs.namespace(|| "commitment tag is comm"))?;
 
         let commitment_tag_is_dummy = alloc_is_zero(
             &mut cs.namespace(|| "commitment tag is dummy"),
@@ -4011,18 +4027,18 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &commitment_tag_is_correct,
         )?;
 
-        let cons_tag = pick(
+        let cons_tag = pick_const(
             &mut cs.namespace(|| "cons_tag"),
             &is_strcons,
-            &g.str_tag,
-            &g.cons_tag,
+            ExprTag::Str.as_field(),
+            ExprTag::Cons.as_field(),
         )?;
 
-        let comm_or_num_tag = pick(
+        let comm_or_num_tag = pick_const(
             &mut cs.namespace(|| "Op2 tag is comm or num"),
             &op2_is_hide,
-            &g.comm_tag,
-            &g.num_tag,
+            ExprTag::Comm.as_field(),
+            ExprTag::Num.as_field(),
         )?;
 
         let is_cons_or_hide = or!(cs, &is_cons, &op2_is_hide)?;
@@ -4059,6 +4075,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             b,
             &diff,
             op2.tag(),
+            p,
         )?;
 
         let field_arithmetic_result = AllocatedPtr::pick(
@@ -4076,7 +4093,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &g.power2_64_num,
         )?;
 
-        let op2_is_diff = alloc_equal(cs.namespace(|| "op2_is_diff"), op2.tag(), &g.op2_diff_tag)?;
+        let op2_is_diff =
+            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_diff"), Op2::Diff.as_field())?;
 
         let diff_is_negative_and_op2_is_diff = Boolean::and(
             &mut cs.namespace(|| "diff is negative and op2 is diff"),
@@ -4189,7 +4207,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &invalid_secret_tag_hide
         )?;
 
-        let op2_is_eval = alloc_equal(cs.namespace(|| "op2_is_eval"), op2.tag(), &g.op2_eval_tag)?;
+        let op2_is_eval =
+            op2.alloc_tag_equal(&mut cs.namespace(|| "op2_is_eval"), Op2::Eval.as_field())?;
 
         let the_cont_ = AllocatedContPtr::pick(
             &mut cs.namespace(|| "maybe type or div by zero error"),
@@ -4226,11 +4245,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             env,
         )?;
 
-        let make_thunk_num = pick(
+        let make_thunk_num = boolean_to_num(
             &mut cs.namespace(|| "maybe eval make_thunk_num"),
-            &op2_is_eval,
-            &g.false_num,
-            &g.true_num,
+            &op2_is_eval.not(),
         )?;
 
         (the_expr, the_env, the_cont, make_thunk_num)
@@ -4254,11 +4271,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let condition = result;
 
-        let cont_is_if = alloc_equal(
-            &mut cs.namespace(|| "cont_is_if"),
-            cont.tag(),
-            &g.if_cont_tag,
-        )?;
+        let cont_is_if =
+            cont.alloc_tag_equal(&mut cs.namespace(|| "cont_is_if"), ContTag::If.as_field())?;
 
         let if_not_dummy = and!(cs, &cont_is_if, not_dummy)?;
 
@@ -4354,15 +4368,11 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let body = AllocatedPtr::by_index(1, &continuation_components);
         let let_cont = AllocatedContPtr::by_index(3, &continuation_components);
 
-        let cont_is_let = alloc_equal(
-            &mut cs.namespace(|| "cont_is_let"),
-            cont.tag(),
-            &g.let_cont_tag,
-        )?;
-        let let_cont_is_let = alloc_equal(
+        let cont_is_let =
+            cont.alloc_tag_equal(&mut cs.namespace(|| "cont_is_let"), ContTag::Let.as_field())?;
+        let let_cont_is_let = let_cont.alloc_tag_equal(
             &mut cs.namespace(|| "let_cont_is_let"),
-            let_cont.tag(),
-            &g.let_cont_tag,
+            ContTag::Let.as_field(),
         )?;
 
         let extended_env_not_dummy0 = and!(cs, &let_cont_is_let, not_dummy)?;
@@ -4379,10 +4389,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &extended_env_not_dummy,
         )?;
 
-        let continuation_is_tail = alloc_equal(
+        let continuation_is_tail = let_cont.alloc_tag_equal(
             &mut cs.namespace(|| "continuation is tail"),
-            let_cont.tag(),
-            &g.tail_cont_tag,
+            ContTag::Tail.as_field(),
         )?;
 
         let tail_cont = AllocatedContPtr::pick(
@@ -4416,10 +4425,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let body = AllocatedPtr::by_index(1, &continuation_components);
         let letrec_cont = AllocatedContPtr::by_index(3, &continuation_components);
 
-        let letrec_cont_is_letrec_cont = alloc_equal(
+        let letrec_cont_is_letrec_cont = letrec_cont.alloc_tag_equal(
             &mut cs.namespace(|| "letrec_cont_is_letrec_cont"),
-            letrec_cont.tag(),
-            &g.letrec_cont_tag,
+            ContTag::LetRec.as_field(),
         )?;
 
         let extend_rec_not_dummy = and!(cs, &letrec_cont_is_letrec_cont, not_dummy)?;
@@ -4437,10 +4445,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let is_error = extended_env.alloc_equal(&mut cs.namespace(|| "is_error"), &g.error_ptr)?;
 
-        let continuation_is_tail = alloc_equal(
+        let continuation_is_tail = letrec_cont.alloc_tag_equal(
             &mut cs.namespace(|| "continuation is tail"),
-            letrec_cont.tag(),
-            &g.tail_cont_tag,
+            ContTag::Tail.as_field(),
         )?;
 
         let tail_cont = AllocatedContPtr::pick(
@@ -4472,11 +4479,14 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
     // Continuation::Unop newer_cont2 is allocated
     /////////////////////////////////////////////////////////////////////////////
     let (the_expr, the_env, the_cont, make_thunk_num, newer_cont2_not_dummy) = {
+        let mut cs = cs.namespace(|| "Unop new_cont2");
         let unop_op1 = AllocatedPtr::by_index(0, &continuation_components);
         let other_unop_continuation = AllocatedContPtr::by_index(1, &continuation_components);
 
-        let op1_is_emit = equal!(cs, &g.op1_emit_tag, unop_op1.tag())?;
-        let op1_is_eval = equal!(cs, &g.op1_eval_tag, unop_op1.tag())?;
+        let op1_is_emit =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_emit"), Op1::Emit.as_field())?;
+        let op1_is_eval =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_eval"), Op1::Eval.as_field())?;
 
         let unop_continuation0 = AllocatedContPtr::pick(
             &mut cs.namespace(|| "unop_continuation0"),
@@ -4492,34 +4502,51 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &unop_continuation0,
         )?;
 
-        let result_has_cons_tag = equal!(cs, &g.cons_tag, result.tag())?;
-        let result_has_str_tag = equal!(cs, &g.str_tag, result.tag())?;
+        let result_is_cons = result.is_cons(&mut cs.namespace(|| "result_is_cons"))?;
+        let result_is_str = result.is_str(&mut cs.namespace(|| "result_is_str"))?;
 
         let result_is_nil = result.is_nil(&mut cs.namespace(|| "result_is_nil"), g)?;
 
-        let car_cdr_has_valid_tag = or!(
-            cs,
-            &result_has_cons_tag,
-            &result_has_str_tag,
-            &result_is_nil
-        )?;
+        let car_cdr_is_valid = or!(cs, &result_is_cons, &result_is_str, &result_is_nil)?;
 
-        let op1_is_car = equal!(cs, &g.op1_car_tag, unop_op1.tag())?;
-        let op1_is_cdr = equal!(cs, &g.op1_cdr_tag, unop_op1.tag())?;
+        let op1_is_car =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_car"), Op1::Car.as_field())?;
+        let op1_is_cdr =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_cdr"), Op1::Cdr.as_field())?;
         let op1_is_car_or_cdr = or!(cs, &op1_is_car, &op1_is_cdr)?;
-        let car_cdr_has_invalid_tag = and!(cs, &op1_is_car_or_cdr, &car_cdr_has_valid_tag.not())?;
+        let car_cdr_is_invalid = and!(cs, &op1_is_car_or_cdr, &car_cdr_is_valid.not())?;
 
-        let op1_is_comm = equal!(cs, &g.op1_comm_tag, unop_op1.tag())?;
-        let op1_is_num = equal!(cs, &g.op1_num_tag, unop_op1.tag())?;
-        let op1_is_char = equal!(cs, &g.op1_char_tag, unop_op1.tag())?;
-        let op1_is_open = equal!(cs, &g.op1_open_tag, unop_op1.tag())?;
-        let op1_is_secret = equal!(cs, &g.op1_secret_tag, unop_op1.tag())?;
-        let op1_is_u64 = equal!(cs, &g.op1_u64_tag, unop_op1.tag())?;
+        let op1_is_comm =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_comm"), Op1::Comm.as_field())?;
+        let op1_is_num =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_num"), Op1::Num.as_field())?;
+        let op1_is_char =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_char"), Op1::Char.as_field())?;
+        let op1_is_open =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_open"), Op1::Open.as_field())?;
+        let op1_is_secret = unop_op1.alloc_tag_equal(
+            &mut cs.namespace(|| "op1_is_secret"),
+            Op1::Secret.as_field(),
+        )?;
+        let op1_is_u64 =
+            unop_op1.alloc_tag_equal(&mut cs.namespace(|| "op1_is_u64"), Op1::U64.as_field())?;
 
-        let tag_is_char = equal!(cs, &g.char_tag, result.tag())?;
-        let tag_is_num = equal!(cs, &g.num_tag, result.tag())?;
-        let tag_is_comm = equal!(cs, &g.comm_tag, result.tag())?;
-        let tag_is_u64 = equal!(cs, &g.u64_tag, result.tag())?;
+        let tag_is_char = result.alloc_tag_equal(
+            &mut cs.namespace(|| "result_is_char"),
+            ExprTag::Char.as_field(),
+        )?;
+        let tag_is_num = result.alloc_tag_equal(
+            &mut cs.namespace(|| "result_is_num"),
+            ExprTag::Num.as_field(),
+        )?;
+        let tag_is_comm = result.alloc_tag_equal(
+            &mut cs.namespace(|| "result_is_comm"),
+            ExprTag::Comm.as_field(),
+        )?;
+        let tag_is_u64 = result.alloc_tag_equal(
+            &mut cs.namespace(|| "result_is_u64"),
+            ExprTag::U64.as_field(),
+        )?;
 
         let tag_is_num_or_comm = or!(cs, &tag_is_num, &tag_is_comm)?;
         let tag_is_num_or_char = or!(cs, &tag_is_num, &tag_is_char)?;
@@ -4536,7 +4563,7 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
         let any_error = or!(
             cs,
-            &car_cdr_has_invalid_tag,
+            &car_cdr_is_invalid,
             &comm_invalid_tag_error,
             &num_invalid_tag_error,
             &char_invalid_tag_error,
@@ -4556,11 +4583,9 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
             &unop_continuation,
         )?;
 
-        let make_thunk_num = pick(
+        let make_thunk_num = boolean_to_num(
             &mut cs.namespace(|| "pick make_thunk_num"),
-            &op1_is_eval,
-            &g.false_num,
-            &g.true_num,
+            &op1_is_eval.not(),
         )?;
 
         let newer_cont2_not_dummy0 = and!(cs, &op1_is_emit, &any_error.not())?;
@@ -4624,7 +4649,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
 
     // This is all clunky because we can't currently return AllocatedBit from case expressions.
     let newer_cont2_not_dummy_result_num = case_results[7].clone();
-    let newer_cont2_not_dummy_ = equal!(cs, &newer_cont2_not_dummy_result_num, &g.true_num)?;
+    // let newer_cont2_not_dummy_ = equal!(cs, &newer_cont2_not_dummy_result_num, &g.true_num)?;
+    let newer_cont2_not_dummy_ = equal_const!(cs, &newer_cont2_not_dummy_result_num, F::one())?;
     let newer_cont2_not_dummy = and!(cs, &newer_cont2_not_dummy_, not_dummy)?;
 
     implies_equal!(
@@ -4692,6 +4718,7 @@ pub fn comparison_helper<F: LurkField, CS: ConstraintSystem<F>>(
     b: &AllocatedNum<F>,
     diff: &AllocatedNum<F>,
     op2: &AllocatedNum<F>,
+    p: &Pointers<F>,
 ) -> Result<(Boolean, AllocatedPtr<F>, Boolean), SynthesisError> {
     let a_is_negative = allocate_is_negative(&mut cs.namespace(|| "enforce a is negative"), a)?;
     let b_is_negative = allocate_is_negative(&mut cs.namespace(|| "enforce b is negative"), b)?;
@@ -4805,11 +4832,11 @@ pub fn comparison_helper<F: LurkField, CS: ConstraintSystem<F>>(
 
     let comp_val_is_zero = alloc_is_zero(&mut cs.namespace(|| "comp_val_is_zero"), &comp_val2)?;
 
-    let comp_val = AllocatedPtr::pick(
+    let comp_val = AllocatedPtr::pick_const(
         &mut cs.namespace(|| "comp_val"),
         &comp_val_is_zero,
-        &g.nil_ptr,
-        &g.t_ptr,
+        &p.nil,
+        &p.t,
     )?;
 
     Ok((is_comparison_tag, comp_val, diff_is_negative))
@@ -5138,11 +5165,8 @@ fn extend_rec<F: LurkField, CS: ConstraintSystem<F>>(
         store,
     )?;
 
-    let var_or_binding_is_cons = alloc_equal(
-        &mut cs.namespace(|| "var_or_binding_is_cons"),
-        var_or_binding.tag(),
-        &g.cons_tag,
-    )?;
+    let var_or_binding_is_cons =
+        var_or_binding.is_cons(&mut cs.namespace(|| "var_or_binding_is_cons"))?;
 
     let cons = AllocatedPtr::construct_cons_named(
         &mut cs.namespace(|| "cons var val"),
@@ -5196,17 +5220,10 @@ fn extend_rec<F: LurkField, CS: ConstraintSystem<F>>(
         &cons_branch_not_dummy,
     )?;
 
-    let is_sym = var_or_binding.is_sym(&mut cs.namespace(|| "var_or_binding is sym"), g)?;
-
+    let is_sym = var_or_binding.is_sym(&mut cs.namespace(|| "var_or_binding is sym"))?;
     let is_nil = var_or_binding.is_nil(&mut cs.namespace(|| "var_or_binding is nil"), g)?;
-
     let is_sym_or_nil = or!(cs, &is_sym, &is_nil)?;
-
-    let is_cons = alloc_equal(
-        &mut cs.namespace(|| "var_or_binding is cons"),
-        var_or_binding.tag(),
-        &g.cons_tag,
-    )?;
+    let is_cons = var_or_binding_is_cons;
 
     let new_env_if_cons = AllocatedPtr::pick(
         &mut cs.namespace(|| "new_env_if_cons"),
@@ -5320,9 +5337,9 @@ mod tests {
             assert!(delta == Delta::Equal);
 
             //println!("{}", print_cs(&cs));
-            assert_eq!(12330, cs.num_constraints());
+            assert_eq!(12131, cs.num_constraints());
             assert_eq!(13, cs.num_inputs());
-            assert_eq!(12002, cs.aux().len());
+            assert_eq!(11806, cs.aux().len());
 
             let public_inputs = multiframe.public_inputs();
             let mut rng = rand::thread_rng();
@@ -5684,7 +5701,7 @@ mod tests {
         let s = &mut Store::<Fr>::default();
 
         let g = GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s).unwrap();
-
+        let p = Pointers::new(s);
         let a = s.num(42);
         let alloc_a = AllocatedPtr::alloc_ptr(&mut cs.namespace(|| "a"), s, || Ok(&a)).unwrap();
         let b = s.num(43);
@@ -5698,6 +5715,7 @@ mod tests {
             alloc_b.hash(),
             &diff,
             &g.op2_less_tag,
+            &p,
         )
         .unwrap();
         assert!(cs.is_satisfied());

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -240,7 +240,7 @@ impl<F: LurkField> CircuitFrame<'_, F, IO<F>, Witness<F>> {
                 &mut allocated_cont_witness,
                 store,
                 g,
-                &p,
+                p,
             )
         };
 
@@ -757,7 +757,7 @@ fn reduce_expression<F: LurkField, CS: ConstraintSystem<F>>(
         allocated_cont_witness,
         store,
         g,
-        &p,
+        p,
     )?;
 
     results.add_clauses_expr(

--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1298,9 +1298,9 @@ pub struct Pointers<F: LurkField> {
     hide: ScalarPtr<F>,
     commit: ScalarPtr<F>,
     num: ScalarPtr<F>,
-    u64_: ScalarPtr<F>,
+    u64: ScalarPtr<F>,
     comm: ScalarPtr<F>,
-    char_: ScalarPtr<F>,
+    char: ScalarPtr<F>,
     eval: ScalarPtr<F>,
     open: ScalarPtr<F>,
     secret: ScalarPtr<F>,
@@ -1344,9 +1344,9 @@ impl<F: LurkField> Pointers<F> {
         let hide = hash_sym("hide");
         let commit = hash_sym("commit");
         let num = hash_sym("num");
-        let u64_ = hash_sym("u64");
+        let u64 = hash_sym("u64");
         let comm = hash_sym("comm");
-        let char_ = hash_sym("char");
+        let char = hash_sym("char");
         let eval = hash_sym("eval");
         let open = hash_sym("open");
         let secret = hash_sym("secret");
@@ -1381,9 +1381,9 @@ impl<F: LurkField> Pointers<F> {
             hide,
             commit,
             num,
-            u64_,
+            u64,
             comm,
-            char_,
+            char,
             eval,
             open,
             secret,
@@ -1444,9 +1444,9 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     def_head_val!(head_is_open, p.open);
     def_head_val!(head_is_secret, p.secret);
     def_head_val!(head_is_num, p.num);
-    def_head_val!(head_is_u64, p.u64_);
+    def_head_val!(head_is_u64, p.u64);
     def_head_val!(head_is_comm, p.comm);
-    def_head_val!(head_is_char, p.char_);
+    def_head_val!(head_is_char, p.char);
     def_head_val!(head_is_begin, p.begin);
     def_head_val!(head_is_car, p.car);
     def_head_val!(head_is_cdr, p.cdr);
@@ -2073,7 +2073,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *p.u64_.value(),
+        *p.u64.value(),
         &g.unop_cont_tag,
         u64_continuation_components,
     );
@@ -2101,7 +2101,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *p.char_.value(),
+        *p.char.value(),
         &g.unop_cont_tag,
         char_continuation_components,
     );
@@ -2601,7 +2601,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == U64, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *p.u64_.value(),
+        *p.u64.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2621,7 +2621,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == CHAR, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *p.char_.value(),
+        *p.char.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -461,10 +461,10 @@ pub fn alloc_equal_const<CS: ConstraintSystem<F>, F: PrimeField>(
     a: &AllocatedNum<F>,
     b: F,
 ) -> Result<Boolean, SynthesisError> {
-    let equal = a.get_value().and_then(|x| Some(x == b));
+    let equal = a.get_value().map(|x| x == b);
 
     // Difference between `a` and `b`. This will be zero if `a` and `b` are equal.
-    let diff = a.get_value().and_then(|x| Some(x - b)); //sub(cs.namespace(|| "a - b"), a, b)?;
+    let diff = a.get_value().map(|x| x - b); //sub(cs.namespace(|| "a - b"), a, b)?;
 
     // result = (a == b)
     let result = AllocatedBit::alloc(cs.namespace(|| "a = b"), equal)?;

--- a/src/circuit/gadgets/constraints.rs
+++ b/src/circuit/gadgets/constraints.rs
@@ -36,7 +36,7 @@ pub fn enforce_equal<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
 /// Adds a constraint to CS, enforcing a add relationship between the allocated numbers a, b, and sum.
 ///
 /// a + b = sum
-pub fn sum<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+pub fn enforce_sum<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     annotation: A,
     a: &AllocatedNum<F>,
@@ -68,7 +68,7 @@ pub fn add<F: PrimeField, CS: ConstraintSystem<F>>(
     })?;
 
     // a + b = res
-    sum(&mut cs, || "sum constraint", a, b, &res);
+    enforce_sum(&mut cs, || "sum constraint", a, b, &res);
 
     Ok(res)
 }
@@ -147,7 +147,7 @@ pub fn enforce_pack<F: LurkField, CS: ConstraintSystem<F>>(
 /// Adds a constraint to CS, enforcing a difference relationship between the allocated numbers a, b, and difference.
 ///
 /// a - b = difference
-pub fn difference<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
+pub fn enforce_difference<F: PrimeField, A, AR, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     annotation: A,
     a: &AllocatedNum<F>,
@@ -181,7 +181,7 @@ pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
     })?;
 
     // a - b = res
-    difference(&mut cs, || "subtraction constraint", a, b, &res);
+    enforce_difference(&mut cs, || "subtraction constraint", a, b, &res);
 
     Ok(res)
 }
@@ -340,6 +340,39 @@ where
     Ok(c)
 }
 
+/// Takes two numbers (`a`, `b`) and returns `a` if the condition is true, and `b` otherwise.
+pub fn pick_const<F: PrimeField, CS: ConstraintSystem<F>>(
+    mut cs: CS,
+    condition: &Boolean,
+    a: F,
+    b: F,
+) -> Result<AllocatedNum<F>, SynthesisError>
+where
+    CS: ConstraintSystem<F>,
+{
+    let c = AllocatedNum::alloc(cs.namespace(|| "pick result"), || {
+        if condition
+            .get_value()
+            .ok_or(SynthesisError::AssignmentMissing)?
+        {
+            Ok(a)
+        } else {
+            Ok(b)
+        }
+    })?;
+
+    // Constrain (b - a) * condition = (b - c), ensuring c = a iff
+    // condition is true, otherwise c = b.
+    cs.enforce(
+        || "pick",
+        |lc| lc + (b, CS::one()) - (a, CS::one()),
+        |_| condition.lc(CS::one(), F::one()),
+        |lc| lc + (b, CS::one()) - c.get_variable(),
+    );
+
+    Ok(c)
+}
+
 /// Convert from Boolean to AllocatedNum
 pub fn boolean_to_num<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
@@ -410,6 +443,61 @@ pub fn alloc_equal<CS: ConstraintSystem<F>, F: PrimeField>(
     cs.enforce(
         || "(diff + result) * q = 1",
         |lc| lc + diff.get_variable() + result.get_variable(),
+        |lc| lc + q,
+        |lc| lc + CS::one(),
+    );
+
+    // Taken together, these constraints enforce that exactly one of `diff` and `result` is 0.
+    // Since result is constrained to be boolean, that means `result` is true iff `diff` is 0.
+    // `Diff` is 0 iff `a == b`.
+    // Therefore, `result = (a == b)`.
+
+    Ok(Boolean::Is(result))
+}
+
+// Like `alloc_equal`, but with second argument a constant.
+pub fn alloc_equal_const<CS: ConstraintSystem<F>, F: PrimeField>(
+    mut cs: CS,
+    a: &AllocatedNum<F>,
+    b: F,
+) -> Result<Boolean, SynthesisError> {
+    let equal = a.get_value().and_then(|x| Some(x == b));
+
+    // Difference between `a` and `b`. This will be zero if `a` and `b` are equal.
+    let diff = a.get_value().and_then(|x| Some(x - b)); //sub(cs.namespace(|| "a - b"), a, b)?;
+
+    // result = (a == b)
+    let result = AllocatedBit::alloc(cs.namespace(|| "a = b"), equal)?;
+
+    // result * diff = 0
+    // This means that at least one of result or diff is zero.
+    cs.enforce(
+        || "result or diff is 0",
+        |lc| lc + result.get_variable(),
+        |lc| lc + a.get_variable() - (b, CS::one()),
+        |lc| lc,
+    );
+
+    // Inverse of `diff`, if it exists, otherwise one.
+    let q = cs.alloc(
+        || "q",
+        || {
+            let tmp0 = diff.ok_or(SynthesisError::AssignmentMissing)?;
+            let tmp1 = tmp0.invert();
+
+            if tmp1.is_some().into() {
+                Ok(tmp1.unwrap())
+            } else {
+                Ok(F::one())
+            }
+        },
+    )?;
+
+    // ((a - b) + result) * q = 1.
+    // This enforces that diff (a - b) and result are not both 0.
+    cs.enforce(
+        || "((a-b) + result) * q = 1",
+        |lc| lc + a.get_variable() - (b, CS::one()) + result.get_variable(),
         |lc| lc + q,
         |lc| lc + CS::one(),
     );
@@ -600,6 +688,31 @@ mod tests {
             tmp.sub_assign(&b.get_value().expect("get_value failed"));
 
             assert_eq!(res.get_value().expect("get_value failed"), tmp);
+            assert!(cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_alloc_equal_const() {
+        let mut rng = &mut XorShiftRng::from_seed(TEST_SEED);
+
+        for _ in 0..10 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let x = Fr::random(&mut rng);
+            let y = Fr::random(&mut rng);
+
+            let a = AllocatedNum::alloc(&mut cs.namespace(|| "a"), || Ok(x)).unwrap();
+
+            let equal =
+                alloc_equal_const(&mut cs.namespace(|| "alloc_equal_const"), &a, x).unwrap();
+            let equal2 =
+                alloc_equal_const(&mut cs.namespace(|| "alloc_equal_const 2"), &a, y).unwrap();
+            // a must always equal x.
+            assert!(equal.get_value().unwrap());
+
+            // a must equal y only if y happens to equal x (very unlikely!), otherwise a must *not* equal y.
+            assert_eq!(equal2.get_value().unwrap(), x == y);
             assert!(cs.is_satisfied());
         }
     }

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -19,17 +19,14 @@ use super::pointer::{AllocatedContPtr, AllocatedPtr};
 #[derive(Clone)]
 pub struct GlobalAllocations<F: LurkField> {
     pub terminal_ptr: AllocatedContPtr<F>,
-    pub outermost_ptr: AllocatedContPtr<F>,
     pub error_ptr_cont: AllocatedContPtr<F>,
     pub error_ptr: AllocatedPtr<F>,
     pub dummy_ptr: AllocatedContPtr<F>,
     pub nil_ptr: AllocatedPtr<F>,
     pub t_ptr: AllocatedPtr<F>,
-    pub lambda_ptr: AllocatedPtr<F>,
     pub dummy_arg_ptr: AllocatedPtr<F>,
     pub empty_str_ptr: AllocatedPtr<F>,
 
-    pub sym_tag: AllocatedNum<F>,
     pub thunk_tag: AllocatedNum<F>,
     pub cons_tag: AllocatedNum<F>,
     pub char_tag: AllocatedNum<F>,
@@ -57,14 +54,12 @@ pub struct GlobalAllocations<F: LurkField> {
     pub op1_commit_tag: AllocatedNum<F>,
     pub op1_num_tag: AllocatedNum<F>,
     pub op1_char_tag: AllocatedNum<F>,
-    pub op1_eval_tag: AllocatedNum<F>,
     pub op1_u64_tag: AllocatedNum<F>,
     pub op1_comm_tag: AllocatedNum<F>,
     pub op1_open_tag: AllocatedNum<F>,
     pub op1_secret_tag: AllocatedNum<F>,
     pub op1_atom_tag: AllocatedNum<F>,
     pub op1_emit_tag: AllocatedNum<F>,
-    pub op2_eval_tag: AllocatedNum<F>,
     pub op2_cons_tag: AllocatedNum<F>,
     pub op2_strcons_tag: AllocatedNum<F>,
     pub op2_hide_tag: AllocatedNum<F>,
@@ -82,39 +77,6 @@ pub struct GlobalAllocations<F: LurkField> {
     pub op2_greater_equal_tag: AllocatedNum<F>,
 
     pub lambda_sym: AllocatedPtr<F>,
-
-    pub let_sym: AllocatedPtr<F>,
-    pub letrec_sym: AllocatedPtr<F>,
-    pub eval_sym: AllocatedPtr<F>,
-    pub quote_sym: AllocatedPtr<F>,
-    pub cons_sym: AllocatedPtr<F>,
-    pub strcons_sym: AllocatedPtr<F>,
-    pub hide_sym: AllocatedPtr<F>,
-    pub commit_sym: AllocatedPtr<F>,
-    pub open_sym: AllocatedPtr<F>,
-    pub secret_sym: AllocatedPtr<F>,
-    pub num_sym: AllocatedPtr<F>,
-    pub u64_sym: AllocatedPtr<F>,
-    pub comm_sym: AllocatedPtr<F>,
-    pub char_sym: AllocatedPtr<F>,
-    pub begin_sym: AllocatedPtr<F>,
-    pub car_sym: AllocatedPtr<F>,
-    pub cdr_sym: AllocatedPtr<F>,
-    pub atom_sym: AllocatedPtr<F>,
-    pub emit_sym: AllocatedPtr<F>,
-    pub plus_sym: AllocatedPtr<F>,
-    pub minus_sym: AllocatedPtr<F>,
-    pub times_sym: AllocatedPtr<F>,
-    pub div_sym: AllocatedPtr<F>,
-    pub mod_sym: AllocatedPtr<F>,
-    pub equal_sym: AllocatedPtr<F>,
-    pub eq_sym: AllocatedPtr<F>,
-    pub less_sym: AllocatedPtr<F>,
-    pub less_equal_sym: AllocatedPtr<F>,
-    pub greater_sym: AllocatedPtr<F>,
-    pub greater_equal_sym: AllocatedPtr<F>,
-    pub if_sym: AllocatedPtr<F>,
-    pub current_env_sym: AllocatedPtr<F>,
 
     pub true_num: AllocatedNum<F>,
     pub false_num: AllocatedNum<F>,
@@ -134,12 +96,6 @@ impl<F: LurkField> GlobalAllocations<F> {
             &store.get_cont_terminal(),
         )?;
 
-        let outermost_ptr = AllocatedContPtr::alloc_constant_cont_ptr(
-            &mut cs.namespace(|| "outermost continuation"),
-            store,
-            &store.get_cont_outermost(),
-        )?;
-
         let error_ptr_cont = AllocatedContPtr::alloc_constant_cont_ptr(
             &mut cs.namespace(|| "error continuation"),
             store,
@@ -157,11 +113,6 @@ impl<F: LurkField> GlobalAllocations<F> {
             AllocatedPtr::alloc_constant_ptr(&mut cs.namespace(|| "nil"), store, &store.get_nil())?;
         let t_ptr =
             AllocatedPtr::alloc_constant_ptr(&mut cs.namespace(|| "T"), store, &store.get_t())?;
-        let lambda_ptr = AllocatedPtr::alloc_constant_ptr(
-            &mut cs.namespace(|| "LAMBDA"),
-            store,
-            &store.get_lurk_sym("lambda", true).unwrap(),
-        )?;
         let dummy_arg_ptr = AllocatedPtr::alloc_constant_ptr(
             &mut cs.namespace(|| "_"),
             store,
@@ -174,7 +125,6 @@ impl<F: LurkField> GlobalAllocations<F> {
             &store.get_str("").unwrap(),
         )?;
 
-        let sym_tag = ExprTag::Sym.allocate_constant(&mut cs.namespace(|| "sym_tag"))?;
         let thunk_tag = ExprTag::Thunk.allocate_constant(&mut cs.namespace(|| "thunk_tag"))?;
         let cons_tag = ExprTag::Cons.allocate_constant(&mut cs.namespace(|| "cons_tag"))?;
         let char_tag = ExprTag::Char.allocate_constant(&mut cs.namespace(|| "char_tag"))?;
@@ -215,7 +165,6 @@ impl<F: LurkField> GlobalAllocations<F> {
             Op1::Commit.allocate_constant(&mut cs.namespace(|| "op1_commit_tag"))?;
         let op1_num_tag = Op1::Num.allocate_constant(&mut cs.namespace(|| "op1_num_tag"))?;
         let op1_char_tag = Op1::Char.allocate_constant(&mut cs.namespace(|| "op1_char_tag"))?;
-        let op1_eval_tag = Op1::Eval.allocate_constant(&mut cs.namespace(|| "op1_eval_tag"))?;
         let op1_u64_tag = Op1::U64.allocate_constant(&mut cs.namespace(|| "op1_u64_tag"))?;
         let op1_comm_tag = Op1::Comm.allocate_constant(&mut cs.namespace(|| "op1_comm_tag"))?;
         let op1_open_tag = Op1::Open.allocate_constant(&mut cs.namespace(|| "op1_open_tag"))?;
@@ -223,7 +172,6 @@ impl<F: LurkField> GlobalAllocations<F> {
             Op1::Secret.allocate_constant(&mut cs.namespace(|| "op1_secret_tag"))?;
         let op1_atom_tag = Op1::Atom.allocate_constant(&mut cs.namespace(|| "op1_atom_tag"))?;
         let op1_emit_tag = Op1::Emit.allocate_constant(&mut cs.namespace(|| "op1_emit_tag"))?;
-        let op2_eval_tag = Op2::Eval.allocate_constant(&mut cs.namespace(|| "op2_eval_tag"))?;
         let op2_cons_tag = Op2::Cons.allocate_constant(&mut cs.namespace(|| "op2_cons_tag"))?;
         let op2_strcons_tag =
             Op2::StrCons.allocate_constant(&mut cs.namespace(|| "op2_strcons_tag"))?;
@@ -274,38 +222,6 @@ impl<F: LurkField> GlobalAllocations<F> {
         }
 
         defsym!(lambda_sym, "lambda");
-        defsym!(let_sym, "let");
-        defsym!(letrec_sym, "letrec");
-        defsym!(eval_sym, "eval");
-        defsym!(quote_sym, "quote");
-        defsym!(cons_sym, "cons");
-        defsym!(strcons_sym, "strcons");
-        defsym!(hide_sym, "hide");
-        defsym!(commit_sym, "commit");
-        defsym!(open_sym, "open");
-        defsym!(secret_sym, "secret");
-        defsym!(num_sym, "num");
-        defsym!(u64_sym, "u64");
-        defsym!(comm_sym, "comm");
-        defsym!(char_sym, "char");
-        defsym!(begin_sym, "begin");
-        defsym!(car_sym, "car");
-        defsym!(cdr_sym, "cdr");
-        defsym!(atom_sym, "atom");
-        defsym!(emit_sym, "emit");
-        defsym!(plus_sym, "+");
-        defsym!(minus_sym, "-");
-        defsym!(times_sym, "*");
-        defsym!(div_sym, "/", "div");
-        defsym!(mod_sym, "%", "mod");
-        defsym!(equal_sym, "=");
-        defsym!(eq_sym, "eq");
-        defsym!(less_sym, "<");
-        defsym!(less_equal_sym, "<=");
-        defsym!(greater_sym, ">");
-        defsym!(greater_equal_sym, ">=");
-        defsym!(if_sym, "if");
-        defsym!(current_env_sym, "current-env");
 
         let true_num = allocate_constant(&mut cs.namespace(|| "true"), F::one())?;
         let false_num = allocate_constant(&mut cs.namespace(|| "false"), F::zero())?;
@@ -319,16 +235,13 @@ impl<F: LurkField> GlobalAllocations<F> {
 
         Ok(Self {
             terminal_ptr,
-            outermost_ptr,
             error_ptr_cont,
             error_ptr,
             dummy_ptr,
             nil_ptr,
             t_ptr,
-            lambda_ptr,
             dummy_arg_ptr,
             empty_str_ptr,
-            sym_tag,
             thunk_tag,
             cons_tag,
             char_tag,
@@ -355,14 +268,12 @@ impl<F: LurkField> GlobalAllocations<F> {
             op1_commit_tag,
             op1_num_tag,
             op1_char_tag,
-            op1_eval_tag,
             op1_u64_tag,
             op1_comm_tag,
             op1_open_tag,
             op1_secret_tag,
             op1_atom_tag,
             op1_emit_tag,
-            op2_eval_tag,
             op2_cons_tag,
             op2_strcons_tag,
             op2_hide_tag,
@@ -379,38 +290,6 @@ impl<F: LurkField> GlobalAllocations<F> {
             op2_greater_tag,
             op2_greater_equal_tag,
             lambda_sym,
-            let_sym,
-            letrec_sym,
-            eval_sym,
-            quote_sym,
-            cons_sym,
-            strcons_sym,
-            hide_sym,
-            commit_sym,
-            open_sym,
-            secret_sym,
-            num_sym,
-            u64_sym,
-            comm_sym,
-            char_sym,
-            begin_sym,
-            car_sym,
-            cdr_sym,
-            atom_sym,
-            emit_sym,
-            plus_sym,
-            minus_sym,
-            times_sym,
-            div_sym,
-            mod_sym,
-            equal_sym,
-            eq_sym,
-            less_sym,
-            less_equal_sym,
-            greater_sym,
-            greater_equal_sym,
-            if_sym,
-            current_env_sym,
             true_num,
             false_num,
             default_num,

--- a/src/circuit/gadgets/macros.rs
+++ b/src/circuit/gadgets/macros.rs
@@ -82,6 +82,17 @@ macro_rules! equal {
     };
 }
 
+// Allocates a bit (returned as Boolean) which is true if a is equal to constant, c.
+macro_rules! equal_const {
+    ($cs:expr, $a:expr, $c:expr) => {
+        alloc_equal_const(
+            $cs.namespace(|| format!("{} equal const {}", stringify!($a), stringify!($c))),
+            $a,
+            $c,
+        )
+    };
+}
+
 // Like equal! but a and b are AllocatedTaggedHashes.
 macro_rules! equal_t {
     ($cs:ident, $a:expr, $b:expr) => {

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -139,7 +139,7 @@ impl<'a, F: LurkField> StepCircuit<F> for MultiFrame<'a, F, IO<F>, Witness<F>> {
         let input_cont = AllocatedContPtr::by_index(2, z);
 
         let (g, p) = if let Some(s) = self.store {
-            let p = Pointers::new(&s);
+            let p = Pointers::new(s);
             (
                 GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s)?,
                 p,

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -19,7 +19,7 @@ use crate::circuit::{
         data::GlobalAllocations,
         pointer::{AllocatedContPtr, AllocatedPtr},
     },
-    CircuitFrame, MultiFrame, Pointers,
+    CircuitFrame, MultiFrame,
 };
 use crate::error::ProofError;
 use crate::eval::{Evaluator, Frame, Witness, IO};
@@ -142,19 +142,18 @@ impl<'a, F: LurkField> StepCircuit<F> for MultiFrame<'a, F, IO<F>, Witness<F>> {
 
         let (new_expr, new_env, new_cont) = match self.frames.as_ref() {
             Some(frames) => {
-                let (s, p) = self.store_and_pointers.expect("store_and_pointers missing");
+                let s = self.store.expect("store missing");
                 let g = GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s)?;
-                self.synthesize_frames(cs, s, input_expr, input_env, input_cont, frames, &g, &p)
+                self.synthesize_frames(cs, s, input_expr, input_env, input_cont, frames, &g)
             }
             None => {
-                assert!(self.store_and_pointers.is_none());
+                assert!(self.store.is_none());
                 let s = Store::default();
-                let p = Pointers::new(&s);
                 let blank_frame = CircuitFrame::blank();
                 let frames = vec![blank_frame; count];
 
                 let g = GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), &s)?;
-                self.synthesize_frames(cs, &s, input_expr, input_env, input_cont, &frames, &g, &p)
+                self.synthesize_frames(cs, &s, input_expr, input_env, input_cont, &frames, &g)
             }
         };
 

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -138,8 +138,7 @@ impl<'a, F: LurkField> StepCircuit<F> for MultiFrame<'a, F, IO<F>, Witness<F>> {
         let input_env = AllocatedPtr::by_index(1, z);
         let input_cont = AllocatedContPtr::by_index(2, z);
 
-        let (g, p) = if let Some(s) = self.store {
-            let p = Pointers::new(s);
+        let (g, p) = if let Some((s, p)) = self.store {
             (
                 GlobalAllocations::new(&mut cs.namespace(|| "global_allocations"), s)?,
                 p,

--- a/src/store.rs
+++ b/src/store.rs
@@ -162,6 +162,7 @@ pub struct Store<F: LurkField> {
     opaque_raw_ptr_count: usize,
 
     pub(crate) lurk_package: Package,
+    constants: OnceCell<NamedConstants<F>>,
 }
 
 #[derive(Default, Debug)]
@@ -856,6 +857,7 @@ impl<F: LurkField> Default for Store<F> {
             dehydrated_cont: Default::default(),
             opaque_raw_ptr_count: 0,
             lurk_package: Package::lurk(),
+            constants: Default::default(),
         };
 
         store.lurk_sym("");
@@ -2464,6 +2466,8 @@ impl<F: LurkField> Store<F> {
     /// safe to call this incrementally. However, for best proving performance, we should call exactly once so all
     /// hashing can be batched, e.g. on the GPU.
     pub fn hydrate_scalar_cache(&mut self) {
+        self.ensure_constants();
+
         self.dehydrated.par_iter().for_each(|ptr| {
             self.hash_expr(ptr).expect("failed to hash_expr");
         });
@@ -2477,6 +2481,16 @@ impl<F: LurkField> Store<F> {
         self.dehydrated_cont.truncate(0);
 
         self.dehydrated_cont.clear();
+    }
+
+    fn ensure_constants(&mut self) -> &NamedConstants<F> {
+        self.constants.get_or_init(|| NamedConstants::new(&self))
+    }
+
+    pub fn get_constants(&self) -> &NamedConstants<F> {
+        self.constants
+            .get()
+            .expect("constants missing. hydrate_scalar_cache should have been called.")
     }
 }
 
@@ -2548,6 +2562,130 @@ impl<F: LurkField> Expression<'_, F> {
 
     pub fn is_opaque(&self) -> bool {
         matches!(self, Self::Opaque(_))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct NamedConstants<F: LurkField> {
+    pub t: ScalarPtr<F>,
+    pub nil: ScalarPtr<F>,
+    pub lambda: ScalarPtr<F>,
+    pub quote: ScalarPtr<F>,
+    pub let_: ScalarPtr<F>,
+    pub letrec: ScalarPtr<F>,
+    pub cons: ScalarPtr<F>,
+    pub strcons: ScalarPtr<F>,
+    pub begin: ScalarPtr<F>,
+    pub car: ScalarPtr<F>,
+    pub cdr: ScalarPtr<F>,
+    pub atom: ScalarPtr<F>,
+    pub emit: ScalarPtr<F>,
+    pub sum: ScalarPtr<F>,
+    pub diff: ScalarPtr<F>,
+    pub product: ScalarPtr<F>,
+    pub quotient: ScalarPtr<F>,
+    pub modulo: ScalarPtr<F>,
+    pub num_equal: ScalarPtr<F>,
+    pub equal: ScalarPtr<F>,
+    pub less: ScalarPtr<F>,
+    pub less_equal: ScalarPtr<F>,
+    pub greater: ScalarPtr<F>,
+    pub greater_equal: ScalarPtr<F>,
+    pub current_env: ScalarPtr<F>,
+    pub if_: ScalarPtr<F>,
+    pub hide: ScalarPtr<F>,
+    pub commit: ScalarPtr<F>,
+    pub num: ScalarPtr<F>,
+    pub u64: ScalarPtr<F>,
+    pub comm: ScalarPtr<F>,
+    pub char: ScalarPtr<F>,
+    pub eval: ScalarPtr<F>,
+    pub open: ScalarPtr<F>,
+    pub secret: ScalarPtr<F>,
+}
+
+impl<F: LurkField> NamedConstants<F> {
+    pub fn new(store: &Store<F>) -> Self {
+        let hash_sym = |name: &str| {
+            store
+                .get_lurk_sym(name, true)
+                .and_then(|s| store.hash_sym(s, HashScalar::Get))
+                .unwrap()
+        };
+
+        let t = hash_sym("t");
+        let nil = store.hash_nil(HashScalar::Get).unwrap();
+        let lambda = hash_sym("lambda");
+        let quote = hash_sym("quote");
+        let let_ = hash_sym("let");
+        let letrec = hash_sym("letrec");
+        let cons = hash_sym("cons");
+        let strcons = hash_sym("strcons");
+        let begin = hash_sym("begin");
+        let car = hash_sym("car");
+        let cdr = hash_sym("cdr");
+        let atom = hash_sym("atom");
+        let emit = hash_sym("emit");
+        let sum = hash_sym("+");
+        let diff = hash_sym("-");
+        let product = hash_sym("*");
+        let quotient = hash_sym("/");
+        let modulo = hash_sym("%");
+        let num_equal = hash_sym("=");
+        let equal = hash_sym("eq");
+        let less = hash_sym("<");
+        let less_equal = hash_sym("<=");
+        let greater = hash_sym(">");
+        let greater_equal = hash_sym(">=");
+        let current_env = hash_sym("current-env");
+        let if_ = hash_sym("if");
+        let hide = hash_sym("hide");
+        let commit = hash_sym("commit");
+        let num = hash_sym("num");
+        let u64 = hash_sym("u64");
+        let comm = hash_sym("comm");
+        let char = hash_sym("char");
+        let eval = hash_sym("eval");
+        let open = hash_sym("open");
+        let secret = hash_sym("secret");
+
+        Self {
+            t,
+            nil,
+            lambda,
+            quote,
+            let_,
+            letrec,
+            cons,
+            strcons,
+            begin,
+            car,
+            cdr,
+            atom,
+            emit,
+            sum,
+            diff,
+            product,
+            quotient,
+            modulo,
+            num_equal,
+            equal,
+            less,
+            less_equal,
+            greater,
+            greater_equal,
+            current_env,
+            if_,
+            hide,
+            commit,
+            num,
+            u64,
+            comm,
+            char,
+            eval,
+            open,
+            secret,
+        }
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -2484,7 +2484,7 @@ impl<F: LurkField> Store<F> {
     }
 
     fn ensure_constants(&mut self) -> &NamedConstants<F> {
-        self.constants.get_or_init(|| NamedConstants::new(&self))
+        self.constants.get_or_init(|| NamedConstants::new(self))
     }
 
     pub fn get_constants(&self) -> &NamedConstants<F> {


### PR DESCRIPTION
This PR eliminates 200 constraints by using constants instead of allocations where possible. This is sometimes cheaper inherently, and sometimes allows us to avoid constraints in the global allocation. It also factors out the work of interning symbol pointers so this happens only once, not while synthesizing the circuit for each frame (but this doesn't change number of constraints, just avoids unnecessary work while proving).