### PR TITLE
CI: generate rustdoc + benches

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,37 @@
+name: Benchmarking
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+   benchmark:
+     name: Continuous benchmarking
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v3
+       - name: Get old benchmarks
+         uses: actions/checkout@v3
+         with:
+           ref: gh-pages
+           path: gh-pages
+       - run: mkdir -p target; cp -r gh-pages/benchmarks/criterion target;
+       - name: Install criterion
+         run: cargo install cargo-criterion
+       - name: Run benchmarks
+         run: cargo criterion --message-format=json > ${{ github.sha }}.json
+       - name: Deploy latest benchmark report
+         uses: peaceiris/actions-gh-pages@v3
+         with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           publish_dir: ./target/criterion
+           destination_dir: benchmarks/criterion
+       - name: Move benchmark json to history
+         run: mkdir history; cp ${{ github.sha }}.json history/
+       - name: Deploy benchmark history
+         uses: peaceiris/actions-gh-pages@v3
+         with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           publish_dir: history/
+           destination_dir: benchmarks/history
+           keep_files: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+jobs:
+  docs:
+    name: Generate crate documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Generate documentation
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
+        with:
+          command: doc
+          args: --workspace --no-deps
+
+      - name: Deploy documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          destination_dir: docs


### PR DESCRIPTION
This introduces two jobs using [GitHub Actions](https://github.com/features/actions):
- the docs job, which publishes the Rustdoc of our crate on the go-pages branch to be published with [Github pages](https://pages.github.com/). [Example of a CI run on my fork](https://www.garillot.net/lurk-rs/docs/). The job is triggered on master pushes or manually. [^1]
- the benchmarks job, which runs the criterion bench on a GitHub machine (yes, this sucks: I plan to make better with self-hosted runners), and maintains a historical log of those benchmarks. [Example of a CI run on my fork](https://www.garillot.net/lurk-rs/benchmarks/criterion/reports/). The job is triggered by GH releases or manually. [^2]

[^1]: expected URL of the eventual output (once merged and triggered) https://lurk-lang.github.io/lurk-rs/docs
[^2]: expected URL of the eventual output (once merged and triggered) https://lurk-lang.github.io/lurk-rs/benchmarks/criterion/reports/