### PR TITLE
Optimize eval syms

### DIFF
--- a/src/circuit/circuit_frame.rs
+++ b/src/circuit/circuit_frame.rs
@@ -1294,7 +1294,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     macro_rules! def_head_val {
         ($var:ident, $name:expr) => {
             let $var =
-                head.alloc_hash_equal(&mut cs.namespace(|| stringify!($var)), *$name.value())?;
+                head.alloc_hash_equal(&mut cs.namespace(|| stringify!($var)), $name.value())?;
         };
     }
     let c = store.get_constants();
@@ -1551,7 +1551,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     };
 
     results.add_clauses_cons(
-        *c.lambda.value(),
+        c.lambda.value(),
         &lambda_expr,
         lambda_env,
         &lambda_cont,
@@ -1577,7 +1577,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         (arg1_or_expr, the_cont)
     };
 
-    results.add_clauses_cons(*c.quote.value(), &arg1_or_expr, env, &the_cont, &g.true_num);
+    results.add_clauses_cons(c.quote.value(), &arg1_or_expr, env, &the_cont, &g.true_num);
 
     ////////////////////////////////////////////////////////////////////////////////
 
@@ -1822,7 +1822,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&default_or_cont_tag, &default_or_cont_hash],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.eval.value(),
+        c.eval.value(),
         &the_op,
         eval_continuation_components,
     );
@@ -1832,14 +1832,14 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let let_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&var_let_letrec, &expanded_let, env, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.let_.value(),
+        c.let_.value(),
         &g.let_cont_tag,
         let_continuation_components,
     );
     let letrec_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&var_let_letrec, &expanded_letrec, env, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.letrec.value(),
+        c.letrec.value(),
         &g.letrec_cont_tag,
         letrec_continuation_components,
     );
@@ -1849,7 +1849,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let cons_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_cons_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.cons.value(),
+        c.cons.value(),
         &g.binop_cont_tag,
         cons_continuation_components,
     );
@@ -1859,7 +1859,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let strcons_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_strcons_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.strcons.value(),
+        c.strcons.value(),
         &g.binop_cont_tag,
         strcons_continuation_components,
     );
@@ -1869,7 +1869,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let hide_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_hide_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.hide.value(),
+        c.hide.value(),
         &g.binop_cont_tag,
         hide_continuation_components,
     );
@@ -1883,7 +1883,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.commit.value(),
+        c.commit.value(),
         &g.unop_cont_tag,
         commit_continuation_components,
     );
@@ -1897,7 +1897,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.open.value(),
+        c.open.value(),
         &g.unop_cont_tag,
         open_continuation_components,
     );
@@ -1911,7 +1911,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.secret.value(),
+        c.secret.value(),
         &g.unop_cont_tag,
         secret_continuation_components,
     );
@@ -1925,7 +1925,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.num.value(),
+        c.num.value(),
         &g.unop_cont_tag,
         num_continuation_components,
     );
@@ -1939,7 +1939,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.u64.value(),
+        c.u64.value(),
         &g.unop_cont_tag,
         u64_continuation_components,
     );
@@ -1953,7 +1953,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.comm.value(),
+        c.comm.value(),
         &g.unop_cont_tag,
         comm_continuation_components,
     );
@@ -1967,7 +1967,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.char.value(),
+        c.char.value(),
         &g.unop_cont_tag,
         char_continuation_components,
     );
@@ -1977,7 +1977,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let begin_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_begin_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.begin.value(),
+        c.begin.value(),
         &g.binop_cont_tag,
         begin_continuation_components,
     );
@@ -1991,7 +1991,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.car.value(),
+        c.car.value(),
         &g.unop_cont_tag,
         car_continuation_components,
     );
@@ -2005,7 +2005,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.cdr.value(),
+        c.cdr.value(),
         &g.unop_cont_tag,
         cdr_continuation_components,
     );
@@ -2019,7 +2019,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.atom.value(),
+        c.atom.value(),
         &g.unop_cont_tag,
         atom_continuation_components,
     );
@@ -2033,7 +2033,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.emit.value(),
+        c.emit.value(),
         &g.unop_cont_tag,
         emit_continuation_components,
     );
@@ -2043,7 +2043,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let sum_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_sum_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.sum.value(),
+        c.sum.value(),
         &g.binop_cont_tag,
         sum_continuation_components,
     );
@@ -2053,7 +2053,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let diff_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_diff_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.diff.value(),
+        c.diff.value(),
         &g.binop_cont_tag,
         diff_continuation_components,
     );
@@ -2063,7 +2063,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let product_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_product_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.product.value(),
+        c.product.value(),
         &g.binop_cont_tag,
         product_continuation_components,
     );
@@ -2073,7 +2073,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let quotient_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_quotient_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.quotient.value(),
+        c.quotient.value(),
         &g.binop_cont_tag,
         quotient_continuation_components,
     );
@@ -2083,7 +2083,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let modulo_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_modulo_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.modulo.value(),
+        c.modulo.value(),
         &g.binop_cont_tag,
         modulo_continuation_components,
     );
@@ -2094,7 +2094,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let numequal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_numequal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.num_equal.value(),
+        c.num_equal.value(),
         &g.binop_cont_tag,
         numequal_continuation_components,
     );
@@ -2104,7 +2104,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let equal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_equal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.equal.value(),
+        c.equal.value(),
         &g.binop_cont_tag,
         equal_continuation_components,
     );
@@ -2114,7 +2114,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let less_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_less_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.less.value(),
+        c.less.value(),
         &g.binop_cont_tag,
         less_continuation_components,
     );
@@ -2124,7 +2124,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let less_equal_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_less_equal_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.less_equal.value(),
+        c.less_equal.value(),
         &g.binop_cont_tag,
         less_equal_continuation_components,
     );
@@ -2134,7 +2134,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let greater_continuation_components: &[&dyn AsAllocatedHashComponents<F>; 4] =
         &[&[&g.op2_greater_tag, &g.default_num], env, &more, cont];
     hash_default_results.add_hash_input_clauses(
-        *c.greater.value(),
+        c.greater.value(),
         &g.binop_cont_tag,
         greater_continuation_components,
     );
@@ -2148,7 +2148,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         cont,
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.greater_equal.value(),
+        c.greater_equal.value(),
         &g.binop_cont_tag,
         greater_equal_continuation_components,
     );
@@ -2162,7 +2162,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &[&g.default_num, &g.default_num],
     ];
     hash_default_results.add_hash_input_clauses(
-        *c.if_.value(),
+        c.if_.value(),
         &g.if_cont_tag,
         if_continuation_components,
     );
@@ -2175,7 +2175,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &g.error_ptr_cont,
     )?;
     results.add_clauses_cons(
-        *c.current_env.value(),
+        c.current_env.value(),
         env,
         env,
         &the_cont_if_rest_is_nil,
@@ -2333,14 +2333,14 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         )?
     };
     results.add_clauses_cons(
-        *c.let_.value(),
+        c.let_.value(),
         &the_expr,
         env,
         &the_cont_letrec,
         &g.false_num,
     );
     results.add_clauses_cons(
-        *c.letrec.value(),
+        c.letrec.value(),
         &the_expr,
         env,
         &the_cont_letrec,
@@ -2357,7 +2357,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &newer_cont,
     )?;
     results.add_clauses_cons(
-        *c.cons.value(),
+        c.cons.value(),
         &arg1,
         env,
         &the_cont_cons_or_strcons,
@@ -2367,7 +2367,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == STRCONS, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.strcons.value(),
+        c.strcons.value(),
         &arg1,
         env,
         &the_cont_cons_or_strcons,
@@ -2382,7 +2382,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         cont,
         &newer_cont,
     )?;
-    results.add_clauses_cons(*c.begin.value(), &arg1, env, &cont_begin, &g.false_num);
+    results.add_clauses_cons(c.begin.value(), &arg1, env, &cont_begin, &g.false_num);
 
     // head == CAR, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
@@ -2394,7 +2394,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     )?;
 
     results.add_clauses_cons(
-        *c.car.value(),
+        c.car.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2404,7 +2404,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == CDR, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.cdr.value(),
+        c.cdr.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2419,12 +2419,12 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
         &g.error_ptr_cont,
         &newer_cont,
     )?;
-    results.add_clauses_cons(*c.hide.value(), &arg1, env, &the_cont_hide, &g.false_num);
+    results.add_clauses_cons(c.hide.value(), &arg1, env, &the_cont_hide, &g.false_num);
 
     // head == COMMIT, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.commit.value(),
+        c.commit.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2436,7 +2436,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     let the_cont_open_or_secret = &newer_cont_if_end_is_nil;
 
     results.add_clauses_cons(
-        *c.open.value(),
+        c.open.value(),
         &arg1_or_expr,
         env,
         the_cont_open_or_secret,
@@ -2447,7 +2447,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     /////////////////////////////////////////////////////////////////////////////
 
     results.add_clauses_cons(
-        *c.secret.value(),
+        c.secret.value(),
         &arg1_or_expr,
         env,
         the_cont_open_or_secret,
@@ -2457,7 +2457,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == NUM, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.num.value(),
+        c.num.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2467,7 +2467,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == U64, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.u64.value(),
+        c.u64.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2477,7 +2477,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == COMM, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.comm.value(),
+        c.comm.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2487,7 +2487,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == CHAR, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.char.value(),
+        c.char.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2496,12 +2496,12 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
     // head == EVAL, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.eval.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.eval.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == ATOM, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.atom.value(),
+        c.atom.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2511,7 +2511,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
     // head == EMIT, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.emit.value(),
+        c.emit.value(),
         &arg1_or_expr,
         env,
         &newer_cont_if_end_is_nil,
@@ -2520,48 +2520,48 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
     // head == +, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.sum.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.sum.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == -, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.diff.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.diff.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == *, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.product.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.product.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == /, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.quotient.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.quotient.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == %, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.modulo.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.modulo.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == =, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.num_equal.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.num_equal.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == EQ, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.equal.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.equal.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == <, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.less.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.less.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == <=, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.less_equal.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.less_equal.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == >, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.greater.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.greater.value(), &arg1, env, &newer_cont, &g.false_num);
 
     // head == >=, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
     results.add_clauses_cons(
-        *c.greater_equal.value(),
+        c.greater_equal.value(),
         &arg1,
         env,
         &newer_cont,
@@ -2570,7 +2570,7 @@ fn reduce_cons<F: LurkField, CS: ConstraintSystem<F>>(
 
     // head == IF, newer_cont is allocated
     /////////////////////////////////////////////////////////////////////////////
-    results.add_clauses_cons(*c.if_.value(), &arg1, env, &newer_cont, &g.false_num);
+    results.add_clauses_cons(c.if_.value(), &arg1, env, &newer_cont, &g.false_num);
 
     let is_zero_arg_call = rest_is_nil;
 
@@ -3746,8 +3746,8 @@ fn apply_continuation<F: LurkField, CS: ConstraintSystem<F>>(
         let args_equal_ptr = AllocatedPtr::pick_const(
             &mut cs.namespace(|| "args_equal_ptr"),
             &args_equal,
-            &c.t,
-            &c.nil,
+            &c.t.scalar_ptr(),
+            &c.nil.scalar_ptr(),
         )?;
 
         let not_dummy = cont.alloc_tag_equal(
@@ -4710,8 +4710,8 @@ pub fn comparison_helper<F: LurkField, CS: ConstraintSystem<F>>(
     let comp_val = AllocatedPtr::pick_const(
         &mut cs.namespace(|| "comp_val"),
         &comp_val_is_zero,
-        &c.nil,
-        &c.t,
+        &c.nil.scalar_ptr(),
+        &c.t.scalar_ptr(),
     )?;
 
     Ok((is_comparison_tag, comp_val, diff_is_negative))

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -436,7 +436,7 @@ fn reduce_with_witness_inner<F: LurkField>(
                 },
 
                 ExprTag::Sym => {
-                    if expr == store.lurk_sym("nil") || (expr == store.t()) {
+                    if expr == store.get_nil() || (expr == store.t()) {
                         // NIL and T are self-evaluating symbols, pass them to the continuation in a thunk.
                         // NOTE: For now, NIL is its own type, but this will change soon, so leave the check here.
 

--- a/src/hash_witness.rs
+++ b/src/hash_witness.rs
@@ -144,7 +144,7 @@ impl HashName for ContName {
 impl<F: LurkField> ConsStub<F> {
     pub fn car_cdr(
         &mut self,
-        s: &mut Store<F>,
+        s: &Store<F>,
         cons: &Ptr<F>,
     ) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         match self {
@@ -336,7 +336,7 @@ impl<F: LurkField> ConsWitness<F> {
     pub fn car_cdr_named(
         &mut self,
         name: ConsName,
-        store: &mut Store<F>,
+        store: &Store<F>,
         cons: &Ptr<F>,
     ) -> Result<(Ptr<F>, Ptr<F>), ReductionError> {
         if !matches!(cons.tag(), ExprTag::Cons | ExprTag::Nil) {
@@ -405,7 +405,7 @@ impl<F: LurkField> Cons<F> {
         (self.car, self.cdr)
     }
 
-    fn get_car_cdr(s: &mut Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
+    fn get_car_cdr(s: &Store<F>, cons: &Ptr<F>) -> Result<(Ptr<F>, Ptr<F>), store::Error> {
         s.car_cdr(cons)
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -2486,14 +2486,13 @@ impl<F: LurkField> Store<F> {
         self.dehydrated_cont.clear();
     }
 
-    fn ensure_constants(&mut self) -> &NamedConstants<F> {
-        self.constants.get_or_init(|| NamedConstants::new(self))
+    fn ensure_constants(&mut self) {
+        // This will clobber whatever was there before.
+        let _ = self.constants.set(NamedConstants::new(self));
     }
 
     pub fn get_constants(&self) -> &NamedConstants<F> {
-        self.constants
-            .get()
-            .expect("constants missing. hydrate_scalar_cache should have been called.")
+        self.constants.get_or_init(|| NamedConstants::new(self))
     }
 }
 
@@ -2569,14 +2568,15 @@ impl<F: LurkField> Expression<'_, F> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct ContantPtrs<F: LurkField>(Option<ScalarPtr<F>>, Ptr<F>);
+pub struct ConstantPtrs<F: LurkField>(Option<ScalarPtr<F>>, Ptr<F>);
 
-impl<F: LurkField> ContantPtrs<F> {
+impl<F: LurkField> ConstantPtrs<F> {
     pub fn value(&self) -> F {
         *self.scalar_ptr().value()
     }
     pub fn scalar_ptr(&self) -> ScalarPtr<F> {
-        self.0.expect("ScalarPtr missing")
+        self.0
+            .expect("ScalarPtr missing; hydrate_scalar_cache should have been called.")
     }
     pub fn ptr(&self) -> Ptr<F> {
         self.1
@@ -2585,53 +2585,54 @@ impl<F: LurkField> ContantPtrs<F> {
 
 #[derive(Clone, Copy, Debug)]
 pub struct NamedConstants<F: LurkField> {
-    pub t: ContantPtrs<F>,
-    pub nil: ContantPtrs<F>,
-    pub lambda: ContantPtrs<F>,
-    pub quote: ContantPtrs<F>,
-    pub let_: ContantPtrs<F>,
-    pub letrec: ContantPtrs<F>,
-    pub cons: ContantPtrs<F>,
-    pub strcons: ContantPtrs<F>,
-    pub begin: ContantPtrs<F>,
-    pub car: ContantPtrs<F>,
-    pub cdr: ContantPtrs<F>,
-    pub atom: ContantPtrs<F>,
-    pub emit: ContantPtrs<F>,
-    pub sum: ContantPtrs<F>,
-    pub diff: ContantPtrs<F>,
-    pub product: ContantPtrs<F>,
-    pub quotient: ContantPtrs<F>,
-    pub modulo: ContantPtrs<F>,
-    pub num_equal: ContantPtrs<F>,
-    pub equal: ContantPtrs<F>,
-    pub less: ContantPtrs<F>,
-    pub less_equal: ContantPtrs<F>,
-    pub greater: ContantPtrs<F>,
-    pub greater_equal: ContantPtrs<F>,
-    pub current_env: ContantPtrs<F>,
-    pub if_: ContantPtrs<F>,
-    pub hide: ContantPtrs<F>,
-    pub commit: ContantPtrs<F>,
-    pub num: ContantPtrs<F>,
-    pub u64: ContantPtrs<F>,
-    pub comm: ContantPtrs<F>,
-    pub char: ContantPtrs<F>,
-    pub eval: ContantPtrs<F>,
-    pub open: ContantPtrs<F>,
-    pub secret: ContantPtrs<F>,
+    pub t: ConstantPtrs<F>,
+    pub nil: ConstantPtrs<F>,
+    pub lambda: ConstantPtrs<F>,
+    pub quote: ConstantPtrs<F>,
+    pub let_: ConstantPtrs<F>,
+    pub letrec: ConstantPtrs<F>,
+    pub cons: ConstantPtrs<F>,
+    pub strcons: ConstantPtrs<F>,
+    pub begin: ConstantPtrs<F>,
+    pub car: ConstantPtrs<F>,
+    pub cdr: ConstantPtrs<F>,
+    pub atom: ConstantPtrs<F>,
+    pub emit: ConstantPtrs<F>,
+    pub sum: ConstantPtrs<F>,
+    pub diff: ConstantPtrs<F>,
+    pub product: ConstantPtrs<F>,
+    pub quotient: ConstantPtrs<F>,
+    pub modulo: ConstantPtrs<F>,
+    pub num_equal: ConstantPtrs<F>,
+    pub equal: ConstantPtrs<F>,
+    pub less: ConstantPtrs<F>,
+    pub less_equal: ConstantPtrs<F>,
+    pub greater: ConstantPtrs<F>,
+    pub greater_equal: ConstantPtrs<F>,
+    pub current_env: ConstantPtrs<F>,
+    pub if_: ConstantPtrs<F>,
+    pub hide: ConstantPtrs<F>,
+    pub commit: ConstantPtrs<F>,
+    pub num: ConstantPtrs<F>,
+    pub u64: ConstantPtrs<F>,
+    pub comm: ConstantPtrs<F>,
+    pub char: ConstantPtrs<F>,
+    pub eval: ConstantPtrs<F>,
+    pub open: ConstantPtrs<F>,
+    pub secret: ConstantPtrs<F>,
+    pub dummy: ConstantPtrs<F>,
 }
 
 impl<F: LurkField> NamedConstants<F> {
     pub fn new(store: &Store<F>) -> Self {
         let hash_sym = |name: &str| {
             let ptr = store.get_lurk_sym(name, true).unwrap();
-            let scalar_ptr = store.hash_sym(ptr, HashScalar::Get).unwrap();
-            ContantPtrs(Some(scalar_ptr), ptr)
+            let maybe_scalar_ptr = store.hash_sym(ptr, HashScalar::Get);
+            ConstantPtrs(maybe_scalar_ptr, ptr)
         };
 
         let t = hash_sym("t");
-        let nil = ContantPtrs(
+        let nil = ConstantPtrs(
             Some(store.hash_nil(HashScalar::Get).unwrap()),
             store.get_nil(),
         );
@@ -2668,6 +2669,7 @@ impl<F: LurkField> NamedConstants<F> {
         let eval = hash_sym("eval");
         let open = hash_sym("open");
         let secret = hash_sym("secret");
+        let dummy = hash_sym("_");
 
         Self {
             t,
@@ -2705,6 +2707,7 @@ impl<F: LurkField> NamedConstants<F> {
             eval,
             open,
             secret,
+            dummy,
         }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -2568,56 +2568,73 @@ impl<F: LurkField> Expression<'_, F> {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+pub struct ContantPtrs<F: LurkField>(Option<ScalarPtr<F>>, Ptr<F>);
+
+impl<F: LurkField> ContantPtrs<F> {
+    pub fn value(&self) -> F {
+        *self.scalar_ptr().value()
+    }
+    pub fn scalar_ptr(&self) -> ScalarPtr<F> {
+        self.0.expect("ScalarPtr missing")
+    }
+    pub fn ptr(&self) -> Ptr<F> {
+        self.1
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct NamedConstants<F: LurkField> {
-    pub t: ScalarPtr<F>,
-    pub nil: ScalarPtr<F>,
-    pub lambda: ScalarPtr<F>,
-    pub quote: ScalarPtr<F>,
-    pub let_: ScalarPtr<F>,
-    pub letrec: ScalarPtr<F>,
-    pub cons: ScalarPtr<F>,
-    pub strcons: ScalarPtr<F>,
-    pub begin: ScalarPtr<F>,
-    pub car: ScalarPtr<F>,
-    pub cdr: ScalarPtr<F>,
-    pub atom: ScalarPtr<F>,
-    pub emit: ScalarPtr<F>,
-    pub sum: ScalarPtr<F>,
-    pub diff: ScalarPtr<F>,
-    pub product: ScalarPtr<F>,
-    pub quotient: ScalarPtr<F>,
-    pub modulo: ScalarPtr<F>,
-    pub num_equal: ScalarPtr<F>,
-    pub equal: ScalarPtr<F>,
-    pub less: ScalarPtr<F>,
-    pub less_equal: ScalarPtr<F>,
-    pub greater: ScalarPtr<F>,
-    pub greater_equal: ScalarPtr<F>,
-    pub current_env: ScalarPtr<F>,
-    pub if_: ScalarPtr<F>,
-    pub hide: ScalarPtr<F>,
-    pub commit: ScalarPtr<F>,
-    pub num: ScalarPtr<F>,
-    pub u64: ScalarPtr<F>,
-    pub comm: ScalarPtr<F>,
-    pub char: ScalarPtr<F>,
-    pub eval: ScalarPtr<F>,
-    pub open: ScalarPtr<F>,
-    pub secret: ScalarPtr<F>,
+    pub t: ContantPtrs<F>,
+    pub nil: ContantPtrs<F>,
+    pub lambda: ContantPtrs<F>,
+    pub quote: ContantPtrs<F>,
+    pub let_: ContantPtrs<F>,
+    pub letrec: ContantPtrs<F>,
+    pub cons: ContantPtrs<F>,
+    pub strcons: ContantPtrs<F>,
+    pub begin: ContantPtrs<F>,
+    pub car: ContantPtrs<F>,
+    pub cdr: ContantPtrs<F>,
+    pub atom: ContantPtrs<F>,
+    pub emit: ContantPtrs<F>,
+    pub sum: ContantPtrs<F>,
+    pub diff: ContantPtrs<F>,
+    pub product: ContantPtrs<F>,
+    pub quotient: ContantPtrs<F>,
+    pub modulo: ContantPtrs<F>,
+    pub num_equal: ContantPtrs<F>,
+    pub equal: ContantPtrs<F>,
+    pub less: ContantPtrs<F>,
+    pub less_equal: ContantPtrs<F>,
+    pub greater: ContantPtrs<F>,
+    pub greater_equal: ContantPtrs<F>,
+    pub current_env: ContantPtrs<F>,
+    pub if_: ContantPtrs<F>,
+    pub hide: ContantPtrs<F>,
+    pub commit: ContantPtrs<F>,
+    pub num: ContantPtrs<F>,
+    pub u64: ContantPtrs<F>,
+    pub comm: ContantPtrs<F>,
+    pub char: ContantPtrs<F>,
+    pub eval: ContantPtrs<F>,
+    pub open: ContantPtrs<F>,
+    pub secret: ContantPtrs<F>,
 }
 
 impl<F: LurkField> NamedConstants<F> {
     pub fn new(store: &Store<F>) -> Self {
         let hash_sym = |name: &str| {
-            store
-                .get_lurk_sym(name, true)
-                .and_then(|s| store.hash_sym(s, HashScalar::Get))
-                .unwrap()
+            let ptr = store.get_lurk_sym(name, true).unwrap();
+            let scalar_ptr = store.hash_sym(ptr, HashScalar::Get).unwrap();
+            ContantPtrs(Some(scalar_ptr), ptr)
         };
 
         let t = hash_sym("t");
-        let nil = store.hash_nil(HashScalar::Get).unwrap();
+        let nil = ContantPtrs(
+            Some(store.hash_nil(HashScalar::Get).unwrap()),
+            store.get_nil(),
+        );
         let lambda = hash_sym("lambda");
         let quote = hash_sym("quote");
         let let_ = hash_sym("let");


### PR DESCRIPTION
This PR extends the `NamedConstants` in the `Store` to also hold `Ptr`s — and uses those during evaluation rather than constantly calling `Store::lurk_sym(…)`. These calls made evaluation become horribly slow when hierarchical symbols were introduced, because of a very bad and unperformant initial implementation. That performance should be improved when some of the LDON work lands. However, even if symbol interning becomes 'cheap', it's still an expensive operation to perform many times per reduction. This PR therefore fixes the root performance problem, which predated the symbol change.

See benchmark results below for an 11x speedup (-91% time).

```
Running benches/eval.rs (target/release/deps/eval-60f9add2215a78cb)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
go_base_10_16_bls12     time:   [6.9912 ms 6.9979 ms 7.0048 ms]                                
                        change: [-91.434% -91.420% -91.407%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

Benchmarking go_base_10_160_bls12: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.7s, or reduce sample count to 70.
go_base_10_160_bls12    time:   [66.837 ms 66.909 ms 66.995 ms]                                 
                        change: [-91.236% -91.215% -91.195%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

go_base_10_16_pasta_pallas                                                                            
                        time:   [6.8763 ms 6.8836 ms 6.8912 ms]
                        change: [-91.304% -91.289% -91.274%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking go_base_10_160_pasta_pallas: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.6s, or reduce sample count to 70.
go_base_10_160_pasta_pallas                                                                            
                        time:   [65.422 ms 65.482 ms 65.545 ms]
                        change: [-91.190% -91.176% -91.162%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

I then ran the benchmark on aea8116c, the commit preceding #180 (which introduced hierarchical symbols). As you can see, the older commit was 68% slower, so this is a strict improvement.


```
     Running benches/eval.rs (target/release/deps/eval-7dda34dad2478af3)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
go_base_10_16_bls12     time:   [11.389 ms 11.419 ms 11.457 ms]                                
                        change: [+62.724% +63.181% +63.802%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Benchmarking go_base_10_160_bls12: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.7s, or reduce sample count to 40.
go_base_10_160_bls12    time:   [106.88 ms 107.19 ms 107.57 ms]                                 
                        change: [+59.707% +60.198% +60.759%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

go_base_10_16_pasta_pallas                                                                            
                        time:   [11.781 ms 11.794 ms 11.808 ms]
                        change: [+71.079% +71.339% +71.597%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild

Benchmarking go_base_10_160_pasta_pallas: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 11.1s, or reduce sample count to 40.
go_base_10_160_pasta_pallas                                                                            
                        time:   [110.15 ms 110.30 ms 110.45 ms]
                        change: [+68.163% +68.436% +68.715%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```

For reference, the `go_base_10_160_pasta_pallas` test performs 10,618 iterations — so current performance (this PR) is ~163K iterations/second.