### PR TITLE
Add clutch crate with enhanced REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "anyhow",
  "blstrs",
  "fcomm",
+ "fil_pasta_curves",
  "lurk",
  "pretty_env_logger",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clutch"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blstrs",
+ "fcomm",
+ "lurk",
+ "pretty_env_logger",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
 dependencies = [
  "csv-core",
  "itoa",
@@ -687,9 +698,9 @@ checksum = "bd63582de2b59ea1aa48d7c1941b5d87618d95484397521b3acdfa0e1e9f5e45"
 
 [[package]]
 name = "ec-gpu-gen"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9bdd4dbcfe28dcea2fc10628f39d003f8399c5fbe06b36d9ee2f718b6eb82b"
+checksum = "fd09bf9d5313ad60379f70250590bccc10f7a04e2773062ac13255a37022584e"
 dependencies = [
  "bitvec",
  "crossbeam-channel",
@@ -1079,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
@@ -1116,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
@@ -1954,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -1968,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-fork"
@@ -1996,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -2027,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "3a382c72b4ba118526e187430bb4963cd6d55051ebf13d9b25574d379cc98d20"
 dependencies = [
  "serde_derive",
 ]
@@ -2064,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "1ef476a5790f0f6decbc66726b6e5d63680ed518283e64c7df415989d880954f"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
@@ -2075,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -2086,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
@@ -2317,18 +2328,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
@@ -2388,9 +2399,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ harness = false
 
 [workspace]
 members = [
-  "lurk_macro", "fcomm"
+  "lurk_macro", "fcomm", "clutch"
 ]
 
 [[bin]]

--- a/clutch/Cargo.toml
+++ b/clutch/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "clutch"
 version = "0.1.0"
+authors = ["porcuquine <porcuquine@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Lurk supertool"

--- a/clutch/Cargo.toml
+++ b/clutch/Cargo.toml
@@ -13,4 +13,5 @@ anyhow = "1.0.69"
 blstrs = "0.6.1"
 fcomm = { path = "../fcomm" }
 lurk = { path = "../" }
+pasta_curves = { version = "0.5.2", features = ["repr-c", "serde"], package = "fil_pasta_curves" }
 pretty_env_logger = "0.4"

--- a/clutch/Cargo.toml
+++ b/clutch/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "clutch"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Lurk supertool"
+repository = "https://github.com/lurk-lang/lurk-rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.69"
+blstrs = "0.6.1"
+fcomm = { path = "../fcomm" }
+lurk = { path = "../" }
+pretty_env_logger = "0.4"

--- a/clutch/README.md
+++ b/clutch/README.md
@@ -1,0 +1,13 @@
+# Lurk Clutch
+
+Clutch is a hatchery where nascent Lurk abstractions incubate. Clutch manages the friction point allowing seamless shifting
+of loosely-coupled gears.
+
+Clutch depends on both Lurk and fcomm. It provides a REPL that is a superset of `lurkrs`, and makes some of `fcomm`
+available from the REPL.
+
+In the future, it will likely also included expanded CLI features. It is expected that code will migrate between these
+(and other) crates as eventual structure is concretized.
+
+Ideally, the `clutch` binary will eventually converge on being the most useful tool for using Lurk. Along the way, it
+should be viewed as a fast-moving prototype where ideas can be implemented and evolve quickly.

--- a/clutch/bin/clutch
+++ b/clutch/bin/clutch
@@ -1,0 +1,1 @@
+cargo run --release -- $@

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -72,7 +72,7 @@ impl ReplTrait<F> for ClutchState<F> {
 
                                 let path =
                                     if let Expression::Str(p) = store.fetch(&proof_path).unwrap() {
-                                        format!("{}", p)
+                                        p.to_string()
                                     } else {
                                         panic!("proof path must be a string");
                                     };
@@ -101,7 +101,7 @@ impl ReplTrait<F> for ClutchState<F> {
 
                                 let path =
                                     if let Expression::Str(p) = store.fetch(&proof_path).unwrap() {
-                                        format!("{}", p)
+                                        p.to_string()
                                     } else {
                                         panic!("proof path must be a string");
                                     };

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -1,7 +1,58 @@
 use anyhow::Result;
-use lurk::field::LanguageField;
+use lurk::field::{LanguageField, LurkField};
+use lurk::package::Package;
 use lurk::proof::nova;
-use lurk::repl::repl;
+use lurk::repl::{repl, ReplState, ReplTrait};
+use lurk::store::{Ptr, Store};
+use std::path::{Path, PathBuf};
+
+struct ClutchState<F: LurkField>(ReplState<F>);
+
+impl<F: LurkField> ReplTrait<F> for ClutchState<F> {
+    fn new(s: &mut Store<F>, limit: usize) -> Self {
+        Self(ReplState::new(s, limit))
+    }
+
+    fn handle_run<P: AsRef<Path> + Copy>(
+        &mut self,
+        store: &mut Store<F>,
+        file_path: P,
+        package: &Package,
+    ) -> Result<()> {
+        self.0.handle_run(store, file_path, package)
+    }
+
+    /// Returns two bools.
+    /// First bool is true if input is a command.
+    /// Second bool is true if processing should continue.
+    fn maybe_handle_command(
+        &mut self,
+        store: &mut Store<F>,
+        line: &str,
+        package: &Package,
+    ) -> Result<(bool, bool)> {
+        self.0.maybe_handle_command(store, line, package)
+    }
+
+    fn handle_meta<P: AsRef<Path> + Copy>(
+        &mut self,
+        store: &mut Store<F>,
+        expr_ptr: Ptr<F>,
+        package: &Package,
+        p: P,
+    ) -> Result<()> {
+        self.0.handle_meta(store, expr_ptr, package, p)
+    }
+
+    fn handle_non_meta(
+        &mut self,
+        store: &mut Store<F>,
+        expr_ptr: Ptr<F>,
+        update_env: bool,
+    ) -> Result<()> {
+        self.0.handle_non_meta(store, expr_ptr, update_env)
+    }
+}
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -27,8 +78,10 @@ fn main() -> Result<()> {
     };
 
     match field {
-        LanguageField::BLS12_381 => repl::<_, blstrs::Scalar>(lurk_file.as_deref()),
-        LanguageField::Pallas => repl::<_, nova::S1>(lurk_file.as_deref()),
-        LanguageField::Vesta => repl::<_, nova::S2>(lurk_file.as_deref()),
+        LanguageField::BLS12_381 => {
+            repl::<_, blstrs::Scalar, ClutchState<blstrs::Scalar>>(lurk_file.as_deref())
+        }
+        LanguageField::Pallas => repl::<_, nova::S1, ClutchState<nova::S1>>(lurk_file.as_deref()),
+        LanguageField::Vesta => repl::<_, nova::S2, ClutchState<nova::S2>>(lurk_file.as_deref()),
     }
 }

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use lurk::field::LanguageField;
+use lurk::proof::nova;
+use lurk::repl::repl;
+
+fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    // If an argument is passed, treat is as a Lurk file to run.
+    let mut args = std::env::args();
+    let lurk_file = if args.len() > 1 {
+        Some(args.nth(1).expect("Lurk file missing"))
+    } else {
+        None
+    };
+
+    let default_field = LanguageField::Pallas;
+    let field = if let Ok(lurk_field) = std::env::var("LURK_FIELD") {
+        match lurk_field.as_str() {
+            "BLS12-381" => LanguageField::BLS12_381,
+            "PALLAS" => LanguageField::Pallas,
+            "VESTA" => LanguageField::Vesta,
+            _ => default_field,
+        }
+    } else {
+        default_field
+    };
+
+    match field {
+        LanguageField::BLS12_381 => repl::<_, blstrs::Scalar>(lurk_file.as_deref()),
+        LanguageField::Pallas => repl::<_, nova::S1>(lurk_file.as_deref()),
+        LanguageField::Vesta => repl::<_, nova::S2>(lurk_file.as_deref()),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use lurk::field::LanguageField;
 use lurk::proof::nova;
-use lurk::repl::repl;
+use lurk::repl::{repl, ReplState};
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -27,8 +27,10 @@ fn main() -> Result<()> {
     };
 
     match field {
-        LanguageField::BLS12_381 => repl::<_, blstrs::Scalar>(lurk_file.as_deref()),
-        LanguageField::Pallas => repl::<_, nova::S1>(lurk_file.as_deref()),
-        LanguageField::Vesta => repl::<_, nova::S2>(lurk_file.as_deref()),
+        LanguageField::BLS12_381 => {
+            repl::<_, blstrs::Scalar, ReplState<blstrs::Scalar>>(lurk_file.as_deref())
+        }
+        LanguageField::Pallas => repl::<_, nova::S1, ReplState<nova::S1>>(lurk_file.as_deref()),
+        LanguageField::Vesta => repl::<_, nova::S2, ReplState<nova::S2>>(lurk_file.as_deref()),
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -41,6 +41,42 @@ pub struct Repl<F: LurkField, T: ReplTrait<F>> {
     _phantom: F,
 }
 
+pub trait ReplTrait<F: LurkField> {
+    fn new(s: &mut Store<F>, limit: usize) -> Self;
+
+    fn handle_run<P: AsRef<Path> + Copy>(
+        &mut self,
+        store: &mut Store<F>,
+        file_path: P,
+        package: &Package,
+    ) -> Result<()>;
+
+    /// Returns two bools.
+    /// First bool is true if input is a command.
+    /// Second bool is true if processing should continue.
+    fn maybe_handle_command(
+        &mut self,
+        store: &mut Store<F>,
+        line: &str,
+        package: &Package,
+    ) -> Result<(bool, bool)>;
+
+    fn handle_meta<P: AsRef<Path> + Copy>(
+        &mut self,
+        store: &mut Store<F>,
+        expr_ptr: Ptr<F>,
+        package: &Package,
+        p: P,
+    ) -> Result<()>;
+
+    fn handle_non_meta(
+        &mut self,
+        store: &mut Store<F>,
+        expr_ptr: Ptr<F>,
+        update_env: bool,
+    ) -> Result<()>;
+}
+
 impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
     pub fn new(s: &mut Store<F>, limit: usize) -> Result<Self> {
         let history_path = dirs::home_dir()
@@ -186,9 +222,6 @@ impl<F: LurkField> ReplState<F> {
         (result, iterations, next_cont, emitted)
     }
 
-    /// Returns two bools.
-    /// First bool is true if input is a command.
-    /// Second bool is true if processing should continue.
     pub fn maybe_handle_command(
         &mut self,
         store: &mut Store<F>,
@@ -315,42 +348,6 @@ impl<F: LurkField> ReplState<F> {
             self.handle_non_meta(store, ptr, update_env)
         }
     }
-}
-
-pub trait ReplTrait<F: LurkField> {
-    fn new(s: &mut Store<F>, limit: usize) -> Self;
-
-    fn handle_run<P: AsRef<Path> + Copy>(
-        &mut self,
-        store: &mut Store<F>,
-        file_path: P,
-        package: &Package,
-    ) -> Result<()>;
-
-    /// Returns two bools.
-    /// First bool is true if input is a command.
-    /// Second bool is true if processing should continue.
-    fn maybe_handle_command(
-        &mut self,
-        store: &mut Store<F>,
-        line: &str,
-        package: &Package,
-    ) -> Result<(bool, bool)>;
-
-    fn handle_meta<P: AsRef<Path> + Copy>(
-        &mut self,
-        store: &mut Store<F>,
-        expr_ptr: Ptr<F>,
-        package: &Package,
-        p: P,
-    ) -> Result<()>;
-
-    fn handle_non_meta(
-        &mut self,
-        store: &mut Store<F>,
-        expr_ptr: Ptr<F>,
-        update_env: bool,
-    ) -> Result<()>;
 }
 
 impl<F: LurkField> ReplTrait<F> for ReplState<F> {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -30,8 +30,8 @@ impl Validator for InputValidator {
 
 #[derive(Clone)]
 pub struct ReplState<F: LurkField> {
-    env: Ptr<F>,
-    limit: usize,
+    pub env: Ptr<F>,
+    pub limit: usize,
 }
 
 pub struct Repl<F: LurkField, T: ReplTrait<F>> {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -34,13 +34,14 @@ pub struct ReplState<F: LurkField> {
     limit: usize,
 }
 
-pub struct Repl<F: LurkField> {
-    state: ReplState<F>,
+pub struct Repl<F: LurkField, T: ReplTrait<F>> {
+    state: T,
     rl: Editor<InputValidator>,
     history_path: PathBuf,
+    _phantom: F,
 }
 
-impl<F: LurkField> Repl<F> {
+impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
     pub fn new(s: &mut Store<F>, limit: usize) -> Result<Self> {
         let history_path = dirs::home_dir()
             .expect("missing home directory")
@@ -59,11 +60,12 @@ impl<F: LurkField> Repl<F> {
             rl.load_history(&history_path)?;
         }
 
-        let state = ReplState::new(s, limit);
+        let state = T::new(s, limit);
         Ok(Self {
             state,
             rl,
             history_path,
+            _phantom: Default::default(),
         })
     }
     pub fn save_history(&mut self) -> Result<()> {
@@ -72,20 +74,29 @@ impl<F: LurkField> Repl<F> {
     }
 }
 
+pub fn repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(lurk_file: Option<P>) -> Result<()> {
+    let s = &mut Store::<F>::default();
+    let limit = 100_000_000;
+    let repl: Repl<F, T> = Repl::new(s, limit)?;
+
+    run_repl(s, repl, lurk_file)
+}
+
 // For the moment, input must be on a single line.
-pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
+pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
+    s: &mut Store<F>,
+    mut repl: Repl<F, T>,
+    lurk_file: Option<P>,
+) -> Result<()> {
+    let package = Package::lurk();
+
     if lurk_file.is_none() {
         println!("Lurk REPL welcomes you.");
     }
 
-    let mut s = Store::<F>::default();
-    let limit = 100_000_000;
-    let mut repl = Repl::new(&mut s, limit)?;
-    let package = Package::lurk();
-
     {
         if let Some(lurk_file) = lurk_file {
-            repl.state.handle_run(&mut s, &lurk_file, &package).unwrap();
+            repl.state.handle_run(s, &lurk_file, &package).unwrap();
             return Ok(());
         }
     }
@@ -97,7 +108,7 @@ pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
             Ok(line) => {
                 repl.save_history()?;
 
-                let result = repl.state.maybe_handle_command(&mut s, &line, &package);
+                let result = repl.state.maybe_handle_command(s, &line, &package);
 
                 match result {
                     Ok((handled_command, should_continue)) if handled_command => {
@@ -119,9 +130,9 @@ pub fn repl<P: AsRef<Path>, F: LurkField>(lurk_file: Option<P>) -> Result<()> {
                 match s.read_maybe_meta(&mut chars, &package) {
                     Ok((expr, is_meta)) => {
                         if is_meta {
-                            repl.state.handle_meta(&mut s, expr, &package, p)?
+                            repl.state.handle_meta(s, expr, &package, p)?
                         } else {
-                            let _ = repl.state.handle_non_meta(&mut s, expr, false);
+                            let _ = repl.state.handle_non_meta(s, expr, false);
 
                             continue;
                         }
@@ -251,16 +262,6 @@ impl<F: LurkField> ReplState<F> {
         self.handle_file(store, file_path.as_ref(), package, true)
     }
 
-    pub fn handle_run<P: AsRef<Path> + Copy>(
-        &mut self,
-        store: &mut Store<F>,
-        file_path: P,
-        package: &Package,
-    ) -> Result<()> {
-        println!("Running from {}.", file_path.as_ref().to_str().unwrap());
-        self.handle_file(store, file_path, package, false)
-    }
-
     pub fn handle_file<P: AsRef<Path> + Copy>(
         &mut self,
         store: &mut Store<F>,
@@ -314,51 +315,123 @@ impl<F: LurkField> ReplState<F> {
             self.handle_non_meta(store, ptr, update_env)
         }
     }
+}
+
+pub trait ReplTrait<F: LurkField> {
+    fn new(s: &mut Store<F>, limit: usize) -> Self;
+
+    fn handle_run<P: AsRef<Path> + Copy>(
+        &mut self,
+        store: &mut Store<F>,
+        file_path: P,
+        package: &Package,
+    ) -> Result<()>;
+
+    /// Returns two bools.
+    /// First bool is true if input is a command.
+    /// Second bool is true if processing should continue.
+    fn maybe_handle_command(
+        &mut self,
+        store: &mut Store<F>,
+        line: &str,
+        package: &Package,
+    ) -> Result<(bool, bool)>;
+
+    fn handle_meta<P: AsRef<Path> + Copy>(
+        &mut self,
+        store: &mut Store<F>,
+        expr_ptr: Ptr<F>,
+        package: &Package,
+        p: P,
+    ) -> Result<()>;
 
     fn handle_non_meta(
         &mut self,
         store: &mut Store<F>,
         expr_ptr: Ptr<F>,
         update_env: bool,
-    ) -> Result<()> {
-        match Evaluator::new(expr_ptr, self.env, store, self.limit).eval() {
-            Ok((
-                IO {
-                    expr: result,
-                    env: _env,
-                    cont: next_cont,
-                },
-                iterations,
-                _emitted,
-            )) => {
-                if !update_env {
-                    print!("[{iterations} iterations] => ");
-                }
+    ) -> Result<()>;
+}
 
-                match next_cont.tag() {
-                    ContTag::Outermost | ContTag::Terminal => {
-                        let mut handle = io::stdout().lock();
-
-                        // We are either loading/running and update the env, or evaluating and don't.
-                        if update_env {
-                            self.env = result
-                        } else {
-                            result.fmt(store, &mut handle)?;
-
-                            println!();
-                        }
-                    }
-                    ContTag::Error => println!("ERROR!"),
-                    _ => println!("Computation incomplete after limit: {}", self.limit),
-                }
-
-                Ok(())
-            }
-            Err(e) => {
-                println!("Evaluation error: {e:?}");
-                Err(e.into())
-            }
+impl<F: LurkField> ReplTrait<F> for ReplState<F> {
+    fn new(s: &mut Store<F>, limit: usize) -> Self {
+        Self {
+            env: empty_sym_env(s),
+            limit,
         }
+    }
+
+    fn handle_run<P: AsRef<Path> + Copy>(
+        &mut self,
+        store: &mut Store<F>,
+        file_path: P,
+        package: &Package,
+    ) -> Result<()> {
+        println!("Running from {}.", file_path.as_ref().to_str().unwrap());
+        self.handle_file(store, file_path, package, false)
+    }
+
+    fn maybe_handle_command(
+        &mut self,
+        store: &mut Store<F>,
+        line: &str,
+        package: &Package,
+    ) -> Result<(bool, bool)> {
+        let mut chars = line.chars().peekmore();
+        let maybe_command = store.read_next(&mut chars, package);
+
+        let result = match &maybe_command {
+            Ok(maybe_command) => match maybe_command.tag() {
+                ExprTag::Sym => {
+                    if let Some(key_string) = store
+                        .fetch(maybe_command)
+                        .unwrap()
+                        .as_simple_keyword_string()
+                    {
+                        match key_string.as_str() {
+                            "QUIT" => (true, false),
+                            "LOAD" => match store.read_string(&mut chars) {
+                                Ok(s) => match s.tag() {
+                                    ExprTag::Str => {
+                                        let file_path = store.fetch(&s).unwrap();
+                                        let file_path = PathBuf::from(file_path.as_str().unwrap());
+                                        self.handle_load(store, file_path, package)?;
+                                        (true, true)
+                                    }
+                                    other => {
+                                        anyhow::bail!("No valid path found: {:?}", other);
+                                    }
+                                },
+                                Err(_) => {
+                                    anyhow::bail!("No path found");
+                                }
+                            },
+                            "RUN" => {
+                                if let Ok(s) = store.read_string(&mut chars) {
+                                    if s.tag() == ExprTag::Str {
+                                        let file_path = store.fetch(&s).unwrap();
+                                        let file_path = PathBuf::from(file_path.as_str().unwrap());
+                                        self.handle_run(store, &file_path, package)?;
+                                    }
+                                }
+                                (true, true)
+                            }
+                            "CLEAR" => {
+                                self.env = empty_sym_env(store);
+                                (true, true)
+                            }
+                            _ => (true, true),
+                        }
+                    } else {
+                        (false, true)
+                    }
+                }
+                _ => (false, true),
+            },
+            _ => (false, true),
+        };
+
+        Ok(result)
     }
 
     fn handle_meta<P: AsRef<Path> + Copy>(
@@ -535,5 +608,51 @@ impl<F: LurkField> ReplState<F> {
             println!();
         };
         Ok(())
+    }
+
+    fn handle_non_meta(
+        &mut self,
+        store: &mut Store<F>,
+        expr_ptr: Ptr<F>,
+        update_env: bool,
+    ) -> Result<()> {
+        match Evaluator::new(expr_ptr, self.env, store, self.limit).eval() {
+            Ok((
+                IO {
+                    expr: result,
+                    env: _env,
+                    cont: next_cont,
+                },
+                iterations,
+                _emitted,
+            )) => {
+                if !update_env {
+                    print!("[{iterations} iterations] => ");
+                }
+
+                match next_cont.tag() {
+                    ContTag::Outermost | ContTag::Terminal => {
+                        let mut handle = io::stdout().lock();
+
+                        // We are either loading/running and update the env, or evaluating and don't.
+                        if update_env {
+                            self.env = result
+                        } else {
+                            result.fmt(store, &mut handle)?;
+
+                            println!();
+                        }
+                    }
+                    ContTag::Error => println!("ERROR!"),
+                    _ => println!("Computation incomplete after limit: {}", self.limit),
+                }
+
+                Ok(())
+            }
+            Err(e) => {
+                println!("Evaluation error: {e:?}");
+                Err(e.into())
+            }
+        }
     }
 }

--- a/tests/lurk-tests.rs
+++ b/tests/lurk-tests.rs
@@ -1,4 +1,7 @@
-use lurk::{proof, repl::repl};
+use lurk::{
+    proof::nova,
+    repl::{repl, ReplState},
+};
 use std::path::Path;
 
 #[test]
@@ -17,6 +20,6 @@ fn lurk_tests() {
     for f in test_files {
         let joined = example_dir.join(f);
 
-        repl::<_, proof::nova::S1>(Some(joined)).unwrap();
+        repl::<_, nova::S1, ReplState<nova::S1>>(Some(joined)).unwrap();
     }
 }


### PR DESCRIPTION
This PR ~adds REPL env state manipulation commands. It also~ adds the clutch crate with minimal support for proving and verifying from the REPL. The immediate purpose of clutch is to support near-term demos that will benefit from a more featurefull REPL. Longer term, it will be used to integrate functional commitments, proofs, and meta-Lurk development without committing the core language to experimental prototypes. Some features are expected to migrate back into the `lurk` or `fcomm` crates once well understood.