### PR TITLE
General commitments

### DIFF
--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -74,12 +74,10 @@ impl ReplTrait<F> for ClutchState<F> {
                                 let (expr, secret) = if rest.is_nil() {
                                     // TODO: also support Commitment::from_ptr_with_hiding (randomized secret at runtime).
                                     (first, F::zero())
+                                } else if let Expression::Num(n) = store.fetch(&second).unwrap() {
+                                    (first, n.into_scalar())
                                 } else {
-                                    if let Expression::Num(n) = store.fetch(&second).unwrap() {
-                                        (first, n.into_scalar())
-                                    } else {
-                                        panic!("secret not a Num")
-                                    }
+                                    panic!("secret not a Num")
                                 };
 
                                 let commitment =

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -30,6 +30,10 @@ impl ReplTrait<F> for ClutchState<F> {
         "Lurk Clutch".into()
     }
 
+    fn prompt(&self) -> String {
+        "!> ".into()
+    }
+
     fn handle_run<P: AsRef<Path> + Copy>(
         &mut self,
         store: &mut Store<F>,
@@ -81,7 +85,7 @@ impl ReplTrait<F> for ClutchState<F> {
                                 } else if let Expression::Num(n) = store.fetch(&second).unwrap() {
                                     (first, n.into_scalar())
                                 } else {
-                                    println!("Secret must be a Num");
+                                    eprintln!("Secret must be a Num");
                                     return Ok(());
                                 };
 
@@ -115,7 +119,7 @@ impl ReplTrait<F> for ClutchState<F> {
                                         Some(store.intern_maybe_opaque_comm(scalar))
                                     }
                                     _ => {
-                                        println!("not a commitment");
+                                        eprintln!("not a commitment");
                                         None
                                     }
                                 };
@@ -139,7 +143,7 @@ impl ReplTrait<F> for ClutchState<F> {
                                     if let Expression::Str(p) = store.fetch(&proof_path).unwrap() {
                                         p.to_string()
                                     } else {
-                                        println!("Proof path must be a string");
+                                        eprintln!("Proof path must be a string");
                                         return Ok(());
                                     };
 
@@ -169,7 +173,7 @@ impl ReplTrait<F> for ClutchState<F> {
                                     if let Expression::Str(p) = store.fetch(&proof_path).unwrap() {
                                         p.to_string()
                                     } else {
-                                        println!("Proof path must be a string");
+                                        eprintln!("Proof path must be a string");
                                         return Ok(());
                                     };
 

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -26,6 +26,10 @@ impl ReplTrait<F> for ClutchState<F> {
         Self(ReplState::new(s, limit))
     }
 
+    fn name() -> String {
+        "Lurk Clutch".into()
+    }
+
     fn handle_run<P: AsRef<Path> + Copy>(
         &mut self,
         store: &mut Store<F>,

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use pasta_curves::pallas;
 
 use fcomm::{Commitment, CommittedExpression, FileStore, LurkPtr, Proof};
@@ -85,8 +85,7 @@ impl ReplTrait<F> for ClutchState<F> {
                                 } else if let Expression::Num(n) = store.fetch(&second).unwrap() {
                                     (first, n.into_scalar())
                                 } else {
-                                    eprintln!("Secret must be a Num");
-                                    return Ok(());
+                                    bail!("Secret must be a Num")
                                 };
 
                                 let commitment =
@@ -119,8 +118,7 @@ impl ReplTrait<F> for ClutchState<F> {
                                         Some(store.intern_maybe_opaque_comm(scalar))
                                     }
                                     _ => {
-                                        eprintln!("not a commitment");
-                                        None
+                                        bail!("not a commitment");
                                     }
                                 };
 
@@ -143,8 +141,7 @@ impl ReplTrait<F> for ClutchState<F> {
                                     if let Expression::Str(p) = store.fetch(&proof_path).unwrap() {
                                         p.to_string()
                                     } else {
-                                        eprintln!("Proof path must be a string");
-                                        return Ok(());
+                                        bail!("Proof path must be a string");
                                     };
 
                                 let chunk_frame_count = 1;
@@ -173,8 +170,7 @@ impl ReplTrait<F> for ClutchState<F> {
                                     if let Expression::Str(p) = store.fetch(&proof_path).unwrap() {
                                         p.to_string()
                                     } else {
-                                        eprintln!("Proof path must be a string");
-                                        return Ok(());
+                                        bail!("Proof path must be a string");
                                     };
 
                                 let proof = Proof::read_from_path(path).unwrap();

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -77,7 +77,8 @@ impl ReplTrait<F> for ClutchState<F> {
                                 } else if let Expression::Num(n) = store.fetch(&second).unwrap() {
                                     (first, n.into_scalar())
                                 } else {
-                                    panic!("secret not a Num")
+                                    println!("Secret must be a Num");
+                                    return Ok(());
                                 };
 
                                 let commitment =
@@ -134,7 +135,8 @@ impl ReplTrait<F> for ClutchState<F> {
                                     if let Expression::Str(p) = store.fetch(&proof_path).unwrap() {
                                         p.to_string()
                                     } else {
-                                        panic!("proof path must be a string");
+                                        println!("Proof path must be a string");
+                                        return Ok(());
                                     };
 
                                 let chunk_frame_count = 1;
@@ -163,7 +165,8 @@ impl ReplTrait<F> for ClutchState<F> {
                                     if let Expression::Str(p) = store.fetch(&proof_path).unwrap() {
                                         p.to_string()
                                     } else {
-                                        panic!("proof path must be a string");
+                                        println!("Proof path must be a string");
+                                        return Ok(());
                                     };
 
                                 let proof = Proof::read_from_path(path).unwrap();

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -18,9 +18,9 @@ use clap::{AppSettings, Args, Parser, Subcommand};
 use clap_verbosity_flag::{Verbosity, WarnLevel};
 
 use fcomm::{
-    self, committed_function_store, error::Error, evaluate, public_params, Claim, Commitment,
-    Evaluation, Expression, FileStore, Function, LurkPtr, Opening, OpeningRequest, Proof,
-    ReductionCount, S1,
+    self, committed_expression_store, error::Error, evaluate, public_params, Claim, Commitment,
+    CommittedExpression, Evaluation, Expression, FileStore, LurkPtr, Opening, OpeningRequest,
+    Proof, ReductionCount, S1,
 };
 
 /// Functional commitments
@@ -174,16 +174,16 @@ impl Commit {
             let path = env::current_dir().unwrap().join(&self.function);
             let src = read_to_string(path).unwrap();
 
-            Function {
-                fun: LurkPtr::Source(src),
+            CommittedExpression {
+                expr: LurkPtr::Source(src),
                 secret: None,
                 commitment: None,
             }
         } else {
-            Function::read_from_path(&self.function).unwrap()
+            CommittedExpression::read_from_path(&self.function).unwrap()
         };
         let fun_ptr = function.fun_ptr(s, limit).unwrap();
-        let function_map = committed_function_store();
+        let function_map = committed_expression_store();
 
         let commitment = if let Some(secret) = function.secret {
             let commitment = Commitment::from_ptr_and_secret(s, &fun_ptr, secret);
@@ -224,7 +224,7 @@ impl Open {
         let rc = ReductionCount::try_from(self.reduction_count).unwrap();
         let prover = NovaProver::<S1>::new(rc.count());
         let pp = public_params(rc.count());
-        let function_map = committed_function_store();
+        let function_map = committed_expression_store();
 
         let handle_proof = |out_path, proof: Proof<S1>| {
             proof.write_to_path(out_path);
@@ -265,13 +265,13 @@ impl Open {
                 if self.lurk {
                     let path = env::current_dir().unwrap().join(function_path);
                     let src = read_to_string(path).unwrap();
-                    Function {
-                        fun: LurkPtr::Source(src),
+                    CommittedExpression {
+                        expr: LurkPtr::Source(src),
                         secret: None,
                         commitment: None,
                     }
                 } else {
-                    Function::read_from_path(function_path).unwrap()
+                    CommittedExpression::read_from_path(function_path).unwrap()
                 }
             };
 

--- a/fcomm/src/bin/fcomm.rs
+++ b/fcomm/src/bin/fcomm.rs
@@ -182,7 +182,7 @@ impl Commit {
         } else {
             CommittedExpression::read_from_path(&self.function).unwrap()
         };
-        let fun_ptr = function.fun_ptr(s, limit).unwrap();
+        let fun_ptr = function.expr_ptr(s, limit).unwrap();
         let function_map = committed_expression_store();
 
         let commitment = if let Some(secret) = function.secret {

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -464,7 +464,7 @@ impl<F: LurkField + Serialize + DeserializeOwned> Commitment<F> {
         input: Ptr<F>,
         limit: usize,
     ) -> Result<(Self, Ptr<F>), Error> {
-        let fun_ptr = function.fun_ptr(s, limit)?;
+        let fun_ptr = function.expr_ptr(s, limit)?;
         let secret = function.secret.expect("CommittedExpression secret missing");
 
         let commitment = Self::from_ptr_and_secret(s, &fun_ptr, secret);
@@ -494,7 +494,7 @@ impl<F: LurkField + Serialize + DeserializeOwned> Commitment<F> {
 }
 
 impl<F: LurkField + Serialize + DeserializeOwned> CommittedExpression<F> {
-    pub fn fun_ptr(&self, s: &mut Store<F>, limit: usize) -> Result<Ptr<F>, Error> {
+    pub fn expr_ptr(&self, s: &mut Store<F>, limit: usize) -> Result<Ptr<F>, Error> {
         let source_ptr = self.expr.ptr(s);
 
         // Evaluate the source to get an actual function.

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -634,8 +634,6 @@ impl<'a> Opening<S1> {
         limit: usize,
         chain: bool,
     ) -> Result<Claim<S1>, Error> {
-        let function_map = committed_expression_store();
-
         let (commitment, expression) =
             Commitment::construct_with_fun_application(s, function, input, limit)?;
         let (public_output, _iterations) = evaluate(s, expression, limit)?;
@@ -686,6 +684,7 @@ impl<'a> Opening<S1> {
                 commitment: Some(new_commitment),
             };
 
+            let function_map = committed_expression_store();
             function_map.set(new_commitment, &new_function)?;
 
             (Some(new_commitment), result_expr)

--- a/fcomm/tests/proof_tests.rs
+++ b/fcomm/tests/proof_tests.rs
@@ -8,7 +8,7 @@ use tempdir::TempDir;
 
 use pasta_curves::pallas;
 
-use fcomm::{Commitment, FileStore, Function, LurkPtr, Proof};
+use fcomm::{Commitment, CommittedExpression, FileStore, LurkPtr, Proof};
 use lurk::store::Store;
 
 pub type S1 = pallas::Scalar;
@@ -180,8 +180,8 @@ fn test_aux(
     chained: bool,
     tmp_dir: TempDir,
 ) {
-    let function = Function::<S1> {
-        fun: LurkPtr::Source(function_source.into()),
+    let function = CommittedExpression::<S1> {
+        expr: LurkPtr::Source(function_source.into()),
         secret: None,
         commitment: None,
     };
@@ -190,7 +190,7 @@ fn test_aux(
 }
 
 fn test_function_aux(
-    function: Function<S1>,
+    function: CommittedExpression<S1>,
     expected_io: Vec<(&str, &str)>,
     chained: bool,
     tmp_dir: TempDir,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use crate::eval::IO;
+use crate::field::LurkField;
 use crate::hash_witness::ConsName;
 use crate::store;
 
@@ -35,4 +37,15 @@ pub enum ReductionError {
     Misc(String),
     #[error("Lookup error: {0}")]
     Store(#[from] store::Error),
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum LurkError<F: LurkField> {
+    IO(IO<F>),
+}
+
+impl<F: LurkField> std::fmt::Display for LurkError<F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self)
+    }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -171,9 +171,14 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
                 match s.read_maybe_meta(&mut chars, &package) {
                     Ok((expr, is_meta)) => {
                         if is_meta {
-                            repl.state.handle_meta(s, expr, &package, p)?
+                            if let Err(e) = repl.state.handle_meta(s, expr, &package, p) {
+                                eprintln!("!Error: {e:?}");
+                            };
+                            continue;
                         } else {
-                            let _ = repl.state.handle_non_meta(s, expr, false);
+                            if let Err(e) = repl.state.handle_non_meta(s, expr, false) {
+                                eprintln!("REPL Error: {e:?}");
+                            }
 
                             continue;
                         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -44,6 +44,8 @@ pub struct Repl<F: LurkField, T: ReplTrait<F>> {
 pub trait ReplTrait<F: LurkField> {
     fn new(s: &mut Store<F>, limit: usize) -> Self;
 
+    fn name() -> String;
+
     fn handle_run<P: AsRef<Path> + Copy>(
         &mut self,
         store: &mut Store<F>,
@@ -127,7 +129,8 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
     let package = Package::lurk();
 
     if lurk_file.is_none() {
-        println!("Lurk REPL welcomes you.");
+        let name = T::name();
+        println!("{name} welcomes you.");
     }
 
     {
@@ -356,6 +359,10 @@ impl<F: LurkField> ReplTrait<F> for ReplState<F> {
             env: empty_sym_env(s),
             limit,
         }
+    }
+
+    fn name() -> String {
+        "Lurk REPL".into()
     }
 
     fn handle_run<P: AsRef<Path> + Copy>(

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -46,6 +46,8 @@ pub trait ReplTrait<F: LurkField> {
 
     fn name() -> String;
 
+    fn prompt(&self) -> String;
+
     fn handle_run<P: AsRef<Path> + Copy>(
         &mut self,
         store: &mut Store<F>,
@@ -130,7 +132,7 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
 
     if lurk_file.is_none() {
         let name = T::name();
-        println!("{name} welcomes you.");
+        eprintln!("{name} welcomes you.");
     }
 
     {
@@ -143,7 +145,7 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
     let pwd_path = std::env::current_dir().unwrap();
     let p: &Path = pwd_path.as_ref();
     loop {
-        match repl.rl.readline("> ") {
+        match repl.rl.readline(&repl.state.prompt()) {
             Ok(line) => {
                 repl.save_history()?;
 
@@ -159,7 +161,7 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
                     }
                     Ok(_) => (),
                     Err(e) => {
-                        println!("Error when handling {line}: {e:?}");
+                        eprintln!("Error when handling {line}: {e:?}");
                         continue;
                     }
                 };
@@ -180,16 +182,16 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
                         continue;
                     }
                     Err(e) => {
-                        println!("Read error: {e:?}")
+                        eprintln!("Read error: {e:?}")
                     }
                 }
             }
             Err(ReadlineError::Interrupted | ReadlineError::Eof) => {
-                println!("Exiting...");
+                eprintln!("Exiting...");
                 break;
             }
             Err(err) => {
-                println!("Error: {err:?}");
+                eprintln!("Error: {err:?}");
                 break;
             }
         }
@@ -294,7 +296,7 @@ impl<F: LurkField> ReplState<F> {
         file_path: P,
         package: &Package,
     ) -> Result<()> {
-        println!("Loading from {}.", file_path.as_ref().to_str().unwrap());
+        eprintln!("Loading from {}.", file_path.as_ref().to_str().unwrap());
         self.handle_file(store, file_path.as_ref(), package, true)
     }
 
@@ -308,7 +310,7 @@ impl<F: LurkField> ReplState<F> {
         let file_path = file_path;
 
         let input = read_to_string(file_path)?;
-        println!(
+        eprintln!(
             "Read from {}: {}",
             file_path.as_ref().to_str().unwrap(),
             input
@@ -365,13 +367,17 @@ impl<F: LurkField> ReplTrait<F> for ReplState<F> {
         "Lurk REPL".into()
     }
 
+    fn prompt(&self) -> String {
+        "> ".into()
+    }
+
     fn handle_run<P: AsRef<Path> + Copy>(
         &mut self,
         store: &mut Store<F>,
         file_path: P,
         package: &Package,
     ) -> Result<()> {
-        println!("Running from {}.", file_path.as_ref().to_str().unwrap());
+        eprintln!("Running from {}.", file_path.as_ref().to_str().unwrap());
         self.handle_file(store, file_path, package, false)
     }
 
@@ -654,7 +660,7 @@ impl<F: LurkField> ReplTrait<F> for ReplState<F> {
                 Ok(())
             }
             Err(e) => {
-                println!("Evaluation error: {e:?}");
+                eprintln!("Evaluation error: {e:?}");
                 Err(e.into())
             }
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -256,14 +256,43 @@ impl<F: LurkField> Hash for Ptr<F> {
 }
 
 impl<F: LurkField> Ptr<F> {
+    // TODO: Make these methods and the similar ones defined on expression consistent, probably including a shared trait.
+
     // NOTE: Although this could be a type predicate now, when NIL becomes a symbol, it won't be possible.
     pub fn is_nil(&self) -> bool {
         matches!(self.0, ExprTag::Nil)
         // FIXME: check value also, probably
     }
+    pub fn is_cons(&self) -> bool {
+        matches!(self.0, ExprTag::Cons)
+    }
+
+    pub fn is_atom(&self) -> bool {
+        !self.is_cons()
+    }
+
+    pub fn is_list(&self) -> bool {
+        matches!(self.0, ExprTag::Nil | ExprTag::Cons)
+    }
 
     pub fn is_opaque(&self) -> bool {
         self.1.is_opaque()
+    }
+
+    pub fn as_cons(self) -> Option<Self> {
+        if self.is_cons() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_list(self) -> Option<Self> {
+        if self.is_list() {
+            Some(self)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1595,7 +1595,7 @@ impl<F: LurkField> Store<F> {
         self.scalar_ptr_cont_map.get(scalar_ptr).map(|p| *p)
     }
 
-    pub(crate) fn fetch_sym(&self, ptr: &Ptr<F>) -> Option<Sym> {
+    pub fn fetch_sym(&self, ptr: &Ptr<F>) -> Option<Sym> {
         debug_assert!(matches!(ptr.0, ExprTag::Sym | ExprTag::Key | ExprTag::Nil));
 
         if ptr.1.is_opaque() {
@@ -1617,18 +1617,18 @@ impl<F: LurkField> Store<F> {
             })
     }
 
-    pub(crate) fn fetch_str(&self, ptr: &Ptr<F>) -> Option<&str> {
+    pub fn fetch_str(&self, ptr: &Ptr<F>) -> Option<&str> {
         debug_assert!(matches!(ptr.0, ExprTag::Str));
         let symbol = SymbolUsize::try_from_usize(ptr.1.idx()).expect("invalid pointer");
         self.str_store.0.resolve(symbol)
     }
 
-    pub(crate) fn fetch_char(&self, ptr: &Ptr<F>) -> Option<char> {
+    pub fn fetch_char(&self, ptr: &Ptr<F>) -> Option<char> {
         debug_assert!(matches!(ptr.0, ExprTag::Char));
         char::from_u32(ptr.1 .0 .0 as u32)
     }
 
-    pub(crate) fn fetch_fun(&self, ptr: &Ptr<F>) -> Option<&(Ptr<F>, Ptr<F>, Ptr<F>)> {
+    pub fn fetch_fun(&self, ptr: &Ptr<F>) -> Option<&(Ptr<F>, Ptr<F>, Ptr<F>)> {
         debug_assert!(matches!(ptr.0, ExprTag::Fun));
         if ptr.1.is_opaque() {
             None
@@ -1638,7 +1638,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub(crate) fn fetch_cons(&self, ptr: &Ptr<F>) -> Option<&(Ptr<F>, Ptr<F>)> {
+    pub fn fetch_cons(&self, ptr: &Ptr<F>) -> Option<&(Ptr<F>, Ptr<F>)> {
         debug_assert!(matches!(ptr.0, ExprTag::Cons));
         if ptr.1.is_opaque() {
             None
@@ -1647,7 +1647,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub(crate) fn fetch_comm(&self, ptr: &Ptr<F>) -> Option<&(FWrap<F>, Ptr<F>)> {
+    pub fn fetch_comm(&self, ptr: &Ptr<F>) -> Option<&(FWrap<F>, Ptr<F>)> {
         debug_assert!(matches!(ptr.0, ExprTag::Comm));
         if ptr.1.is_opaque() {
             None
@@ -1656,7 +1656,7 @@ impl<F: LurkField> Store<F> {
         }
     }
 
-    pub(crate) fn fetch_num(&self, ptr: &Ptr<F>) -> Option<&Num<F>> {
+    pub fn fetch_num(&self, ptr: &Ptr<F>) -> Option<&Num<F>> {
         debug_assert!(matches!(ptr.0, ExprTag::Num));
         self.num_store.get_index(ptr.1.idx())
     }
@@ -1666,7 +1666,7 @@ impl<F: LurkField> Store<F> {
         self.thunk_store.get_index(ptr.1.idx())
     }
 
-    pub(crate) fn fetch_uint(&self, ptr: &Ptr<F>) -> Option<UInt> {
+    pub fn fetch_uint(&self, ptr: &Ptr<F>) -> Option<UInt> {
         // If more UInt variants are added, the following assertion should be relaxed to check for any of them.
         debug_assert!(matches!(ptr.0, ExprTag::U64));
         match ptr.0 {


### PR DESCRIPTION
This PR add support for `!(:commit …)` and `!(:open …)` commands from the clutch REPL. It incidentally also renames the function map and related types/directories in fcomm to be more general, since there was not actually anything function-specific (apart from the names) about them. NOTE: this does mean that any local committed functions will no longer be findable unless migrated manually.

Two-arg `!(:commit …)` adds a secret, but somewhat counter-intuitively reverses the args from what `.lurk.hide` does. Maybe we should add `!(:hide …)`. Likewise, a one-arg commit command that produces a random secret (like in fcomm). We could also just mirror fcomm, with no default 0 secret… and with the one-arg version giving the random secret.

See example below. The REPL is closed and reopened between commitment and opening. 
```
clutch git:(general-commitments) ✗ bin/clutch
    Finished release [optimized] target(s) in 0.13s
     Running `/Users/clwk/fil/lurk-rs/target/release/clutch`
Lurk REPL welcomes you.
> !(:commit "Now for something completely different.")
(comm 0x25acba3a8f7d7925bdc099e2ded42942fe0fbf5847279686cadc9f785315035b)
> 
Exiting...
➜  clutch git:(general-commitments) ✗ bin/clutch
    Finished release [optimized] target(s) in 0.13s
     Running `/Users/clwk/fil/lurk-rs/target/release/clutch`
Lurk REPL welcomes you.
> !(:open 0x25acba3a8f7d7925bdc099e2ded42942fe0fbf5847279686cadc9f785315035b)
"Now for something completely different."
>
```