### PR TITLE
feat: Introduces a dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,9 @@ members = [
 [[bin]]
 name = "lurkrs"
 path = "src/main.rs"
+
+[profile.dev]
+# By compiling dependencies with optimizations, performing tests gets much faster.
+opt-level = 3
+lto = true
+codegen-units = 1


### PR DESCRIPTION
This:
- makes running tests go from 2180 to 528s on my machine,

The rest of the dev profile is unchanged:
```
debug = true
debug-assertions = true
overflow-checks = true
panic = 'unwind'
incremental = true
rpath = false
```

See [doc](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles)