### PR TITLE
Add demo support and simple demo to clutch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c697cc33851b02ab0c26b2e8a211684fbe627ff1cc506131f35026dd7686dd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,13 +71,14 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9834fcc22e0874394a010230586367d4a3e9f11b560f469262678547e1d2575e"
+checksum = "c0dcbed38184f9219183fcf38beb4cdbf5df7163a6d7cd227c6ac89b7966d6fe"
 dependencies = [
+ "anstyle",
  "bstr",
  "doc-comment",
- "predicates",
+ "predicates 3.0.1",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -184,7 +191,7 @@ checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.2.4",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -206,7 +213,7 @@ checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.2.4",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -219,7 +226,7 @@ dependencies = [
  "arrayvec 0.7.2",
  "cc",
  "cfg-if",
- "constant_time_eq 0.2.4",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -236,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.6",
 ]
@@ -428,8 +435,8 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -468,6 +475,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blstrs",
+ "clap 4.1.8",
  "fcomm",
  "fil_pasta_curves",
  "lurk",
@@ -483,9 +491,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "core2"
@@ -684,7 +692,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
 ]
 
@@ -820,7 +828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5109f6bc9cd57feda665da326f3f6c57e0498c8fe9f7d12d7b8abc96719ca91b"
 dependencies = [
  "execute-command-tokens",
- "quote 1.0.23",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -857,7 +865,7 @@ dependencies = [
  "lurk-ipld",
  "once_cell",
  "pairing",
- "predicates",
+ "predicates 2.1.5",
  "pretty_env_logger",
  "rand 0.8.5",
  "serde",
@@ -901,8 +909,8 @@ dependencies = [
  "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -1200,9 +1208,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libm"
@@ -1367,8 +1375,8 @@ version = "0.1.0"
 dependencies = [
  "blstrs",
  "lurk",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -1461,8 +1469,8 @@ checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -1712,16 +1720,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates-core"
-version = "1.0.5"
+name = "predicates"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
+checksum = "1ba7d6ead3e3966038f68caa9fc1f860185d95a793180bbcfe0d0da47b3961ed"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools 0.10.5",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1754,8 +1774,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
  "version_check",
 ]
@@ -1766,8 +1786,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "version_check",
 ]
 
@@ -1782,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -1844,11 +1864,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "proc-macro2 1.0.51",
+ "proc-macro2 1.0.52",
 ]
 
 [[package]]
@@ -2062,7 +2082,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688599bdab9f42105d0ae1494335a9ffafdeb7d36325e6b10fd4abc5829d6284"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2099,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.153"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a382c72b4ba118526e187430bb4963cd6d55051ebf13d9b25574d379cc98d20"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
@@ -2136,12 +2156,12 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.153"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef476a5790f0f6decbc66726b6e5d63680ed518283e64c7df415989d880954f"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2162,8 +2182,8 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2209,9 +2229,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
 dependencies = [
  "lock_api",
 ]
@@ -2274,8 +2294,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2302,8 +2322,8 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "unicode-ident",
 ]
 
@@ -2313,8 +2333,8 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
@@ -2368,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"
@@ -2402,8 +2422,8 @@ version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2441,8 +2461,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2496,9 +2516,9 @@ checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"
@@ -2551,8 +2571,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
@@ -2563,7 +2583,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.26",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2573,8 +2593,8 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -2664,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2679,45 +2699,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "wyz"
@@ -2774,8 +2794,8 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
  "syn 1.0.109",
  "synstructure",
 ]

--- a/clutch/Cargo.toml
+++ b/clutch/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/lurk-lang/lurk-rs"
 [dependencies]
 anyhow = "1.0.69"
 blstrs = "0.6.1"
+clap = "4.1.8"
 fcomm = { path = "../fcomm" }
 lurk = { path = "../" }
 pasta_curves = { version = "0.5.2", features = ["repr-c", "serde"], package = "fil_pasta_curves" }

--- a/clutch/demo/simple.lurk
+++ b/clutch/demo/simple.lurk
@@ -1,0 +1,18 @@
+123
+
+(+ 1 1)
+
+!(:def square (lambda (x) (* x x)))
+
+(square 8)
+
+!(:def make-adder
+   (lambda (n)
+     (lambda (x)
+       (+ x n))))
+
+!(:def five-plus
+   (make-adder 5))
+
+(five-plus 3)
+

--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -106,7 +106,7 @@ impl ReplTrait<F> for ClutchState<F> {
         let expression_map = fcomm::committed_expression_store();
 
         let demo = command.clone().and_then(|c| {
-            let l = Self::base_prompt().len();
+            let l = Self::base_prompt().trim_start_matches("\n").len();
             let matches = c.get_matches();
 
             matches
@@ -136,7 +136,11 @@ impl ReplTrait<F> for ClutchState<F> {
 
     fn prompt(&mut self) -> String {
         if let Some(demo_input) = self.demo.as_ref().and_then(|d: &Demo| d.peek_input()) {
-            format!("{}{demo_input}", Self::base_prompt())
+            if demo_input.trim().is_empty() {
+                "".to_string()
+            } else {
+                format!("{}{demo_input}", Self::base_prompt())
+            }
         } else {
             Self::base_prompt()
         }

--- a/clutch/src/lib.rs
+++ b/clutch/src/lib.rs
@@ -106,7 +106,7 @@ impl ReplTrait<F> for ClutchState<F> {
         let expression_map = fcomm::committed_expression_store();
 
         let demo = command.clone().and_then(|c| {
-            let l = Self::base_prompt().trim_start_matches("\n").len();
+            let l = Self::base_prompt().trim_start_matches('\n').len();
             let matches = c.get_matches();
 
             matches

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -4,7 +4,7 @@ use clutch::ClutchState;
 
 use lurk::field::LanguageField;
 use lurk::proof::nova;
-use lurk::repl::repl;
+use lurk::repl::repl_cli;
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
     };
 
     match field {
-        LanguageField::Pallas => repl::<nova::S1, ClutchState<nova::S1>>(true),
+        LanguageField::Pallas => repl_cli::<nova::S1, ClutchState<nova::S1>>(),
         _ => panic!("unsupported field"),
     }
 }

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
     };
 
     match field {
-        LanguageField::Pallas => repl::<nova::S1, ClutchState<nova::S1>>(),
+        LanguageField::Pallas => repl::<nova::S1, ClutchState<nova::S1>>(true),
         _ => panic!("unsupported field"),
     }
 }

--- a/clutch/src/main.rs
+++ b/clutch/src/main.rs
@@ -9,14 +9,6 @@ use lurk::repl::repl;
 fn main() -> Result<()> {
     pretty_env_logger::init();
 
-    // If an argument is passed, treat is as a Lurk file to run.
-    let mut args = std::env::args();
-    let lurk_file = if args.len() > 1 {
-        Some(args.nth(1).expect("Lurk file missing"))
-    } else {
-        None
-    };
-
     let default_field = LanguageField::Pallas;
     let field = if let Ok(lurk_field) = std::env::var("LURK_FIELD") {
         match lurk_field.as_str() {
@@ -30,9 +22,7 @@ fn main() -> Result<()> {
     };
 
     match field {
-        LanguageField::Pallas => {
-            repl::<_, nova::S1, ClutchState<nova::S1>>(lurk_file.as_deref(), None)
-        }
+        LanguageField::Pallas => repl::<nova::S1, ClutchState<nova::S1>>(),
         _ => panic!("unsupported field"),
     }
 }

--- a/fcomm/src/lib.rs
+++ b/fcomm/src/lib.rs
@@ -89,7 +89,9 @@ pub fn public_params(rc: usize) -> Result<Arc<PublicParams<'static>>, Error> {
             // TODO: Add versioning to cache key
             let key = format!("public-params-rc-{rc}");
             if let Some(pp) = disk_cache.get(&key) {
-                Ok(Arc::new(pp))
+                let pp = Arc::new(pp);
+                mem_cache.insert(rc, pp.clone());
+                Ok(pp)
             } else {
                 let pp = Arc::new(nova::public_params(rc));
                 mem_cache.insert(rc, pp.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ fn main() -> Result<()> {
     };
 
     match field {
-        LanguageField::BLS12_381 => repl::<blstrs::Scalar, ReplState<blstrs::Scalar>>(),
-        LanguageField::Pallas => repl::<nova::S1, ReplState<nova::S1>>(),
-        LanguageField::Vesta => repl::<nova::S2, ReplState<nova::S2>>(),
+        LanguageField::BLS12_381 => repl::<blstrs::Scalar, ReplState<blstrs::Scalar>>(true),
+        LanguageField::Pallas => repl::<nova::S1, ReplState<nova::S1>>(true),
+        LanguageField::Vesta => repl::<nova::S2, ReplState<nova::S2>>(true),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,32 +3,8 @@ use lurk::field::LanguageField;
 use lurk::proof::nova;
 use lurk::repl::{repl, ReplState};
 
-use clap::{Arg, ArgAction, Command};
-
 fn main() -> Result<()> {
     pretty_env_logger::init();
-
-    let matches = Command::new("Lurk REPL")
-        .arg(
-            Arg::new("lurk_file")
-                .help("Lurk file to run")
-                .action(ArgAction::Set)
-                .value_name("LURKFILE")
-                .index(1)
-                .help("Specifies the path of a lurk file to run"),
-        )
-        .arg(
-            Arg::new("lightstore")
-                .long("lightstore")
-                .value_parser(clap::builder::NonEmptyStringValueParser::new())
-                .action(ArgAction::Set)
-                .value_name("LIGHTSTORE")
-                .help("Specifies the lightstore file path"),
-        )
-        .get_matches();
-
-    let lurk_file = matches.get_one::<String>("lurk_file");
-    let lightstore_file = matches.get_one::<String>("lightstore");
 
     let default_field = LanguageField::Pallas;
     let field = if let Ok(lurk_field) = std::env::var("LURK_FIELD") {
@@ -43,14 +19,8 @@ fn main() -> Result<()> {
     };
 
     match field {
-        LanguageField::BLS12_381 => {
-            repl::<_, blstrs::Scalar, ReplState<blstrs::Scalar>>(lurk_file, lightstore_file)
-        }
-        LanguageField::Pallas => {
-            repl::<_, nova::S1, ReplState<nova::S1>>(lurk_file, lightstore_file)
-        }
-        LanguageField::Vesta => {
-            repl::<_, nova::S2, ReplState<nova::S2>>(lurk_file, lightstore_file)
-        }
+        LanguageField::BLS12_381 => repl::<blstrs::Scalar, ReplState<blstrs::Scalar>>(),
+        LanguageField::Pallas => repl::<nova::S1, ReplState<nova::S1>>(),
+        LanguageField::Vesta => repl::<nova::S2, ReplState<nova::S2>>(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use lurk::field::LanguageField;
 use lurk::proof::nova;
-use lurk::repl::{repl, ReplState};
+use lurk::repl::{repl_cli, ReplState};
 
 fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -19,8 +19,8 @@ fn main() -> Result<()> {
     };
 
     match field {
-        LanguageField::BLS12_381 => repl::<blstrs::Scalar, ReplState<blstrs::Scalar>>(true),
-        LanguageField::Pallas => repl::<nova::S1, ReplState<nova::S1>>(true),
-        LanguageField::Vesta => repl::<nova::S2, ReplState<nova::S2>>(true),
+        LanguageField::BLS12_381 => repl_cli::<blstrs::Scalar, ReplState<blstrs::Scalar>>(),
+        LanguageField::Pallas => repl_cli::<nova::S1, ReplState<nova::S1>>(),
+        LanguageField::Vesta => repl_cli::<nova::S2, ReplState<nova::S2>>(),
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -124,21 +124,18 @@ impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
     }
 }
 
-pub fn repl<F: LurkField, T: ReplTrait<F>>(is_cli: bool) -> Result<()> {
+pub fn repl_cli<F: LurkField, T: ReplTrait<F>>() -> Result<()> {
     let command = T::command();
     let matches = command.clone().get_matches();
 
-    let (lurk_file, light_store) = if is_cli {
-        (
-            matches.get_one::<String>("lurk_file"),
-            matches.get_one::<String>("lightstore"),
-        )
-    } else {
-        (None, None)
-    };
+    let lurk_file = matches.get_one::<String>("lurk_file");
+    let light_store = matches.get_one::<String>("lightstore");
 
-    let c = if is_cli { Some(command) } else { None };
-    repl_aux::<_, F, T>(lurk_file, light_store, c)
+    repl_aux::<_, F, T>(lurk_file, light_store, Some(command))
+}
+
+pub fn repl<F: LurkField, T: ReplTrait<F>, P: AsRef<Path>>(lurk_file: Option<P>) -> Result<()> {
+    repl_aux::<_, F, T>(lurk_file, None, None)
 }
 
 fn repl_aux<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
@@ -181,7 +178,6 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
 
     {
         if let Some(lurk_file) = lurk_file {
-            dbg!(&lurk_file.as_ref());
             repl.state.handle_run(s, &lurk_file, &package).unwrap();
             return Ok(());
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -9,6 +9,7 @@ use crate::store::{ContPtr, Expression, Pointer, Ptr, Store};
 use crate::tag::{ContTag, ExprTag};
 use crate::writer::Write;
 use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, Command};
 use peekmore::PeekMore;
 use rustyline::error::ReadlineError;
 use rustyline::validate::{
@@ -36,6 +37,7 @@ impl Validator for InputValidator {
 pub struct ReplState<F: LurkField> {
     pub env: Ptr<F>,
     pub limit: usize,
+    pub command: Option<Command>,
 }
 
 pub struct Repl<F: LurkField, T: ReplTrait<F>> {
@@ -46,11 +48,15 @@ pub struct Repl<F: LurkField, T: ReplTrait<F>> {
 }
 
 pub trait ReplTrait<F: LurkField> {
-    fn new(s: &mut Store<F>, limit: usize) -> Self;
+    fn new(s: &mut Store<F>, limit: usize, command: Option<Command>) -> Self;
 
     fn name() -> String;
 
-    fn prompt(&self) -> String;
+    fn prompt(&mut self) -> String;
+
+    fn process_line(&mut self, line: String) -> String;
+
+    fn command() -> Command;
 
     fn handle_run<P: AsRef<Path> + Copy>(
         &mut self,
@@ -86,7 +92,7 @@ pub trait ReplTrait<F: LurkField> {
 }
 
 impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
-    pub fn new(s: &mut Store<F>, limit: usize) -> Result<Self> {
+    pub fn new(s: &mut Store<F>, limit: usize, command: Option<Command>) -> Result<Self> {
         let history_path = dirs::home_dir()
             .expect("missing home directory")
             .join(".lurk-history");
@@ -104,7 +110,7 @@ impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
             rl.load_history(&history_path)?;
         }
 
-        let state = T::new(s, limit);
+        let state = T::new(s, limit, command);
         Ok(Self {
             state,
             rl,
@@ -118,9 +124,22 @@ impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
     }
 }
 
-pub fn repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
+pub fn repl<F: LurkField, T: ReplTrait<F>>() -> Result<()> {
+    let command = T::command();
+    let matches = command.clone().get_matches();
+
+    let (lurk_file, light_store) = (
+        matches.get_one::<String>("lurk_file"),
+        matches.get_one::<String>("lightstore"),
+    );
+
+    repl_aux::<_, F, T>(lurk_file, light_store, Some(command))
+}
+
+fn repl_aux<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
     lurk_file: Option<P>,
     light_store: Option<P>,
+    command: Option<Command>,
 ) -> Result<()> {
     let received_light_store = light_store.is_some();
     let mut s = light_store
@@ -137,7 +156,7 @@ pub fn repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
         .unwrap_or_default();
     let s_ref = &mut s;
     let limit = 100_000_000;
-    let repl: Repl<F, T> = Repl::new(s_ref, limit)?;
+    let repl: Repl<F, T> = Repl::new(s_ref, limit, command)?;
 
     run_repl(s_ref, repl, lurk_file)
 }
@@ -165,7 +184,11 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
     let pwd_path = std::env::current_dir().unwrap();
     let p: &Path = pwd_path.as_ref();
     loop {
-        match repl.rl.readline(&repl.state.prompt()) {
+        let line = repl
+            .rl
+            .readline(&repl.state.prompt())
+            .map(|line| repl.state.process_line(line));
+        match line {
             Ok(line) => {
                 repl.save_history()?;
 
@@ -226,10 +249,11 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
 }
 
 impl<F: LurkField> ReplState<F> {
-    pub fn new(s: &mut Store<F>, limit: usize) -> Self {
+    pub fn new(s: &mut Store<F>, limit: usize, command: Option<Command>) -> Self {
         Self {
             env: empty_sym_env(s),
             limit,
+            command,
         }
     }
     pub fn eval_expr(
@@ -381,10 +405,11 @@ impl<F: LurkField> ReplState<F> {
 }
 
 impl<F: LurkField> ReplTrait<F> for ReplState<F> {
-    fn new(s: &mut Store<F>, limit: usize) -> Self {
+    fn new(s: &mut Store<F>, limit: usize, command: Option<Command>) -> Self {
         Self {
             env: empty_sym_env(s),
             limit,
+            command,
         }
     }
 
@@ -392,8 +417,31 @@ impl<F: LurkField> ReplTrait<F> for ReplState<F> {
         "Lurk REPL".into()
     }
 
-    fn prompt(&self) -> String {
+    fn prompt(&mut self) -> String {
         "> ".into()
+    }
+
+    fn process_line(&mut self, line: String) -> String {
+        line
+    }
+    fn command() -> Command {
+        Command::new("Lurk REPL")
+            .arg(
+                Arg::new("lurk_file")
+                    .help("Lurk file to run")
+                    .action(ArgAction::Set)
+                    .value_name("LURKFILE")
+                    .index(1)
+                    .help("Specifies the path of a lurk file to run"),
+            )
+            .arg(
+                Arg::new("lightstore")
+                    .long("lightstore")
+                    .value_parser(clap::builder::NonEmptyStringValueParser::new())
+                    .action(ArgAction::Set)
+                    .value_name("LIGHTSTORE")
+                    .help("Specifies the lightstore file path"),
+            )
     }
 
     fn handle_run<P: AsRef<Path> + Copy>(

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -124,16 +124,21 @@ impl<F: LurkField, T: ReplTrait<F>> Repl<F, T> {
     }
 }
 
-pub fn repl<F: LurkField, T: ReplTrait<F>>() -> Result<()> {
+pub fn repl<F: LurkField, T: ReplTrait<F>>(is_cli: bool) -> Result<()> {
     let command = T::command();
     let matches = command.clone().get_matches();
 
-    let (lurk_file, light_store) = (
-        matches.get_one::<String>("lurk_file"),
-        matches.get_one::<String>("lightstore"),
-    );
+    let (lurk_file, light_store) = if is_cli {
+        (
+            matches.get_one::<String>("lurk_file"),
+            matches.get_one::<String>("lightstore"),
+        )
+    } else {
+        (None, None)
+    };
 
-    repl_aux::<_, F, T>(lurk_file, light_store, Some(command))
+    let c = if is_cli { Some(command) } else { None };
+    repl_aux::<_, F, T>(lurk_file, light_store, c)
 }
 
 fn repl_aux<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
@@ -176,6 +181,7 @@ pub fn run_repl<P: AsRef<Path>, F: LurkField, T: ReplTrait<F>>(
 
     {
         if let Some(lurk_file) = lurk_file {
+            dbg!(&lurk_file.as_ref());
             repl.state.handle_run(s, &lurk_file, &package).unwrap();
             return Ok(());
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -707,8 +707,14 @@ impl<F: LurkField> ReplTrait<F> for ReplState<F> {
         if let Some(expr) = res {
             let mut handle = io::stdout().lock();
             expr.fmt(store, &mut handle)?;
-            println!();
+
+            // TODO: Why is this seemingly necessary to flush?
+            // This doesn't work: io::stdout().flush().unwrap();
+            // We don't really want the newline.
+            println!("");
         };
+
+        io::stdout().flush().unwrap();
         Ok(())
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -707,7 +707,7 @@ impl<F: LurkField> ReplTrait<F> for ReplState<F> {
             // TODO: Why is this seemingly necessary to flush?
             // This doesn't work: io::stdout().flush().unwrap();
             // We don't really want the newline.
-            println!("");
+            println!();
         };
 
         io::stdout().flush().unwrap();

--- a/tests/lurk-tests.rs
+++ b/tests/lurk-tests.rs
@@ -32,6 +32,6 @@ fn lurk_tests() {
     for f in test_files {
         let joined = example_dir.join(f);
 
-        repl::<nova::S1, ReplState<nova::S1>>(false).unwrap();
+        repl::<nova::S1, ReplState<nova::S1>, _>(Some(joined)).unwrap();
     }
 }

--- a/tests/lurk-tests.rs
+++ b/tests/lurk-tests.rs
@@ -32,6 +32,6 @@ fn lurk_tests() {
     for f in test_files {
         let joined = example_dir.join(f);
 
-        repl::<_, nova::S1, ReplState<nova::S1>>(Some(joined), None).unwrap();
+        repl::<nova::S1, ReplState<nova::S1>>(false).unwrap();
     }
 }


### PR DESCRIPTION
This PR adds support for a candy-like demo mode to clutch. If a `--demo` argument is provided, it names a file used to get a list of REPL inputs. Inputs in the provided script are separated by blank lines. If provided, these inputs will be sequentially supplied to the REPL when an empty line is received. In concert with this fakery, the next demo line to be supplied will be appended to the prompt. The net effect is that repeatedly pressing return (entering blank lines) will walk through the supplied demo script.

Here's the resulting output, using the simple demo script provided in this PR:
```
➜  clutch git:(clutch-demo) ✗ bin/clutch --demo demo/simple.lurk        
    Finished release [optimized] target(s) in 0.13s
     Running `/Users/clwk/fil/lurk-rs/target/release/clutch --demo demo/simple.lurk`
Lurk Clutch welcomes you.

!> 123
[1 iterations] => 123

!> (+ 1 1)
[3 iterations] => 2

!> !(:def square (lambda (x) (* x x)))
SQUARE

!> (square 8)
[7 iterations] => 64

!> !(:def make-adder
       (lambda (n)
         (lambda (x)
           (+ x n))))
MAKE-ADDER

!> !(:def five-plus
       (make-adder 5))
FIVE-PLUS

!> (five-plus 3)
[9 iterations] => 8

!>
```