### PR TITLE
Rename fun keys to expr in fcomm example json.

### DIFF
--- a/fcomm/examples/chained-function.json
+++ b/fcomm/examples/chained-function.json
@@ -1,2 +1,2 @@
-{"fun":{"Source":"(letrec ((secret 12345) (a (lambda (acc x) (let ((acc (+ acc x))) (cons acc (hide secret (a acc))))))) (a 0))"}}
+{"expr":{"Source":"(letrec ((secret 12345) (a (lambda (acc x) (let ((acc (+ acc x))) (cons acc (hide secret (a acc))))))) (a 0))"}}
 

--- a/fcomm/examples/num-list-function.json
+++ b/fcomm/examples/num-list-function.json
@@ -1,1 +1,1 @@
-{"fun":{"Source":"(let ((nums '(1 2 3 4 5))) (lambda (f) (f nums)))"}}
+{"expr":{"Source":"(let ((nums '(1 2 3 4 5))) (lambda (f) (f nums)))"}}


### PR DESCRIPTION
This is cleanup to make the example json consistent with the struct changes in #284.