### PR TITLE
Slight store performance improvements (low-hanging fruits)

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -1650,9 +1650,6 @@ impl<F: LurkField> Store<F> {
     pub fn fetch_scalar(&self, scalar_ptr: &ScalarPtr<F>) -> Option<Ptr<F>> {
         self.scalar_ptr_map.get(scalar_ptr).map(|p| *p)
     }
-    pub fn fetch_scalar_m(&mut self, scalar_ptr: &ScalarPtr<F>) -> Option<Ptr<F>> {
-        self.scalar_ptr_map.get(scalar_ptr).map(|p| *p)
-    }
 
     pub fn fetch_scalar_cont(&self, scalar_ptr: &ScalarContPtr<F>) -> Option<ContPtr<F>> {
         self.scalar_ptr_cont_map.get(scalar_ptr).map(|p| *p)

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,6 +4,7 @@ use rayon::prelude::*;
 use std::collections::VecDeque;
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
+use std::sync::Arc;
 use std::{fmt, marker::PhantomData};
 use string_interner::symbol::{Symbol, SymbolUsize};
 use thiserror;
@@ -168,7 +169,7 @@ pub struct Store<F: LurkField> {
 
     pointer_scalar_ptr_cache: dashmap::DashMap<Ptr<F>, ScalarPtr<F>>,
 
-    pub(crate) lurk_package: Package,
+    pub(crate) lurk_package: Arc<Package>,
     constants: OnceCell<NamedConstants<F>>,
 }
 
@@ -912,7 +913,7 @@ impl<F: LurkField> Default for Store<F> {
             dehydrated_cont: Default::default(),
             opaque_raw_ptr_count: 0,
             pointer_scalar_ptr_cache: Default::default(),
-            lurk_package: Package::lurk(),
+            lurk_package: Arc::new(Package::lurk()),
             constants: Default::default(),
         };
 
@@ -1053,7 +1054,7 @@ impl<F: LurkField> Store<F> {
     }
 
     pub fn lurk_sym<T: AsRef<str>>(&mut self, name: T) -> Ptr<F> {
-        let package = self.lurk_package.clone(); // This clone is annoying.
+        let package = self.lurk_package.clone();
 
         self.intern_sym_with_case_conversion(name, &package)
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -265,27 +265,27 @@ impl<F: LurkField> Ptr<F> {
     // TODO: Make these methods and the similar ones defined on expression consistent, probably including a shared trait.
 
     // NOTE: Although this could be a type predicate now, when NIL becomes a symbol, it won't be possible.
-    pub fn is_nil(&self) -> bool {
+    pub const fn is_nil(&self) -> bool {
         matches!(self.0, ExprTag::Nil)
         // FIXME: check value also, probably
     }
-    pub fn is_cons(&self) -> bool {
+    pub const fn is_cons(&self) -> bool {
         matches!(self.0, ExprTag::Cons)
     }
 
-    pub fn is_atom(&self) -> bool {
+    pub const fn is_atom(&self) -> bool {
         !self.is_cons()
     }
 
-    pub fn is_list(&self) -> bool {
+    pub const fn is_list(&self) -> bool {
         matches!(self.0, ExprTag::Nil | ExprTag::Cons)
     }
 
-    pub fn is_opaque(&self) -> bool {
+    pub const fn is_opaque(&self) -> bool {
         self.1.is_opaque()
     }
 
-    pub fn as_cons(self) -> Option<Self> {
+    pub const fn as_cons(self) -> Option<Self> {
         if self.is_cons() {
             Some(self)
         } else {
@@ -293,7 +293,7 @@ impl<F: LurkField> Ptr<F> {
         }
     }
 
-    pub fn as_list(self) -> Option<Self> {
+    pub const fn as_list(self) -> Option<Self> {
         if self.is_list() {
             Some(self)
         } else {
@@ -548,10 +548,10 @@ impl<F: LurkField> Pointer<F> for ContPtr<F> {
 }
 
 impl<F: LurkField> ContPtr<F> {
-    pub fn new(tag: ContTag, raw_ptr: RawPtr<F>) -> Self {
+    pub const fn new(tag: ContTag, raw_ptr: RawPtr<F>) -> Self {
         Self(tag, raw_ptr)
     }
-    pub fn is_error(&self) -> bool {
+    pub const fn is_error(&self) -> bool {
         matches!(self.0, ContTag::Error)
     }
 }
@@ -568,11 +568,11 @@ impl<F: LurkField> RawPtr<F> {
         RawPtr((p, false), Default::default())
     }
 
-    fn is_opaque(&self) -> bool {
+    const fn is_opaque(&self) -> bool {
         self.0 .1
     }
 
-    pub fn idx(&self) -> usize {
+    pub const fn idx(&self) -> usize {
         self.0 .0
     }
 }
@@ -791,7 +791,7 @@ impl<F: LurkField> Continuation<F> {
         }
     }
 
-    pub fn cont_tag(&self) -> ContTag {
+    pub const fn cont_tag(&self) -> ContTag {
         match self {
             Self::Outermost => ContTag::Outermost,
             Self::Dummy => ContTag::Dummy,
@@ -1088,7 +1088,7 @@ impl<F: LurkField> Store<F> {
         Ok(self.car_cdr(expr)?.1)
     }
 
-    pub(crate) fn poseidon_constants(&self) -> &HashConstants<F> {
+    pub(crate) const fn poseidon_constants(&self) -> &HashConstants<F> {
         &self.poseidon_cache.constants
     }
 
@@ -2576,7 +2576,7 @@ impl<F: LurkField> Expression<'_, F> {
         }
     }
 
-    pub fn as_str(&self) -> Option<&str> {
+    pub const fn as_str(&self) -> Option<&str> {
         match self {
             Expression::Str(s) => Some(s),
             _ => None,
@@ -2590,7 +2590,7 @@ impl<F: LurkField> Expression<'_, F> {
         }
     }
 
-    pub fn as_sym(&self) -> Option<&Sym> {
+    pub const fn as_sym(&self) -> Option<&Sym> {
         match self {
             Expression::Sym(s) => Some(s),
             _ => None,
@@ -2604,37 +2604,37 @@ impl<F: LurkField> Expression<'_, F> {
         }
     }
 
-    pub fn is_null(&self) -> bool {
+    pub const fn is_null(&self) -> bool {
         matches!(self, Self::Nil)
     }
 
-    pub fn is_cons(&self) -> bool {
+    pub const fn is_cons(&self) -> bool {
         matches!(self, Self::Cons(_, _))
     }
 
-    pub fn is_list(&self) -> bool {
+    pub const fn is_list(&self) -> bool {
         self.is_null() || self.is_cons()
     }
 
-    pub fn is_sym(&self) -> bool {
+    pub const fn is_sym(&self) -> bool {
         matches!(self, Self::Sym(_))
     }
-    pub fn is_fun(&self) -> bool {
+    pub const fn is_fun(&self) -> bool {
         matches!(self, Self::Fun(_, _, _))
     }
 
-    pub fn is_num(&self) -> bool {
+    pub const fn is_num(&self) -> bool {
         matches!(self, Self::Num(_))
     }
-    pub fn is_str(&self) -> bool {
+    pub const fn is_str(&self) -> bool {
         matches!(self, Self::Str(_))
     }
 
-    pub fn is_thunk(&self) -> bool {
+    pub const fn is_thunk(&self) -> bool {
         matches!(self, Self::Thunk(_))
     }
 
-    pub fn is_opaque(&self) -> bool {
+    pub const fn is_opaque(&self) -> bool {
         matches!(self, Self::Opaque(_))
     }
 }
@@ -2650,7 +2650,7 @@ impl<F: LurkField> ConstantPtrs<F> {
         self.0
             .expect("ScalarPtr missing; hydrate_scalar_cache should have been called.")
     }
-    pub fn ptr(&self) -> Ptr<F> {
+    pub const fn ptr(&self) -> Ptr<F> {
         self.1
     }
 }


### PR DESCRIPTION
This:
- removes cloning the external symbols `HashSet` on each symbol internalization from the store (this could probably also be removed from the repl),
- adds a few const functions where possible,
- and a few minor cleanups:
```
go_base_10_16_bls12     time:   [3.7405 ms 3.7457 ms 3.7512 ms]
                        change: [-27.969% -27.813% -27.653%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

go_base_10_160_bls12    time:   [35.656 ms 35.686 ms 35.717 ms]
                        change: [-28.890% -28.219% -27.799%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

go_base_10_16_pasta_pallas
                        time:   [3.8389 ms 3.8437 ms 3.8493 ms]
                        change: [-28.424% -28.246% -28.066%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

go_base_10_160_pasta_pallas
                        time:   [37.019 ms 37.131 ms 37.249 ms]
                        change: [-28.107% -27.759% -27.413%] (p = 0.00 < 0.05)
                        Performance has improved.
```
See also the before/after flamegraph linked in the first commit.


### Edit: after replacing `package_name` by an `Arc`

```
go_base_10_16_bls12     time:   [3.7013 ms 3.7050 ms 3.7092 ms]
                        change: [-27.409% -27.190% -26.967%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

go_base_10_160_bls12    time:   [35.369 ms 35.423 ms 35.495 ms]
                        change: [-27.675% -27.452% -27.235%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

go_base_10_16_pasta_pallas
                        time:   [3.8327 ms 3.8370 ms 3.8416 ms]
                        change: [-28.351% -27.917% -27.536%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

go_base_10_160_pasta_pallas
                        time:   [36.550 ms 36.587 ms 36.625 ms]
                        change: [-27.235% -27.099% -26.971%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```