### PR TITLE
[test] fix a Prop unit test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,4 +80,4 @@ path = "src/main.rs"
 # By compiling dependencies with optimizations, performing tests gets much faster.
 opt-level = 3
 lto = true
-codegen-units = 1
+

--- a/src/num.rs
+++ b/src/num.rs
@@ -284,7 +284,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn prop_num_ipld(x: Num<Fr>)  {
+        fn prop_num_ipld(x in any::<Num<Fr>>())  {
              let to_ipld = libipld::serde::to_ipld(x).unwrap();
              let y = libipld::serde::from_ipld(to_ipld).unwrap();
              assert_eq!(


### PR DESCRIPTION
- fixes one bug in a test,
- codegen-units=1, introduced in #273, is rather extreme and cuts parallelism in compilation without adding much speed (ant least on my machines)
