### PR TITLE
Fix clutch commitments and some optimizations.

### DIFF
--- a/clutch/demo/alpha.lurk
+++ b/clutch/demo/alpha.lurk
@@ -1,0 +1,127 @@
+!(:def people '((:first-name "Alonzo" :last-name "Church" :balance 123 :id 0)
+                (:first-name "Alan" :last-name "Turing" :balance 456 :id 1)
+                (:first-name "Satoshi" :last-name "Nakamoto" :balance 9000 :id 2)))
+
+!(:defrec get (lambda (key plist)
+                (if plist
+                    (if (eq key (car plist))
+                        (car (cdr plist))
+                        (get key (cdr (cdr plist))))
+                    nil)))
+
+(get :last-name (car people))
+
+!(:defrec map (lambda (f list)
+                (if list
+                    (cons (f (car list))
+                          (map f (cdr list)))
+                    ())))
+
+!(:defrec filter (lambda (pred list)
+                   (if list
+                       (if (pred (car list))
+                           (cons (car list) (filter pred (cdr list)))
+                           (filter pred (cdr list)))
+                       ())))
+
+!(:def balance-at-least? (lambda (x)
+                           (lambda (entry)
+                             (>= (get :balance entry) x))))
+
+(map (get :first-name) (filter (balance-at-least? 200) people))
+
+(map (get :balance) people)
+
+!(:defrec sum (lambda (vals)
+                (if vals
+                    (+ (car vals) (sum (cdr vals)))
+                    0)))
+
+!(:def total-funds (lambda (db) (sum (map (get :balance) db))))
+
+!(:def initial-total-funds (emit (total-funds people)))
+
+!(:def funds-are-conserved? (lambda (db) (= initial-total-funds (total-funds db))))
+
+!(:def set (lambda (key value plist)
+             (letrec ((aux (lambda (acc plist)
+                             (if plist
+                                 (if (eq key (car plist))
+                                     (aux (cons key (cons value acc))
+                                          (cdr (cdr plist)))
+                                     (aux (cons (car plist)
+                                                (cons (car (cdr plist)) acc))
+                                          (cdr (cdr plist))))
+                                 acc))))
+               (aux () plist))))
+
+(set :balance 666 (car people))
+
+!(:def update (lambda (key update-fn plist)
+                (letrec ((aux (lambda (acc plist)
+                                (if plist
+                                    (if (eq key (car plist))
+                                        (aux (cons key (cons (update-fn (car (cdr plist))) acc))
+                                             (cdr (cdr plist)))
+                                        (aux (cons (car plist)
+                                                   (cons (car (cdr plist)) acc))
+                                             (cdr (cdr plist))))
+                                    acc))))
+                  (aux () plist))))
+
+;; Double Church's balance!
+(update :balance (lambda (x) (* x 2)) (car people))
+
+!(:def update-where (lambda (predicate key update-fn db)
+                      (letrec ((aux (lambda (db)
+                                      (if db
+                                          (if (predicate (car db))
+                                              (cons (update key update-fn (car db))
+                                                    (aux (cdr db)))
+                                              (cons (car db)
+                                                    (aux (cdr db))))
+                                          nil))))
+                        (aux db))))
+
+!(:def has-id? (lambda (id x) (eq id (get :id x))))
+
+(update-where (has-id? 2) :first-name (lambda (x) (strcons #\Z (cdr x))) people)
+
+!(:def send (lambda (amount from-id to-id db)
+              (let ((from (car (filter (has-id? from-id) db))))
+                (if (balance-at-least? amount from)
+                    (let ((debited (update-where (has-id? from-id) :balance (lambda (x) (- x amount)) db))
+                          (credited (update-where (has-id? to-id) :balance (lambda (x) (+ x amount)) debited)))
+                      credited)
+                    (begin (emit "INSUFFICIENT FUNDS") db)))))
+
+!(:def ledger people)
+
+(send 200 1 0 people)
+
+!(:assert (funds-are-conserved? ledger))
+
+(send 200 0 1 people)
+
+!(:assert (funds-are-conserved? ledger))
+
+;; TODO: when proving multi-arg functions works.
+;; !(:def fn<-db (lambda (db)
+;;                 (lambda (amount from-id to-id)
+;;                   (send amount from-id to-id db))))
+
+!(:def fn<-db (lambda (db)
+                (lambda (transfer)
+                  (let ((amount (car transfer))
+                        (rest (cdr transfer))
+                        (from-id (car rest))
+                        (rest (cdr rest))
+                        (to-id (car rest)))
+                    (send (emit amount) (emit from-id) (emit to-id) (emit db))))))
+
+
+!(:commit (fn<-db ledger))
+0x36283c9973a837574e3e5a15815b60a541df265b0f218ab048e99a7c44ee3769
+
+!(:call 0x36283c9973a837574e3e5a15815b60a541df265b0f218ab048e99a7c44ee3769 '(1 0 2))
+;; !(:prove)

--- a/src/circuit/gadgets/data.rs
+++ b/src/circuit/gadgets/data.rs
@@ -200,12 +200,6 @@ impl<F: LurkField> GlobalAllocations<F> {
                     c.$cname.scalar_ptr(),
                 )?;
             };
-            ($var:ident, $name:expr, $namespace:expr) => {
-                let $var = AllocatedPtr::alloc_constant(
-                    &mut cs.namespace(|| $namespace),
-                    hash_sym($name),
-                )?;
-            };
         }
 
         defsym!(nil_ptr, "nil", nil);

--- a/src/package.rs
+++ b/src/package.rs
@@ -108,7 +108,7 @@ impl Package {
 
         let name_is_prefix = sym_path.iter().zip(name.path()).all(|(a, b)| a == b);
 
-        if name_is_prefix {
+        if name_is_prefix && sym_path != name_path {
             Sym::new_from_path(false, sym_path[name_path.len()..].to_vec())
         } else {
             sym.clone()

--- a/src/proof/nova.rs
+++ b/src/proof/nova.rs
@@ -301,8 +301,7 @@ mod tests {
     use pallas::Scalar as Fr;
 
     const DEFAULT_CHUNK_FRAME_COUNT: usize = 5;
-    //    const CHUNK_FRAME_COUNTS_TO_TEST: [usize; 3] = [1, 2, 5];
-    const CHUNK_FRAME_COUNTS_TO_TEST: [usize; 1] = [1];
+    const CHUNK_FRAME_COUNTS_TO_TEST: [usize; 3] = [1, 2, 5];
     fn test_aux(
         s: &mut Store<Fr>,
         expr: &str,

--- a/src/store.rs
+++ b/src/store.rs
@@ -1339,7 +1339,7 @@ impl<F: LurkField> Store<F> {
             }
             (ExprTag::Str, Some(Str(s))) => Some(self.intern_str(s)),
             (ExprTag::Sym, Some(Sym(s))) => Some(self.intern_sym(s)),
-            (ExprTag::Key, Some(Sym(_))) => todo!(),
+            (ExprTag::Key, Some(Sym(k))) => Some(self.intern_key(k)),
             (ExprTag::Num, Some(Num(x))) => Some(self.intern_num(crate::Num::Scalar(*x))),
             (ExprTag::Thunk, Some(Thunk(t))) => {
                 let value = self.intern_scalar_ptr(t.value, scalar_store)?;
@@ -1420,6 +1420,13 @@ impl<F: LurkField> Store<F> {
 
     pub fn intern_sym(&mut self, sym: &Sym) -> Ptr<F> {
         let name = sym.full_name();
+        self.intern_sym_by_full_name(name)
+    }
+
+    pub fn intern_key(&mut self, sym: &Sym) -> Ptr<F> {
+        let name = sym.full_name();
+
+        assert!(names_keyword(&name).0);
         self.intern_sym_by_full_name(name)
     }
 


### PR DESCRIPTION
This PR makes a few fixes and optimizations discovered while working on the clutch demo.

- Handle interning keywords.
- Avoid interning symbols for every circuit and instead use the `NamedConstant`s.
- Revert circuit tests to check multiple `chunk_frame_count`s.

UPDATE: More optimizations/fixes including a very significant one:
- Handle and edge case in symbol name abbreviation.
- Return cached ScalarPtrs when possible (in (`get_`)`expr_hash()`. This is the big one.

In the demo work motivating these changes, a somewhat complex commitment became stalled out indefinitely at high CPU usage but now completes instantly. I ~will push~ pushed that WIP demo code to this PR also for reference. You can run it with `bin/clutch --demo demo/alpha.lurk` (from `clutch` directory). Just keep hitting return to step through the canned inputs. The very last `!(:commit …)` is the one that was interminable prior to these fixes.