### PR TITLE
CI: Update Mac resource class to Gen2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ executors:
     resource_class: arm.large
   darwin:
     macos:
-      xcode: "13.3.0"
+      xcode: "14.2.0"
     working_directory: ~/lurk
-    resource_class: medium
+    resource_class: macos.x86.medium.gen2
 
 commands:
   set_env_path:


### PR DESCRIPTION
The current `medium` class is [now deprecated](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891), so this PR updates to the recommended Gen2 replacement. Incidentally, this reduces Mac CI time by ~40% and brings the total time down to around 16 minutes.